### PR TITLE
Add Zeroize to fields and elliptic curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - #51 (ark-ff) Removed `unitary_inverse` from `QuadExtField`. Make this change by
     replacing `x.unitary_inverse()` with `let mut tmp = x.clone(); tmp.conjugate()`
 - #53 (ark-poly) Add `Zero` trait bound to `Polynomial`.
+- #106 (ark-ff, ark-ec) Add `Zeroize` trait bound to `Field, ProjectiveGroup, AffineGroup` traits.
 
 ### Features
 - #20 (ark-poly) Add structs/traits for multivariate polynomials

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -20,6 +20,7 @@ derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
 rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 rand_xorshift = "0.2"

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -33,6 +33,7 @@ use ark_std::{
     vec::Vec,
 };
 use num_traits::Zero;
+use zeroize::Zeroize;
 
 pub mod models;
 pub use self::models::*;
@@ -133,6 +134,7 @@ pub trait ProjectiveCurve:
     + Debug
     + Display
     + UniformRand
+    + Zeroize
     + Zero
     + Neg<Output = Self>
     + Add<Self, Output = Self>
@@ -239,6 +241,7 @@ pub trait AffineCurve:
     + Display
     + Zero
     + Neg<Output = Self>
+    + Zeroize
     + From<<Self as AffineCurve>::Projective>
 {
     const COFACTOR: &'static [u64];

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -19,6 +19,7 @@ use ark_ff::{
 use crate::{models::SWModelParameters as Parameters, AffineCurve, ProjectiveCurve};
 
 use num_traits::{One, Zero};
+use zeroize::Zeroize;
 
 use rand::{
     distributions::{Distribution, Standard},
@@ -129,6 +130,16 @@ impl<P: Parameters> GroupAffine<P> {
     pub fn is_in_correct_subgroup_assuming_on_curve(&self) -> bool {
         self.mul_bits(BitIteratorBE::new(P::ScalarField::characteristic()))
             .is_zero()
+    }
+}
+
+impl<P: Parameters> Zeroize for GroupAffine<P> {
+    // The phantom data does not contain element-specific data
+    // and thus does not need to be zeroized.
+    fn zeroize(&mut self) {
+        self.x.zeroize();
+        self.y.zeroize();
+        self.infinity.zeroize();
     }
 }
 
@@ -337,6 +348,16 @@ impl<P: Parameters> GroupProjective<P> {
             z,
             _params: PhantomData,
         }
+    }
+}
+
+impl<P: Parameters> Zeroize for GroupProjective<P> {
+    // The phantom data does not contain element-specific data
+    // and thus does not need to be zeroized.
+    fn zeroize(&mut self) {
+        self.x.zeroize();
+        self.y.zeroize();
+        self.z.zeroize();
     }
 }
 

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -14,11 +14,11 @@ use ark_std::{
     vec::Vec,
 };
 use num_traits::{One, Zero};
-use zeroize::Zeroize;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
+use zeroize::Zeroize;
 
 use ark_ff::{
     bytes::{FromBytes, ToBytes},

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -14,6 +14,7 @@ use ark_std::{
     vec::Vec,
 };
 use num_traits::{One, Zero};
+use zeroize::Zeroize;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -161,6 +162,15 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
 
     fn mul_by_cofactor_inv(&self) -> Self {
         self.mul(P::COFACTOR_INV).into()
+    }
+}
+
+impl<P: Parameters> Zeroize for GroupAffine<P> {
+    // The phantom data does not contain element-specific data
+    // and thus does not need to be zeroized.
+    fn zeroize(&mut self) {
+        self.x.zeroize();
+        self.y.zeroize();
     }
 }
 
@@ -391,6 +401,16 @@ impl<P: Parameters> GroupProjective<P> {
             z,
             _params: PhantomData,
         }
+    }
+}
+impl<P: Parameters> Zeroize for GroupProjective<P> {
+    // The phantom data does not contain element-specific data
+    // and thus does not need to be zeroized.
+    fn zeroize(&mut self) {
+        self.x.zeroize();
+        self.y.zeroize();
+        self.t.zeroize();
+        self.z.zeroize();
     }
 }
 

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -21,6 +21,7 @@ derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
 rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [build-dependencies]
 rustc_version = "0.3"

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -1,6 +1,6 @@
 macro_rules! bigint_impl {
     ($name:ident, $num_limbs:expr) => {
-        #[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Hash)]
+        #[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Hash, Zeroize)]
         pub struct $name(pub [u64; $num_limbs]);
 
         impl $name {

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -15,6 +15,7 @@ use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
+use zeroize::Zeroize;
 
 #[macro_use]
 mod macros;
@@ -50,6 +51,7 @@ pub trait BigInteger:
     + Sync
     + 'static
     + UniformRand
+    + Zeroize
     + AsMut<[u64]>
     + AsRef<[u64]>
     + From<u64>

--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -544,5 +544,13 @@ macro_rules! impl_Fp {
                 self.mul_assign(&other.inverse().unwrap());
             }
         }
+
+        impl<P: $FpParameters> zeroize::Zeroize for $Fp<P> {
+            // The phantom data does not contain element-specific data
+            // and thus does not need to be zeroized.
+            fn zeroize(&mut self) {
+                self.0.zeroize();
+            }
+        }
     }
 }

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -17,6 +17,7 @@ use ark_std::{
 };
 
 use num_traits::{One, Zero};
+use zeroize::Zeroize;
 
 #[macro_use]
 pub mod macros;
@@ -66,11 +67,12 @@ pub trait Field:
     + Send
     + Sync
     + Eq
+    + Zero
     + One
     + Ord
     + Neg<Output = Self>
     + UniformRand
-    + Zero
+    + Zeroize
     + Sized
     + Hash
     + CanonicalSerialize

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -12,6 +12,7 @@ use ark_std::{
 };
 
 use num_traits::{One, Zero};
+use zeroize::Zeroize;
 
 use rand::{
     distributions::{Distribution, Standard},
@@ -274,6 +275,16 @@ impl<P: CubicExtParameters> PartialOrd for CubicExtField<P> {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl<P: CubicExtParameters> Zeroize for CubicExtField<P> {
+    // The phantom data does not contain element-specific data
+    // and thus does not need to be zeroized.
+    fn zeroize(&mut self) {
+        self.c0.zeroize();
+        self.c1.zeroize();
+        self.c2.zeroize();
     }
 }
 

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -12,6 +12,7 @@ use ark_std::{
 };
 
 use num_traits::{One, Zero};
+use zeroize::Zeroize;
 
 use rand::{
     distributions::{Distribution, Standard},
@@ -327,6 +328,15 @@ impl<P: QuadExtParameters> PartialOrd for QuadExtField<P> {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl<P: QuadExtParameters> Zeroize for QuadExtField<P> {
+    // The phantom data does not contain element-specific data
+    // and thus does not need to be zeroized.
+    fn zeroize(&mut self) {
+        self.c0.zeroize();
+        self.c1.zeroize();
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR implements Zeroize for the Field, AffineGroup, and ProjectiveGroup traits.  

Why Zeroize is helpful:

If you operate in the threat model of an attacker getting user space memory leakage (E.g. Heartbleed, cold boot attacks, DMA attacks), then a method to hopefully lower the probability of a succesful attack is to reduce the amount of time secrets are in memory. 

This is pretty hard to do in the ideal sense, as you'd want all associated temporaries to be wiped as soon as possible (including register spills, the thread being switched etc.).

However if you have all temporaries be created in stack, then you can get some level of memory wiping by Zero'ing out your secret itself and everything on heap when you are done with them, and then hoping that everything that was created on stack gets written over relatively soon (or manually doing that with unsafe / some other method)

Adding Zeroize gives end application developers more of an ability to do the above, since they can now zeroize secrets, and use the `secret` trait, to allocate secrets on heap and have them be zero'd out when they're done. 

cref: https://github.com/arkworks-rs/snark/issues/111

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
