### PR TITLE
Improve Lagrange coefficient speed, documentation and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - #35 (ark-ff) Implement `ToConstraintField` for `bool`
 - #48 (ark-ff) Speedup `sqrt` on `QuadExtField`
 - #94 (ark-ff) Implement `ToBytes` and `FromBytes` for `u128`
+- #99 (ark-poly) Speedup `evaluate_all_lagrange_coefficients`
+
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -121,9 +121,9 @@ pub trait EvaluationDomain<F: FftField>:
     }
 
     /// Evaluate all the lagrange polynomials defined by this domain at the
-    /// point `tau`. This is computed in time O(|domain|). 
+    /// point `tau`. This is computed in time O(|domain|).
     /// Then given the evaluations of a degree d polynomial P over this domain,
-    /// where d < |domain|, `P(tau)` can be computed as 
+    /// where d < |domain|, `P(tau)` can be computed as
     /// `P(tau) = sum_{i in [|Domain|]} L_{i, Domain}(tau) * P(g^i)`.
     /// `L_{i, Domain}` is the value of the i-th lagrange coefficient
     /// in the returned vector.

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -121,7 +121,12 @@ pub trait EvaluationDomain<F: FftField>:
     }
 
     /// Evaluate all the lagrange polynomials defined by this domain at the
-    /// point `tau`.
+    /// point `tau`. This is computed in time O(|domain|). 
+    /// Then given the evaluations of a degree d polynomial P over this domain,
+    /// where d < |domain|, `P(tau)` can be computed as 
+    /// `P(tau) = sum_{i in [|Domain|]} L_{i, Domain}(tau) * P(g^i)`.
+    /// `L_{i, Domain}` is the value of the i-th lagrange coefficient
+    /// in the returned vector.
     fn evaluate_all_lagrange_coefficients(&self, tau: F) -> Vec<F>;
 
     /// Return the sparse vanishing polynomial.

--- a/poly/src/domain/radix2.rs
+++ b/poly/src/domain/radix2.rs
@@ -118,44 +118,66 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
     }
 
     fn evaluate_all_lagrange_coefficients(&self, tau: F) -> Vec<F> {
-        // Evaluate all Lagrange polynomials
+        // Evaluate all Lagrange polynomials at tau to get the lagrange coefficients.
+        // Define the following as
+        // - H: The coset we are in, with generator g and offset h
+        // - m: The size of the coset H
+        // - Z_H: The vanishing polynomial for H. Z_H(x) = prod_{i in m} (x - hg^i) = x^m - h^m
+        // - v_i: A sequence of values, where v_0 = 1/(m * h^(m-1)), and v_{i + 1} = g * v_i
+        //
+        // We then compute L_{i,H}(tau) as `L_{i,H}(tau) = Z_H(tau) * v_i / (tau - h g^i)`
+        //
+        // However notice that if tau in H, 
+        // both the numerator and denominator equal 0 when i corresponds to the value tau equals, and 0 everywhere else
+        // We handle this case separately, and we can easily detect by checking if the vanishing poly is 0.
         let size = self.size();
-        let t_size = tau.pow(&[self.size]);
-        let one = F::one();
-        if t_size.is_one() {
+        // TODO: Make this use the vanishing polynomial
+        let z_h_at_tau = tau.pow(&[self.size]) - F::one();
+        let domain_offset = F::one();
+        if z_h_at_tau.is_zero() {
+            // In this case, we know that tau = hg^i, for some value i.
+            // Then i-th lagrange coefficient in this case is then simply 1,
+            // and all other lagrange coefficients are 0.
+            // Thus we find i by brute force.
             let mut u = vec![F::zero(); size];
-            let mut omega_i = one;
+            let mut omega_i = domain_offset;
             for u_i in u.iter_mut().take(size) {
                 if omega_i == tau {
-                    *u_i = one;
+                    *u_i = F::one();
                     break;
                 }
                 omega_i *= &self.group_gen;
             }
             u
         } else {
+            // In this case we have to compute `Z_H(tau) * v_i / (tau - h g^i)`
+            // for i in 0..size
+            // We actually compute this by computing (Z_H(tau) * v_i)^{-1} * (tau - h g^i)
+            // and then batch inverting to get the correct lagrange coefficients.
+            // We let `l_i = (Z_H(tau) * v_i)^-1` and `r_i = tau - h g^i`
+            // Notice that since Z_H(tau) is i-independent, 
+            // and v_i = g * v_{i-1}, it follows that
+            // l_i = g^-1 * l_{i-1}
+            // TODO: consider caching the computation of l_i to save N multiplications
             use ark_ff::fields::batch_inversion;
 
-            let mut l = (t_size - one) * self.size_inv;
-            let mut r = one;
-            let mut u = vec![F::zero(); size];
-            let mut ls = vec![F::zero(); size];
+            // v_0_inv = m * h^(m-1)
+            let v_0_inv = F::from(self.size) * domain_offset.pow(&[self.size - 1]);
+            let mut l_i = z_h_at_tau.inverse().unwrap() * v_0_inv;
+            let mut negative_cur_elem = -domain_offset;
+            let mut lagrange_coefficients_inverse = vec![F::zero(); size];
             for i in 0..size {
-                u[i] = tau - r;
-                ls[i] = l;
-                l *= &self.group_gen;
-                r *= &self.group_gen;
+                let r_i = tau + negative_cur_elem;
+                lagrange_coefficients_inverse[i] = l_i * r_i;
+                // Increment l_i and negative_cur_elem
+                l_i *= &self.group_gen_inv;
+                negative_cur_elem *= &self.group_gen;
             }
 
-            batch_inversion(u.as_mut_slice());
-
-            ark_std::cfg_iter_mut!(u)
-                .zip(ls)
-                .for_each(|(tau_minus_r, l)| {
-                    *tau_minus_r = l * *tau_minus_r;
-                });
-
-            u
+            // Invert the lagrange coefficients inverse, to get the actual coefficients,
+            // and return these
+            batch_inversion(lagrange_coefficients_inverse.as_mut_slice());
+            lagrange_coefficients_inverse
         }
     }
 
@@ -221,7 +243,7 @@ pub(crate) fn serial_radix2_fft<T: DomainCoeff<F>, F: FftField>(a: &mut [T], ome
 #[cfg(test)]
 mod tests {
     use crate::{EvaluationDomain, Radix2EvaluationDomain};
-    use ark_ff::{test_rng, Field, Zero};
+    use ark_ff::{UniformRand, test_rng, Field, Zero};
     use ark_test_curves::bls12_381::Fr;
     use rand::Rng;
 
@@ -270,6 +292,33 @@ mod tests {
             for (i, element) in domain.elements().enumerate() {
                 assert_eq!(element, domain.group_gen.pow([i as u64]));
             }
+        }
+    }
+
+    #[test]
+    fn non_systematic_lagrange_coefficients_test() {
+        use crate::polynomial::UVPolynomial;
+        use crate::polynomial::univariate::*;
+        use crate::polynomial::Polynomial;
+        // Test that lagrange interpolation for a random polynomial at a random point works.
+        for domain_dim in 1..10 {
+            let domain_size = 1 << domain_dim;
+            let domain = Radix2EvaluationDomain::<Fr>::new(domain_size).unwrap();
+            // Get random pt + lagrange coefficients
+            let rand_pt = Fr::rand(&mut test_rng());
+            let lagrange_coeffs = domain.evaluate_all_lagrange_coefficients(rand_pt);
+
+            // Sample the random polynomial, evaluate it over the domain and the random point.
+            let rand_poly = DensePolynomial::<Fr>::rand(domain_size - 1, &mut test_rng());
+            let poly_evals = domain.fft(rand_poly.coeffs());
+            let actual_eval = rand_poly.evaluate(&rand_pt);
+
+            // Do lagrange interpolation, and compare against the actual evaluation
+            let mut interpolated_eval = Fr::zero();
+            for i in 0..domain_size {
+                interpolated_eval += lagrange_coeffs[i] * poly_evals[i];
+            }
+            assert_eq!(actual_eval, interpolated_eval);
         }
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Add documentation for lagrange coefficients, add a test for their correctness, and speedup the computation by N multiplications. (Based on the same speedup done in libiop)

Also it makes dependence on the domain offset explicit, for ease of conversion in a future PR to support the domain being a coset.

The test demonstrates that correctness of this has been maintained.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
