### PR TITLE
Correct CHANGELOG in #144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     by replacing `sparse_poly.evaluate(pt)` to `sparse_poly.evaluate(&pt)`.
 - #129 (ark-ff) Move `ark_ff::{UniformRand, test_rng}` to `ark_std::{UniformRand, test_rng}`.
     Importing these from `ark-ff` is still possible, but is deprecated and will be removed in the following release.
+- #144 (ark-poly) Add `CanonicalSerialize` and `CanonicalDeserialize` trait bounds for `Polynomial`.
 
 ### Features
 - #20 (ark-poly) Add structs/traits for multivariate polynomials

--- a/poly/README.md
+++ b/poly/README.md
@@ -8,10 +8,10 @@ The `polynomial` module provides the following traits for defining polynomials:
 
 - [`Polynomial`](https://github.com/arkworks-rs/algebra/blob/master/poly/src/polynomial/mod.rs#L16):
 Requires implementors to support common operations on polynomials,
-such as `Add`, `Sub`, `Zero`, evaluation at a point, degree, etc.
-- [`UVPolynomial`](https://github.com/arkworks-rs/algebra/blob/master/poly/src/polynomial/mod.rs#L41):
-Specifies that a `Polynomial` is actually a *univariate* polynomial,
+such as `Add`, `Sub`, `Zero`, evaluation at a point, degree, etc,
 and defines methods to serialize to and from the coefficient representation of the polynomial.
+- [`UVPolynomial`](https://github.com/arkworks-rs/algebra/blob/master/poly/src/polynomial/mod.rs#L41):
+Specifies that a `Polynomial` is actually a *univariate* polynomial.
 - [`MVPolynomial`](https://github.com/arkworks-rs/algebra/blob/master/poly/src/polynomial/mod.rs#L59):
 Specifies that a `Polynomial` is actually a *multivariate* polynomial.
 

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -46,8 +46,8 @@ impl<F: FftField> CanonicalSerialize for GeneralEvaluationDomain<F> {
         type_id.serialize(&mut writer)?;
 
         match self {
-            GeneralEvaluationDomain::Radix2(d) => d.serialize(&mut writer),
-            GeneralEvaluationDomain::MixedRadix(d) => d.serialize(&mut writer),
+            GeneralEvaluationDomain::Radix2(domain) => domain.serialize(&mut writer),
+            GeneralEvaluationDomain::MixedRadix(domain) => domain.serialize(&mut writer),
         }
     }
 
@@ -59,8 +59,8 @@ impl<F: FftField> CanonicalSerialize for GeneralEvaluationDomain<F> {
 
         type_id.serialized_size()
             + match self {
-                GeneralEvaluationDomain::Radix2(d) => d.serialized_size(),
-                GeneralEvaluationDomain::MixedRadix(d) => d.serialized_size(),
+                GeneralEvaluationDomain::Radix2(domain) => domain.serialized_size(),
+                GeneralEvaluationDomain::MixedRadix(domain) => domain.serialized_size(),
             }
     }
 
@@ -72,8 +72,10 @@ impl<F: FftField> CanonicalSerialize for GeneralEvaluationDomain<F> {
         type_id.serialize_uncompressed(&mut writer)?;
 
         match self {
-            GeneralEvaluationDomain::Radix2(d) => d.serialize_uncompressed(&mut writer),
-            GeneralEvaluationDomain::MixedRadix(d) => d.serialize_uncompressed(&mut writer),
+            GeneralEvaluationDomain::Radix2(domain) => domain.serialize_uncompressed(&mut writer),
+            GeneralEvaluationDomain::MixedRadix(domain) => {
+                domain.serialize_uncompressed(&mut writer)
+            }
         }
     }
 
@@ -85,8 +87,8 @@ impl<F: FftField> CanonicalSerialize for GeneralEvaluationDomain<F> {
         type_id.serialize_unchecked(&mut writer)?;
 
         match self {
-            GeneralEvaluationDomain::Radix2(d) => d.serialize_unchecked(&mut writer),
-            GeneralEvaluationDomain::MixedRadix(d) => d.serialize_unchecked(&mut writer),
+            GeneralEvaluationDomain::Radix2(domain) => domain.serialize_unchecked(&mut writer),
+            GeneralEvaluationDomain::MixedRadix(domain) => domain.serialize_unchecked(&mut writer),
         }
     }
 
@@ -98,8 +100,8 @@ impl<F: FftField> CanonicalSerialize for GeneralEvaluationDomain<F> {
 
         type_id.uncompressed_size()
             + match self {
-                GeneralEvaluationDomain::Radix2(d) => d.uncompressed_size(),
-                GeneralEvaluationDomain::MixedRadix(d) => d.uncompressed_size(),
+                GeneralEvaluationDomain::Radix2(domain) => domain.uncompressed_size(),
+                GeneralEvaluationDomain::MixedRadix(domain) => domain.uncompressed_size(),
             }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes the CHANGELOG in #144, which indeed is a breaking change because additional trait bounds are placed. This has already caused a problem for #140.

cc @ValarDragon 

---

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
