### PR TITLE
Speedup `sqrt` on `PrimeField` when a square root exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - #122 (ark-poly) Add infrastructure for benchmarking `FFT`s.
 - #125 (ark-poly) Add parallelization to applying coset shifts within `coset_fft`.
 - #126 (ark-ec) Use `ark_ff::batch_inversion` for point normalization
+- #131 (ark-ff) Speedup `sqrt` on `PrimeField` when a square root exists. (And slows it down when doesn't exist)
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -229,53 +229,64 @@ macro_rules! sqrt_impl {
         // Actually this is just normal Tonelli-Shanks; since `P::Generator`
         // is a quadratic non-residue, `P::ROOT_OF_UNITY = P::GENERATOR ^ t`
         // is also a quadratic non-residue (since `t` is odd).
-        match $self.legendre() {
-            Zero => Some(*$self),
-            QuadraticNonResidue => None,
-            QuadraticResidue => {
-                let mut z = $Self::qnr_to_t();
-                let mut w = $self.pow($P::T_MINUS_ONE_DIV_TWO);
-                let mut x = w * $self;
-                let mut b = x * &w;
+        if $self.is_zero() {
+            return Some($Self::zero());
+        }
+        // Try computing the square root (x at the end of the algorithm)
+        // Check at the end of the algorithm if x was a square root
+        // Begin Tonelli-Shanks
+        let mut z = $Self::qnr_to_t();
+        let mut w = $self.pow($P::T_MINUS_ONE_DIV_TWO);
+        let mut x = w * $self;
+        let mut b = x * &w;
 
-                let mut v = $P::TWO_ADICITY as usize;
-                // t = self^t
-                #[cfg(debug_assertions)]
-                {
-                    let mut check = b;
-                    for _ in 0..(v - 1) {
-                        check.square_in_place();
-                    }
-                    if !check.is_one() {
-                        panic!("Input is not a square root, but it passed the QR test")
-                    }
-                }
-
-                while !b.is_one() {
-                    let mut k = 0usize;
-
-                    let mut b2k = b;
-                    while !b2k.is_one() {
-                        // invariant: b2k = b^(2^k) after entering this loop
-                        b2k.square_in_place();
-                        k += 1;
-                    }
-
-                    let j = v - k - 1;
-                    w = z;
-                    for _ in 0..j {
-                        w.square_in_place();
-                    }
-
-                    z = w.square();
-                    b *= &z;
-                    x *= &w;
-                    v = k;
-                }
-
-                Some(x)
+        let mut v = $P::TWO_ADICITY as usize;
+        // t = self^t
+        #[cfg(debug_assertions)]
+        {
+            let mut check = b;
+            for _ in 0..(v - 1) {
+                check.square_in_place();
+            }
+            if !check.is_one() {
+                panic!("Input is not a square root, but it passed the QR test")
             }
         }
+
+        while !b.is_one() {
+            let mut k = 0usize;
+
+            let mut b2k = b;
+            while !b2k.is_one() {
+                // invariant: b2k = b^(2^k) after entering this loop
+                b2k.square_in_place();
+                k += 1;
+            }
+
+            let j = v - k - 1;
+            w = z;
+            for _ in 0..j {
+                w.square_in_place();
+            }
+
+            z = w.square();
+            b *= &z;
+            x *= &w;
+            v = k;
+        }
+        // Is x the square root? If so, return it.
+        if (x * x == *$self) {
+            return Some(x);
+        }
+        // Consistency check that if no square root is found,
+        // it is because none exists.
+        #[cfg(debug_assertions)]
+        {
+            if ($self.legendre() != QuadraticNonResidue) {
+                panic!("Input has a square root per its legendre symbol, but it was not found")
+            }
+        }
+        None
     }};
 }
 


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Applies daira's suggestion from #40 to make the square root algorithm skip computing the legendre symbol. This speeds up the square root when the element is actually a square root, in exchange for slowing down the square root when its not actually a square root. 

I think this makes sense as a trade-off, as getting faster point decompression in the honest case is quite useful. And in  cases I'm aware of, with an adversary who want to delay another node, you would have made your curve point pass deserialization and fail in other logic later on

cref #40

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
