### PR TITLE
Add `element(i: usize)` to `Domain` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - #48 (ark-ff) Speedup `sqrt` on `QuadExtField`
 - #94 (ark-ff) Implement `ToBytes` and `FromBytes` for `u128`
 - #99 (ark-poly) Speedup `evaluate_all_lagrange_coefficients`
-- #101 (ark-ff) Add `get_element(i: usize)` on the `Domain` Trait.
+- #101 (ark-ff) Add `element(i: usize)` on the `Domain` Trait.
 
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - #48 (ark-ff) Speedup `sqrt` on `QuadExtField`
 - #94 (ark-ff) Implement `ToBytes` and `FromBytes` for `u128`
 - #99 (ark-poly) Speedup `evaluate_all_lagrange_coefficients`
+- #101 (ark-ff) Add `get_element(i: usize)` on the `Domain` Trait.
 
 
 ### Bug fixes

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -112,6 +112,11 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
         map!(self, evaluate_vanishing_polynomial, tau)
     }
 
+    /// Returns the ith element of the domain
+    fn get_element(&self, i: usize) -> F {
+        map!(self, get_element, i)
+    }
+
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> GeneralElements<F> {
         GeneralElements(map!(self, elements))

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -112,9 +112,9 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
         map!(self, evaluate_vanishing_polynomial, tau)
     }
 
-    /// Returns the ith element of the domain
-    fn get_element(&self, i: usize) -> F {
-        map!(self, get_element, i)
+    /// Returns the `i`-th element of the domain.
+    fn element(&self, i: usize) -> F {
+        map!(self, element, i)
     }
 
     /// Return an iterator over the elements of the domain.

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -203,6 +203,14 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
         tau.pow(&[self.size]) - F::one()
     }
 
+    /// Returns the ith element of the domain, where elements are ordered by 
+    /// their power of the generator which they correspond to.
+    /// e.g. the ith element is g^i
+    fn get_element(&self, i: usize) -> F {
+        // TODO: Consider precomputed exponentiation tables if we need this to be faster.
+        self.group_gen.pow(&[i as u64]);
+    }
+
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> Elements<F> {
         Elements {

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -208,7 +208,7 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
     /// e.g. the ith element is g^i
     fn get_element(&self, i: usize) -> F {
         // TODO: Consider precomputed exponentiation tables if we need this to be faster.
-        self.group_gen.pow(&[i as u64]);
+        self.group_gen.pow(&[i as u64])
     }
 
     /// Return an iterator over the elements of the domain.

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -203,7 +203,7 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
         tau.pow(&[self.size]) - F::one()
     }
 
-    /// Returns the ith element of the domain, where elements are ordered by 
+    /// Returns the ith element of the domain, where elements are ordered by
     /// their power of the generator which they correspond to.
     /// e.g. the ith element is g^i
     fn get_element(&self, i: usize) -> F {

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -203,10 +203,10 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
         tau.pow(&[self.size]) - F::one()
     }
 
-    /// Returns the ith element of the domain, where elements are ordered by
+    /// Returns the `i`-th element of the domain, where elements are ordered by
     /// their power of the generator which they correspond to.
-    /// e.g. the ith element is g^i
-    fn get_element(&self, i: usize) -> F {
+    /// e.g. the `i`-th element is g^i
+    fn element(&self, i: usize) -> F {
         // TODO: Consider precomputed exponentiation tables if we need this to be faster.
         self.group_gen.pow(&[i as u64])
     }

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -136,7 +136,7 @@ pub trait EvaluationDomain<F: FftField>:
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F;
 
     /// Returns the `i`-th element of the domain.
-    fn element(&self, i: usize) -> F {
+    fn element(&self, i: usize) -> F;
 
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> Self::Elements;

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -135,6 +135,9 @@ pub trait EvaluationDomain<F: FftField>:
     /// This evaluates the vanishing polynomial for this domain at tau.
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F;
 
+    /// Returns the ith element of the domain.
+    fn get_element(&self, i: usize) -> F;
+
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> Self::Elements;
 

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -135,8 +135,8 @@ pub trait EvaluationDomain<F: FftField>:
     /// This evaluates the vanishing polynomial for this domain at tau.
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F;
 
-    /// Returns the ith element of the domain.
-    fn get_element(&self, i: usize) -> F;
+    /// Returns the `i`-th element of the domain.
+    fn element(&self, i: usize) -> F {
 
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> Self::Elements;

--- a/poly/src/domain/radix2.rs
+++ b/poly/src/domain/radix2.rs
@@ -193,7 +193,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
         tau.pow(&[self.size]) - F::one()
     }
 
-    /// Returns the ith element of the domain, where elements are ordered by 
+    /// Returns the ith element of the domain, where elements are ordered by
     /// their power of the generator which they correspond to.
     /// e.g. the ith element is g^i
     fn get_element(&self, i: usize) -> F {

--- a/poly/src/domain/radix2.rs
+++ b/poly/src/domain/radix2.rs
@@ -193,10 +193,10 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
         tau.pow(&[self.size]) - F::one()
     }
 
-    /// Returns the ith element of the domain, where elements are ordered by
+    /// Returns the `i`-th element of the domain, where elements are ordered by
     /// their power of the generator which they correspond to.
-    /// e.g. the ith element is g^i
-    fn get_element(&self, i: usize) -> F {
+    /// e.g. the `i`-th element is g^i
+    fn element(&self, i: usize) -> F {
         // TODO: Consider precomputed exponentiation tables if we need this to be faster.
         self.group_gen.pow(&[i as u64])
     }

--- a/poly/src/domain/radix2.rs
+++ b/poly/src/domain/radix2.rs
@@ -198,7 +198,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
     /// e.g. the ith element is g^i
     fn get_element(&self, i: usize) -> F {
         // TODO: Consider precomputed exponentiation tables if we need this to be faster.
-        self.group_gen.pow(&[i as u64]);
+        self.group_gen.pow(&[i as u64])
     }
 
     /// Return an iterator over the elements of the domain.

--- a/poly/src/domain/radix2.rs
+++ b/poly/src/domain/radix2.rs
@@ -193,6 +193,14 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
         tau.pow(&[self.size]) - F::one()
     }
 
+    /// Returns the ith element of the domain, where elements are ordered by 
+    /// their power of the generator which they correspond to.
+    /// e.g. the ith element is g^i
+    fn get_element(&self, i: usize) -> F {
+        // TODO: Consider precomputed exponentiation tables if we need this to be faster.
+        self.group_gen.pow(&[i as u64]);
+    }
+
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> Elements<F> {
         Elements {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds a function `get_element(i)` to the `Domain` trait, which returns the `i`th element of a domain. Such a method is useful in many applications, including STARKs.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests - Did not, I view this as sufficiently simple at the moment
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
