### PR TITLE
Add serialization for `String`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - #131, #137 (ark-ff) Speedup `sqrt` on fields when a square root exists. (And slows it down when doesn't exist)
 - #141 (ark-ff) Add `Fp64`
 - #144 (ark-poly) Add serialization for polynomials and evaluations
+- #149 (ark-serialize) Add an impl of `CanonicalSerialize/Deserialize` for `String`.
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -912,6 +912,11 @@ mod test {
     }
 
     #[test]
+    fn test_string() {
+        test_serialize(String::from("arkworks"));
+    }
+
+    #[test]
     fn test_tuple() {
         test_serialize((123u64, 234u32, Dummy));
     }

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -9,6 +9,7 @@ use ark_std::{
     borrow::{Cow, ToOwned},
     collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
+    string::String,
     vec::Vec,
 };
 pub use error::*;
@@ -201,6 +202,27 @@ impl CanonicalDeserialize for usize {
         let mut bytes = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut bytes)?;
         usize::try_from(u64::from_le_bytes(bytes)).map_err(|_| SerializationError::InvalidData)
+    }
+}
+
+// Implement Serialization for `String`
+impl CanonicalSerialize for String {
+    #[inline]
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        self.clone().into_bytes().serialize(&mut writer)
+    }
+
+    #[inline]
+    fn serialized_size(&self) -> usize {
+        self.clone().into_bytes().serialized_size()
+    }
+}
+
+impl CanonicalDeserialize for String {
+    #[inline]
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        String::from_utf8(Vec::<u8>::deserialize(&mut reader)?)
+            .map_err(|_| SerializationError::InvalidData)
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds the serialization for `String`. This would simplify some existing serialization code in `poly-commit`, as evidenced by https://github.com/arkworks-rs/poly-commit/blob/master/src/data_structures.rs#L129.

closes: #148 

---

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
