### PR TITLE
Add documentation for parallel FFT algorithm

### DIFF
--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -69,7 +69,7 @@ pub(crate) fn parallel_fft<T: DomainCoeff<F>, F: FftField>(
     assert_eq!(m % num_threads, 0);
     let coset_size = m / num_threads;
 
-    // We compute the FFT non-mutatively first in tmp first, 
+    // We compute the FFT non-mutatively first in tmp first,
     // and then shuffle it back into a.
     // The evaluations are going to be arranged in cosets, each of size |a| / num_threads.
     // so the first coset is (1, g^{num_cosets}, g^{2*num_cosets}, etc.)
@@ -80,36 +80,52 @@ pub(crate) fn parallel_fft<T: DomainCoeff<F>, F: FftField>(
     let new_two_adicity = ark_ff::utils::k_adicity(2, coset_size);
 
     // For each coset, we first build a polynomial of degree |coset size|,
-    // whose evaluations over coset j will agree with the evaluations of a over the coset.
-    // Denote the jth such polynomial as poly_j
-    tmp.par_iter_mut().enumerate().for_each(|(j, jth_poly_coeffs)| {
-        // Shuffle into a sub-FFT
-        let omega_j = omega.pow(&[j as u64]);
-        let omega_step = omega.pow(&[(j * coset_size) as u64]);
+    // whose evaluations over coset k will agree with the evaluations of a over the coset.
+    // Denote the kth such polynomial as poly_k
+    tmp.par_iter_mut()
+        .enumerate()
+        .for_each(|(k, kth_poly_coeffs)| {
+            // Shuffle into a sub-FFT
+            let omega_k = omega.pow(&[k as u64]);
+            let omega_step = omega.pow(&[(k * coset_size) as u64]);
 
-        let mut elt = F::one();
-        for i in 0..coset_size {
-            // Make jth_poly_coeffs[i] = 
-            // `sum_{c in num_cosets} g^{j * (i + c * |coset|)} * a[i + c * |coset|]`
+            let mut elt = F::one();
+            // Construct kth_poly_coeffs, which is a polynomial whose evaluations on this coset
+            // should equal the evaluations of a on this coset.
+            // `kth_poly_coeffs[i] = sum_{c in num_cosets} g^{k * (i + c * |coset|)} * a[i + c * |coset|]`
             // Where c represents the index of the coset being considered.
-            // TODO: Include or cite a proof that this is correct.
-            for c in 0..num_threads {
-                let idx = i + (c * coset_size);
-                // t = the value of a corresponding to the ith element of the sth coset.
-                let mut t = a[idx];
-                // elt = g^{j * idx}
-                t *= elt;
-                jth_poly_coeffs[i] += t;
-                elt *= &omega_step;
+            // multiplying by g^{k*i} corresponds to the shift for just being in a different coset.
+            //
+            // TODO: Come back and improve the speed, and make this a more 'normal' Cooley-Tukey.
+            // This appears to be an FFT of the polynomial
+            // `P(x) = sum_{c in |coset|} a[i + c |coset|] * x^c`
+            // onto this coset.
+            // However this is being evaluated in time O(N) instead of time O(|coset|log(|coset|)).
+            // If this understanding is the case, its doing standard Cooley-Tukey,
+            // but not taking the efficient decomposition on the inner sum,
+            // yielding the current bad time complexity.
+            // At the moment, this has time complexity of at least 2*N field mul's per thread,
+            // so we will be getting pretty bad parallelism.
+            // Exact complexity per thread atm is `2N + (N/num threads)log(N/num threads)` field muls
+            // Compare to the time complexity of serial is Nlog(N) field muls), with log(N) in [15, 25]
+            for i in 0..coset_size {
+                for c in 0..num_threads {
+                    let idx = i + (c * coset_size);
+                    // t = the value of a corresponding to the ith element of the sth coset.
+                    let mut t = a[idx];
+                    // elt = g^{k * idx}
+                    t *= elt;
+                    kth_poly_coeffs[i] += t;
+                    elt *= &omega_step;
+                }
+                elt *= &omega_k;
             }
-            elt *= &omega_j;
-        }
 
-        // Perform sub-FFT
-        // Since the sub-FFt is mutative, after this point
-        // `jth_poly_coeffs` should be renamed `jth_coset_evals`
-        serial_fft(jth_poly_coeffs, new_omega, new_two_adicity);
-    });
+            // Perform sub-FFT
+            // Since the sub-FFT is mutative, after this point
+            // `kth_poly_coeffs` should be renamed `kth_coset_evals`
+            serial_fft(kth_poly_coeffs, new_omega, new_two_adicity);
+        });
 
     // shuffle the values computed above into a
     // The evaluations of a should be ordered as (1, g, g^2, ...)

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -62,7 +62,7 @@ pub(crate) fn parallel_fft<T: DomainCoeff<F>, F: FftField>(
     // as though `a` is a polynomial that we are trying to evaluate.
 
     // Partition `a` equally into the number of threads.
-    // each partition is then of size m_div_num_threads
+    // each partition is then of size m / num_threads.
     let m = a.len();
     let num_threads = 1 << (log_cpus as usize);
     let num_cosets = num_threads;
@@ -101,9 +101,7 @@ pub(crate) fn parallel_fft<T: DomainCoeff<F>, F: FftField>(
             // `P(x) = sum_{c in |coset|} a[i + c |coset|] * x^c`
             // onto this coset.
             // However this is being evaluated in time O(N) instead of time O(|coset|log(|coset|)).
-            // If this understanding is the case, its doing standard Cooley-Tukey,
-            // but not taking the efficient decomposition on the inner sum,
-            // yielding the current bad time complexity.
+            // If this understanding is the case, its not doing standard Cooley-Tukey.
             // At the moment, this has time complexity of at least 2*N field mul's per thread,
             // so we will be getting pretty bad parallelism.
             // Exact complexity per thread atm is `2N + (N/num threads)log(N/num threads)` field muls


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Renames variables and documents the parallel FFT. I was going to start work on #83 , but then realized I didn't actually understand our paralell FFT algorithm, so didn't know how to best adapt it to this setting. The implemented algorithm seems like it was a direct translation of the C++ parallel FFT algorithm in libfqfft, which is also completely undocumented.

I'm still not sure what the underlying algorithm is. (Its not quite Cooley Tukey, since both the FFT's being done are of the same size) Its definitely slower than it ought to be at the moment.

I left comments in the code pointing out how to reduce its arithmetic complexity at least from `2N + |coset size| FFT` to `2 * |coset size| FFT` per thread. However that is still higher than Cooley Tukey (but perhaps Cooley Tukey is less clear to parallelize or will have less cache locality).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work. - N/A, functionality unchanged at the moment
- [ ] Wrote unit tests - N/A
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` - N/A
- [x] Re-reviewed `Files changed` in the Github PR explorer
