### PR TITLE
Change EC scalar mul from taking a bigint to taking AsRef<[u64]>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     replacing `x.unitary_inverse()` with `let mut tmp = x.clone(); tmp.conjugate()`
 - #53 (ark-poly) Add `Zero` trait bound to `Polynomial`.
 - #106 (ark-ff, ark-ec) Add `Zeroize` trait bound to `Field, ProjectiveGroup, AffineGroup` traits.
+- #110 (ark-ec) Change the trait bound on the scalar for `mul`, from (essentially) `Into<BigInt>` to `AsRef<[u64]>`
 
 ### Features
 - #20 (ark-poly) Add structs/traits for multivariate polynomials

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -206,9 +206,9 @@ pub trait ProjectiveCurve:
     fn add_assign_mixed(&mut self, other: &Self::Affine);
 
     /// Performs scalar multiplication of this element.
-    fn mul<S: Into<<Self::ScalarField as PrimeField>::BigInt>>(mut self, other: S) -> Self {
+    fn mul<S: AsRef<[u64]>>(mut self, other: S) -> Self {
         let mut res = Self::zero();
-        for b in ark_ff::BitIteratorBE::without_leading_zeros(other.into()) {
+        for b in ark_ff::BitIteratorBE::without_leading_zeros(other) {
             res.double_in_place();
             if b {
                 res += self;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Changes the elliptic curve scalar mul function to now take in `AsRef<[u64]>`. This change has been tested to not require any update to `curves` or `r1cs-std`, per the steps in #34. This is making me suspect that the change is not breaking, but that would be surprising. 

I don't see why `Into<Bigint>` would also be `AsRef<[u64]>`, so I'm listing this as a breaking change for now. Do you know @Pratyush?

closes: #61 
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work. - Not sure if it was accepted per se, but its more consistent, and lets one multiply by a small constant more easily
- [x] Wrote unit tests - correctness is caught by existing tests
- [x] Updated relevant documentation in the code - don't see any docs to update
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
