### PR TITLE
Add `Zero` trait bound to `Polynomial`

### DIFF
--- a/poly/src/polynomial/mod.rs
+++ b/poly/src/polynomial/mod.rs
@@ -1,6 +1,6 @@
 //! Modules for working with univariate or multivariate polynomials.
 
-use ark_ff::Field;
+use ark_ff::{Field, Zero};
 use ark_std::{
     fmt::Debug,
     hash::Hash,
@@ -22,18 +22,13 @@ pub trait Polynomial<F: Field>:
     + Eq
     + Add
     + Neg
+    + Zero
     + for<'a> AddAssign<&'a Self>
     + for<'a> AddAssign<(F, &'a Self)>
     + for<'a> SubAssign<&'a Self>
 {
     /// The type of evaluation points for this polynomial.
     type Point: Sized + Clone + Ord + Debug + Sync + Hash;
-
-    /// Returns the zero polynomial.
-    fn zero() -> Self;
-
-    /// Checks if the given polynomial is zero.
-    fn is_zero(&self) -> bool;
 
     /// Returns the total degree of the polynomial
     fn degree(&self) -> usize;

--- a/poly/src/polynomial/multivariate/sparse.rs
+++ b/poly/src/polynomial/multivariate/sparse.rs
@@ -3,7 +3,7 @@ use crate::{
     multivariate::{SparseTerm, Term},
     MVPolynomial, Polynomial,
 };
-use ark_ff::Field;
+use ark_ff::{Field, Zero};
 use ark_std::{
     cmp::Ordering,
     fmt,
@@ -34,19 +34,6 @@ impl<F: Field, T: Term> SparsePolynomial<F, T> {
 
 impl<F: Field> Polynomial<F> for SparsePolynomial<F, SparseTerm> {
     type Point = Vec<F>;
-
-    /// Returns the zero polynomial.
-    fn zero() -> Self {
-        Self {
-            num_vars: 0,
-            terms: Vec::new(),
-        }
-    }
-
-    /// Checks if the given polynomial is zero.
-    fn is_zero(&self) -> bool {
-        self.terms.is_empty() || self.terms.iter().all(|(c, _)| c.is_zero())
-    }
 
     /// Returns the total degree of the polynomial
     fn degree(&self) -> usize {
@@ -234,6 +221,21 @@ impl<F: Field, T: Term> fmt::Debug for SparsePolynomial<F, T> {
             }
         }
         Ok(())
+    }
+}
+
+impl<F: Field, T: Term> Zero for SparsePolynomial<F, T> {
+    /// Returns the zero polynomial.
+    fn zero() -> Self {
+        Self {
+            num_vars: 0,
+            terms: Vec::new(),
+        }
+    }
+
+    /// Checks if the given polynomial is zero.
+    fn is_zero(&self) -> bool {
+        self.terms.is_empty() || self.terms.iter().all(|(c, _)| c.is_zero())
     }
 }
 

--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -9,7 +9,7 @@ use ark_std::{
     vec::Vec,
 };
 
-use ark_ff::{FftField, Field};
+use ark_ff::{FftField, Field, Zero};
 use rand::Rng;
 
 #[cfg(feature = "parallel")]
@@ -24,16 +24,6 @@ pub struct DensePolynomial<F: Field> {
 
 impl<F: Field> Polynomial<F> for DensePolynomial<F> {
     type Point = F;
-
-    /// Returns the zero polynomial.
-    fn zero() -> Self {
-        Self { coeffs: Vec::new() }
-    }
-
-    /// Checks if the given polynomial is zero.
-    fn is_zero(&self) -> bool {
-        self.coeffs.is_empty() || self.coeffs.iter().all(|coeff| coeff.is_zero())
-    }
 
     /// Returns the total degree of the polynomial
     fn degree(&self) -> usize {
@@ -363,6 +353,18 @@ impl<'a, 'b, F: FftField> Mul<&'a DensePolynomial<F>> for &'b DensePolynomial<F>
             self_evals *= &other_evals;
             self_evals.interpolate()
         }
+    }
+}
+
+impl<F: Field> Zero for DensePolynomial<F> {
+    /// Returns the zero polynomial.
+    fn zero() -> Self {
+        Self { coeffs: Vec::new() }
+    }
+
+    /// Checks if the given polynomial is zero.
+    fn is_zero(&self) -> bool {
+        self.coeffs.is_empty() || self.coeffs.iter().all(|coeff| coeff.is_zero())
     }
 }
 

--- a/poly/src/polynomial/univariate/mod.rs
+++ b/poly/src/polynomial/univariate/mod.rs
@@ -1,7 +1,7 @@
 //! Work with sparse and dense polynomials.
 
 use crate::{EvaluationDomain, Evaluations, Polynomial, UVPolynomial};
-use ark_ff::{FftField, Field};
+use ark_ff::{FftField, Field, Zero};
 use ark_std::{borrow::Cow, convert::TryInto, vec::Vec};
 use DenseOrSparsePolynomial::*;
 


### PR DESCRIPTION
These were already required methods for `Polynomial`, but moving it to the appropriate trait allows us to generically handle polynomials as additive shares (which require an additive identity).