### PR TITLE
Use correct feature for assembly compilation

### DIFF
--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -8,7 +8,6 @@
 )]
 #![allow(clippy::op_ref, clippy::suspicious_op_assign_impl)]
 #![cfg_attr(not(use_asm), forbid(unsafe_code))]
-
 #![cfg_attr(use_asm, feature(llvm_asm))]
 #![cfg_attr(use_asm, deny(unsafe_code))]
 

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -7,8 +7,9 @@
     rust_2018_idioms
 )]
 #![allow(clippy::op_ref, clippy::suspicious_op_assign_impl)]
-#![cfg_attr(use_asm, feature(asm))]
 #![cfg_attr(not(use_asm), forbid(unsafe_code))]
+
+#![cfg_attr(use_asm, feature(llvm_asm))]
 #![cfg_attr(use_asm, deny(unsafe_code))]
 
 #[macro_use]


### PR DESCRIPTION
`asm` is the new Rust assembly feature; we should be using `llvm_asm` instead.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #91 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
