### PR TITLE
More efficient fixed-base MSM

### DIFF
--- a/ec/src/msm/fixed_base.rs
+++ b/ec/src/msm/fixed_base.rs
@@ -1,6 +1,7 @@
-use crate::ProjectiveCurve;
+use crate::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, FpParameters, PrimeField};
 use ark_std::vec::Vec;
+use ark_std::{cfg_iter, cfg_iter_mut};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -16,12 +17,11 @@ impl FixedBaseMSM {
         }
     }
 
-    // TODO: parallelize this by extracting out `g_outer` computation.
     pub fn get_window_table<T: ProjectiveCurve>(
         scalar_size: usize,
         window: usize,
         g: T,
-    ) -> Vec<Vec<T>> {
+    ) -> Vec<Vec<T::Affine>> {
         let in_window = 1 << window;
         let outerc = (scalar_size + window - 1) / window;
         let last_in_window = 1 << (scalar_size - (outerc - 1) * window);
@@ -29,45 +29,54 @@ impl FixedBaseMSM {
         let mut multiples_of_g = vec![vec![T::zero(); in_window]; outerc];
 
         let mut g_outer = g;
-        for (outer, multiples_of_g) in multiples_of_g.iter_mut().enumerate().take(outerc) {
-            let mut g_inner = T::zero();
-            let cur_in_window = if outer == outerc - 1 {
-                last_in_window
-            } else {
-                in_window
-            };
-            for inner in multiples_of_g.iter_mut().take(cur_in_window) {
-                *inner = g_inner;
-                g_inner += &g_outer;
-            }
+        let mut g_outers = Vec::with_capacity(outerc);
+        for _ in 0..outerc {
+            g_outers.push(g_outer);
             for _ in 0..window {
                 g_outer.double_in_place();
             }
         }
-        multiples_of_g
+        cfg_iter_mut!(multiples_of_g)
+            .enumerate()
+            .take(outerc)
+            .zip(g_outers)
+            .for_each(|((outer, multiples_of_g), g_outer)| {
+                let cur_in_window = if outer == outerc - 1 {
+                    last_in_window
+                } else {
+                    in_window
+                };
+
+                let mut g_inner = T::zero();
+                for inner in multiples_of_g.iter_mut().take(cur_in_window) {
+                    *inner = g_inner;
+                    g_inner += &g_outer;
+                }
+            });
+        cfg_iter!(multiples_of_g)
+            .map(|s| T::batch_normalization_into_affine(&s))
+            .collect()
     }
 
     pub fn windowed_mul<T: ProjectiveCurve>(
         outerc: usize,
         window: usize,
-        multiples_of_g: &[Vec<T>],
+        multiples_of_g: &[Vec<T::Affine>],
         scalar: &T::ScalarField,
     ) -> T {
+        let modulus_size = <T::ScalarField as PrimeField>::Params::MODULUS_BITS as usize;
         let mut scalar_val = scalar.into_repr().to_bits();
         scalar_val.reverse();
 
-        let mut res = multiples_of_g[0][0];
+        let mut res = multiples_of_g[0][0].into_projective();
         for outer in 0..outerc {
             let mut inner = 0usize;
             for i in 0..window {
-                if outer * window + i
-                    < (<T::ScalarField as PrimeField>::Params::MODULUS_BITS as usize)
-                    && scalar_val[outer * window + i]
-                {
+                if outer * window + i < modulus_size && scalar_val[outer * window + i] {
                     inner |= 1 << i;
                 }
             }
-            res += &multiples_of_g[outer][inner];
+            res.add_assign_mixed(&multiples_of_g[outer][inner]);
         }
         res
     }
@@ -75,13 +84,13 @@ impl FixedBaseMSM {
     pub fn multi_scalar_mul<T: ProjectiveCurve>(
         scalar_size: usize,
         window: usize,
-        table: &[Vec<T>],
+        table: &[Vec<T::Affine>],
         v: &[T::ScalarField],
     ) -> Vec<T> {
         let outerc = (scalar_size + window - 1) / window;
         assert!(outerc <= table.len());
 
-        ark_std::cfg_iter!(v)
+        cfg_iter!(v)
             .map(|e| Self::windowed_mul::<T>(outerc, window, table, e))
             .collect::<Vec<_>>()
     }


### PR DESCRIPTION
Parallelizes table generation, and uses mixed addition to speed up MSM.
Just the mixed arithmetic gives a ~20% speedup in Groth16 setup over BLS12-377, and parallelization of the table generation gives an additional 20% improvement for G2 (there is no improvement for G1).