### PR TITLE
Add a Field::from_base_field_elements method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The main features of this release are:
 - Multi-variate polynomial support
 - Many speedups to operations involving polynomials
 - Some speedups to `sqrt`
-- Speedup to fixed-base `MSM`s
+- Small speedups to `MSM`s
 
 ### Breaking changes
 - #20 (ark-poly) Move univariate DensePolynomial and SparsePolynomial into a 
@@ -36,13 +36,13 @@ The main features of this release are:
     if the top bits of the `u8` value do *not* correspond to one of the possible outputs of `Flags::u8_bitmask`, then these methods output `None`, whereas before they output
     a default value.
   Downstream users other than `ark-curves` should not see breakage unless they rely on these methods/traits explicitly.
+- #165 (ark-ff) Add `from_base_field_elements` as a method to the `Field` trait.
 
 ### Features
 - #20 (ark-poly) Add structs/traits for multivariate polynomials
 - #96 (ark-ff) Make the `field_new` macro accept values in integer form, without requiring decomposition into limbs, and without requiring encoding in Montgomery form.
 - #106 (ark-ff, ark-ec) Add `Zeroize` trait bound to `Field, ProjectiveGroup, AffineGroup` traits.
 - #117 (ark-poly) Add operations to `SparsePolynomial`, so it implements `Polynomial`
-
 
 ### Improvements
 - #22 (ark-ec) Speedup fixed-base MSMs
@@ -77,6 +77,6 @@ The main features of this release are:
 - #119 (ark-poly) Fix bugs in degree calculation if adding/subtracting same degree polynomials
      whose leading coefficients cancel.
 - #160 (ark-serialize, ark-ff, ark-ec) Support serializing when `MODULUS_BITS + FLAG_BITS` is greater than the multiple of 8 just greater than `MODULUS_BITS`, which is the case for the Pasta curves (fixes #47).
-
+- #165 (ark-ff) Enforce in the type system that an extension fields `BaseField` extends from the correct `BasePrimeField`.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -277,6 +277,13 @@ macro_rules! impl_Fp {
                 1
             }
 
+            fn from_base_prime_field_elems(elems: &[Self::BasePrimeField]) -> Option<Self> {
+                if elems.len() != (Self::extension_degree() as usize) {
+                    return None;
+                }
+                Some(elems[0])
+            }
+
             #[inline]
             fn double(&self) -> Self {
                 let mut temp = *self;

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -130,6 +130,10 @@ pub trait Field:
     /// to `Self::BasePrimeField`.
     fn extension_degree() -> u64;
 
+    /// Convert a slice of base prime field elements into a field element.
+    /// If the slice length != Self::extension_degree(), must return None.
+    fn from_base_prime_field_elems(elems: &[Self::BasePrimeField]) -> Option<Self>;
+
     /// Returns `self + self`.
     #[must_use]
     fn double(&self) -> Self;
@@ -524,7 +528,8 @@ pub fn batch_inversion_and_mul<F: Field>(v: &mut [F], coeff: &F) {
     });
 }
 
-// Given a vector of field elements {v_i}, compute the vector {coeff * v_i^(-1)}
+/// Given a vector of field elements {v_i}, compute the vector {coeff * v_i^(-1)}
+/// This method is explicitly single core.
 fn serial_batch_inversion_and_mul<F: Field>(v: &mut [F], coeff: &F) {
     // Montgomery’s Trick and Fast Implementation of Masked AES
     // Genelle, Prouff and Quisquater

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -29,7 +29,7 @@ pub trait CubicExtParameters: 'static + Send + Sync {
     /// The prime field that this quadratic extension is eventually an extension of.
     type BasePrimeField: PrimeField;
     /// The base field that this field is a quadratic extension of.
-    type BaseField: Field;
+    type BaseField: Field<BasePrimeField = Self::BasePrimeField>;
     /// The type of the coefficients for an efficient implemntation of the
     /// Frobenius endomorphism.
     type FrobCoeff: Field;
@@ -142,6 +142,19 @@ impl<P: CubicExtParameters> Field for CubicExtField<P> {
 
     fn extension_degree() -> u64 {
         3 * P::BaseField::extension_degree()
+    }
+
+    fn from_base_prime_field_elems(elems: &[Self::BasePrimeField]) -> Option<Self> {
+        if elems.len() != (Self::extension_degree() as usize) {
+            return None;
+        }
+        let base_ext_deg = P::BaseField::extension_degree() as usize;
+        Some(Self::new(
+            P::BaseField::from_base_prime_field_elems(&elems[0..base_ext_deg]).unwrap(),
+            P::BaseField::from_base_prime_field_elems(&elems[base_ext_deg..2 * base_ext_deg])
+                .unwrap(),
+            P::BaseField::from_base_prime_field_elems(&elems[2 * base_ext_deg..]).unwrap(),
+        ))
     }
 
     fn double(&self) -> Self {
@@ -552,5 +565,46 @@ where
         res.append(&mut c2_elems);
 
         Some(res)
+    }
+}
+
+#[cfg(test)]
+mod cube_ext_tests {
+    use super::*;
+    use crate::test_field::{Fq, Fq2, Fq6};
+    use ark_std::test_rng;
+
+    #[test]
+    fn test_from_base_prime_field_elements() {
+        let ext_degree = Fq6::extension_degree() as usize;
+        // Test on slice lengths that aren't equal to the extension degree
+        let max_num_elems_to_test = 10;
+        for d in 0..max_num_elems_to_test {
+            if d == ext_degree {
+                continue;
+            }
+            let mut random_coeffs = Vec::<Fq>::new();
+            for _ in 0..d {
+                random_coeffs.push(Fq::rand(&mut test_rng()));
+            }
+            let res = Fq6::from_base_prime_field_elems(&random_coeffs);
+            assert_eq!(res, None);
+        }
+        // Test on slice lengths that are equal to the extension degree
+        // We test consistency against Fq2::new
+        let number_of_tests = 10;
+        for _ in 0..number_of_tests {
+            let mut random_coeffs = Vec::<Fq>::new();
+            for _ in 0..ext_degree {
+                random_coeffs.push(Fq::rand(&mut test_rng()));
+            }
+            let actual = Fq6::from_base_prime_field_elems(&random_coeffs).unwrap();
+
+            let expected_0 = Fq2::new(random_coeffs[0], random_coeffs[1]);
+            let expected_1 = Fq2::new(random_coeffs[2], random_coeffs[3]);
+            let expected_2 = Fq2::new(random_coeffs[3], random_coeffs[4]);
+            let expected = Fq6::new(expected_0, expected_1, expected_2);
+            assert_eq!(actual, expected);
+        }
     }
 }

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -26,9 +26,9 @@ use crate::{
 };
 
 pub trait CubicExtParameters: 'static + Send + Sync {
-    /// The prime field that this quadratic extension is eventually an extension of.
+    /// The prime field that this cubic extension is eventually an extension of.
     type BasePrimeField: PrimeField;
-    /// The base field that this field is a quadratic extension of.
+    /// The base field that this field is a cubic extension of.
     type BaseField: Field<BasePrimeField = Self::BasePrimeField>;
     /// The type of the coefficients for an efficient implemntation of the
     /// Frobenius endomorphism.

--- a/ff/src/test_field/mod.rs
+++ b/ff/src/test_field/mod.rs
@@ -302,6 +302,7 @@ pub(crate) mod fq2 {
 }
 
 pub(crate) mod fq6 {
+    // Copy of BLS12-377's Fq6
     use super::{fq::*, fq2::*};
     use crate::{field_new, fields::*};
 

--- a/ff/src/test_field/mod.rs
+++ b/ff/src/test_field/mod.rs
@@ -1,5 +1,9 @@
 #[allow(unused)]
 pub(crate) use fq::*;
+#[allow(unused)]
+pub(crate) use fq2::*;
+#[allow(unused)]
+pub(crate) use fq6::*;
 pub(crate) use fr::*;
 
 pub(crate) mod fr {
@@ -226,6 +230,11 @@ pub(crate) mod fq {
         ]);
     }
 
+    #[allow(dead_code)]
+    pub const FQ_ONE: Fq = Fq::new(FqParameters::R);
+    #[allow(dead_code)]
+    pub const FQ_ZERO: Fq = Fq::new(BigInteger([0, 0, 0, 0, 0, 0]));
+
     #[test]
     fn test_const_from_repr() {
         use crate::fields::PrimeField;
@@ -245,5 +254,131 @@ pub(crate) mod fq {
             Fq::from_repr(int).unwrap(),
             Fq::const_from_repr(int, r2, modulus, inv)
         );
+    }
+}
+
+pub(crate) mod fq2 {
+    // Copy of BLS12-377's Fq2
+    use super::fq::*;
+    use crate::{field_new, fields::*};
+
+    pub type Fq2 = Fp2<Fq2Parameters>;
+
+    pub struct Fq2Parameters;
+
+    impl Fp2Parameters for Fq2Parameters {
+        type Fp = Fq;
+
+        /// NONRESIDUE = -5
+        #[rustfmt::skip]
+        const NONRESIDUE: Fq = field_new!(Fq, "-5");
+
+        /// QUADRATIC_NONRESIDUE = U
+        #[rustfmt::skip]
+        const QUADRATIC_NONRESIDUE: (Fq, Fq) = (FQ_ZERO, FQ_ONE);
+
+        /// Coefficients for the Frobenius automorphism.
+        #[rustfmt::skip]
+        const FROBENIUS_COEFF_FP2_C1: &'static [Fq] = &[
+            // NONRESIDUE**(((q^0) - 1) / 2)
+            FQ_ONE,
+            // NONRESIDUE**(((q^1) - 1) / 2)
+            field_new!(Fq, "-1"),
+        ];
+
+        #[inline(always)]
+        fn mul_fp_by_nonresidue(fe: &Self::Fp) -> Self::Fp {
+            let original = fe;
+            let mut fe = -fe.double();
+            fe.double_in_place();
+            fe - original
+        }
+    }
+
+    #[allow(dead_code)]
+    pub const FQ2_ZERO: Fq2 = field_new!(Fq2, FQ_ZERO, FQ_ZERO);
+    #[allow(dead_code)]
+    pub const FQ2_ONE: Fq2 = field_new!(Fq2, FQ_ONE, FQ_ZERO);
+}
+
+pub(crate) mod fq6 {
+    use super::{fq::*, fq2::*};
+    use crate::{field_new, fields::*};
+
+    #[allow(dead_code)]
+    pub type Fq6 = Fp6<Fq6Parameters>;
+
+    #[derive(Clone, Copy)]
+    pub struct Fq6Parameters;
+
+    impl Fp6Parameters for Fq6Parameters {
+        type Fp2Params = Fq2Parameters;
+
+        /// NONRESIDUE = U
+        #[rustfmt::skip]
+        const NONRESIDUE: Fq2 = field_new!(Fq2, FQ_ZERO, FQ_ONE);
+
+        #[rustfmt::skip]
+        const FROBENIUS_COEFF_FP6_C1: &'static [Fq2] = &[
+            // Fp2::NONRESIDUE^(((q^0) - 1) / 3)
+            field_new!(Fq2, FQ_ONE, FQ_ZERO),
+            // Fp2::NONRESIDUE^(((q^1) - 1) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946"),
+                FQ_ZERO,
+            ),
+            // Fp2::NONRESIDUE^(((q^2) - 1) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945"),
+                FQ_ZERO,
+            ),
+            // Fp2::NONRESIDUE^(((q^3) - 1) / 3)
+            field_new!(Fq2, field_new!(Fq, "-1"), FQ_ZERO),
+            // Fp2::NONRESIDUE^(((q^4) - 1) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047231"),
+                FQ_ZERO,
+            ),
+            // Fp2::NONRESIDUE^(((q^5) - 1) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047232"),
+                FQ_ZERO,
+            ),
+        ];
+        #[rustfmt::skip]
+        const FROBENIUS_COEFF_FP6_C2: &'static [Fq2] = &[
+            // Fp2::NONRESIDUE^((2*(q^0) - 2) / 3)
+            field_new!(Fq2, FQ_ONE, FQ_ZERO),
+            // Fp2::NONRESIDUE^((2*(q^1) - 2) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945"),
+                FQ_ZERO
+            ),
+            // Fp2::NONRESIDUE^((2*(q^2) - 2) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047231"),
+                FQ_ZERO,
+            ),
+            // Fp2::NONRESIDUE^((2*(q^3) - 2) / 3)
+            field_new!(Fq2, FQ_ONE, FQ_ZERO),
+            // Fp2::NONRESIDUE^((2*(q^4) - 2) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945"),
+                FQ_ZERO,
+            ),
+            // Fp2::NONRESIDUE^((2*(q^5) - 2) / 3)
+            field_new!(Fq2,
+                field_new!(Fq, "258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047231"),
+                FQ_ZERO,
+            ),
+        ];
+
+        #[inline(always)]
+        fn mul_fp2_by_nonresidue(fe: &Fq2) -> Fq2 {
+            // Karatsuba multiplication with constant other = u.
+            let c0 = Fq2Parameters::mul_fp_by_nonresidue(&fe.c1);
+            let c1 = fe.c0;
+            field_new!(Fq2, c0, c1)
+        }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR adds a Field::from_base_field_elements() method. This is useful for writing hashing to curve code that is general over the base field of the curve.

Furthermore, this PR also fixes a type safety issue with field extensions, where an extension fields basefield may not extend from the base prime field. (Needed for this PR to compile)

To test this, I've added an `fq2` and `fq6` to `test_fields`.

closes: #163 
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
