### PR TITLE
Use `ark_ff::batch_inversion` for point normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - #115 (ark-ff) Add parallel implementation of `batch_inversion`.
 - #122 (ark-poly) Add infrastructure for benchmarking `FFT`s.
 - #125 (ark-poly) Add parallelization to applying coset shifts within `coset_fft`.
+- #126 (ark-ec) Use `ark_ff::batch_inversion` for point normalization
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -399,38 +399,12 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
 
     #[inline]
     fn batch_normalization(v: &mut [Self]) {
-        // Montgomery’s Trick and Fast Implementation of Masked AES
-        // Genelle, Prouff and Quisquater
-        // Section 3.2
-
-        // First pass: compute [a, ab, abc, ...]
-        let mut prod = Vec::with_capacity(v.len());
-        let mut tmp = P::BaseField::one();
-        for g in v.iter_mut()
-            // Ignore normalized elements
+        let mut z_s = v
+            .iter()
             .filter(|g| !g.is_normalized())
-        {
-            tmp *= &g.z;
-            prod.push(tmp);
-        }
-
-        // Invert `tmp`.
-        tmp = tmp.inverse().unwrap(); // Guaranteed to be nonzero.
-
-        // Second pass: iterate backwards to compute inverses
-        for (g, s) in v.iter_mut()
-            // Backwards
-            .rev()
-            // Ignore normalized elements
-            .filter(|g| !g.is_normalized())
-            // Backwards, skip last element, fill in one for last term.
-            .zip(prod.into_iter().rev().skip(1).chain(Some(P::BaseField::one())))
-        {
-            // tmp := tmp * g.z; g.z := tmp * s = 1/z
-            let newtmp = tmp * &g.z;
-            g.z = tmp * &s;
-            tmp = newtmp;
-        }
+            .map(|g| g.z)
+            .collect::<Vec<_>>();
+        ark_ff::batch_inversion(&mut z_s);
 
         #[cfg(not(feature = "parallel"))]
         let v_iter = v.iter_mut();
@@ -438,12 +412,15 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         let v_iter = v.par_iter_mut();
 
         // Perform affine transformations
-        v_iter.filter(|g| !g.is_normalized()).for_each(|g| {
-            let z2 = g.z.square(); // 1/z
-            g.x *= &z2; // x/z^2
-            g.y *= &(z2 * &g.z); // y/z^3
-            g.z = P::BaseField::one(); // z = 1
-        });
+        v_iter
+            .filter(|g| !g.is_normalized())
+            .zip(z_s)
+            .for_each(|(g, z)| {
+                let z2 = z.square(); // 1/z
+                g.x *= &z2; // x/z^2
+                g.y *= &(z2 * &z); // y/z^3
+                g.z = P::BaseField::one(); // z = 1
+            });
     }
 
     fn double_in_place(&mut self) -> &mut Self {

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -444,38 +444,12 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
     }
 
     fn batch_normalization(v: &mut [Self]) {
-        // Montgomery’s Trick and Fast Implementation of Masked AES
-        // Genelle, Prouff and Quisquater
-        // Section 3.2
-
-        // First pass: compute [a, ab, abc, ...]
-        let mut prod = Vec::with_capacity(v.len());
-        let mut tmp = P::BaseField::one();
-        for g in v.iter_mut()
-            // Ignore normalized elements
+        let mut z_s = v
+            .iter()
             .filter(|g| !g.is_normalized())
-        {
-            tmp *= &g.z;
-            prod.push(tmp);
-        }
-
-        // Invert `tmp`.
-        tmp = tmp.inverse().unwrap(); // Guaranteed to be nonzero.
-
-        // Second pass: iterate backwards to compute inverses
-        for (g, s) in v.iter_mut()
-            // Backwards
-            .rev()
-                // Ignore normalized elements
-                .filter(|g| !g.is_normalized())
-                // Backwards, skip last element, fill in one for last term.
-                .zip(prod.into_iter().rev().skip(1).chain(Some(P::BaseField::one())))
-        {
-            // tmp := tmp * g.z; g.z := tmp * s = 1/z
-            let newtmp = tmp * &g.z;
-            g.z = tmp * &s;
-            tmp = newtmp;
-        }
+            .map(|g| g.z)
+            .collect::<Vec<_>>();
+        ark_ff::batch_inversion(&mut z_s);
 
         #[cfg(not(feature = "parallel"))]
         let v_iter = v.iter_mut();
@@ -483,12 +457,15 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         let v_iter = v.par_iter_mut();
 
         // Perform affine transformations
-        v_iter.filter(|g| !g.is_normalized()).for_each(|g| {
-            g.x *= &g.z; // x/z
-            g.y *= &g.z;
-            g.t *= &g.z;
-            g.z = P::BaseField::one(); // z = 1
-        });
+        v_iter
+            .filter(|g| !g.is_normalized())
+            .zip(z_s)
+            .for_each(|(g, z)| {
+                g.x *= &z; // x/z
+                g.y *= &z;
+                g.t *= &z;
+                g.z = P::BaseField::one(); // z = 1
+            });
     }
 
     fn double_in_place(&mut self) -> &mut Self {

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -444,22 +444,13 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
     }
 
     fn batch_normalization(v: &mut [Self]) {
-        let mut z_s = v
-            .iter()
-            .filter(|g| !g.is_normalized())
-            .map(|g| g.z)
-            .collect::<Vec<_>>();
+        let mut z_s = v.iter().map(|g| g.z).collect::<Vec<_>>();
         ark_ff::batch_inversion(&mut z_s);
 
-        #[cfg(not(feature = "parallel"))]
-        let v_iter = v.iter_mut();
-        #[cfg(feature = "parallel")]
-        let v_iter = v.par_iter_mut();
-
         // Perform affine transformations
-        v_iter
-            .filter(|g| !g.is_normalized())
+        ark_std::cfg_iter_mut!(v)
             .zip(z_s)
+            .filter(|(g, _)| !g.is_normalized())
             .for_each(|(g, z)| {
                 g.x *= &z; // x/z
                 g.y *= &z;

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -15,6 +15,8 @@ ark-ec = { path = "../ec", default-features = false }
 [features]
 default = []
 
+parallel = [ "ark-ff/parallel", "ark-ec/parallel" ]
+
 bls12_381_scalar_field = []
 bls12_381_curve = [ "bls12_381_scalar_field" ]
 

--- a/test-curves/src/bls12_381/g1.rs
+++ b/test-curves/src/bls12_381/g1.rs
@@ -51,3 +51,28 @@ pub const G1_GENERATOR_X: Fq = field_new!(Fq, "368541675371338701678108831518307
 /// 1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569
 #[rustfmt::skip]
 pub const G1_GENERATOR_Y: Fq = field_new!(Fq, "1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569");
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ark_ec::ProjectiveCurve;
+    use ark_ff::UniformRand;
+
+    #[test]
+    fn batch_normalization() {
+        let mut rng = ark_ff::test_rng();
+
+        let mut g_s = [G1Projective::zero(); 100];
+        for i in 0..100 {
+            g_s[i] = G1Projective::rand(&mut rng);
+        }
+
+        let mut g_s_affine_naive = [G1Affine::zero(); 100];
+        for (i, g) in g_s.iter().enumerate() {
+            g_s_affine_naive[i] = g.into_affine();
+        }
+
+        let g_s_affine_fast = G1Projective::batch_normalization_into_affine(&g_s);
+        assert_eq!(g_s_affine_naive.as_ref(), g_s_affine_fast.as_slice());
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Reuses existing batch inversion code for batch normalization. Enables better parallelization, at the expense of some more allocation.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
