### PR TITLE
Add to_bytes to bigint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The main features of this release are:
     a default value.
   Downstream users other than `ark-curves` should not see breakage unless they rely on these methods/traits explicitly.
 - #165 (ark-ff) Add `from_base_field_elements` as a method to the `Field` trait.
+- #166 (ark-ff) Change `BigInt::{from_bytes, to_bits}` to `from_bytes_le, from_bytes_be, to_bits_le, to_bits_be`.
 
 ### Features
 - #20 (ark-poly) Add structs/traits for multivariate polynomials
@@ -69,7 +70,7 @@ The main features of this release are:
 - #153 (ark-serialize) Add an impl of `CanonicalSerialize/Deserialize` for `Rc<T>`.
 - #157 (ark-ec) Speed up `variable_base_msm` by not relying on unnecessary normalization.
 - #158 (ark-serialize) Add an impl of `CanonicalSerialize/Deserialize` for `()`.
-- #166 (ark-ff) Add a `to_bytes()` method to `BigInt`.
+- #166 (ark-ff) Add a `to_bytes_be()` and `to_bytes_le` methods to `BigInt`.
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The main features of this release are:
 - #153 (ark-serialize) Add an impl of `CanonicalSerialize/Deserialize` for `Rc<T>`.
 - #157 (ark-ec) Speed up `variable_base_msm` by not relying on unnecessary normalization.
 - #158 (ark-serialize) Add an impl of `CanonicalSerialize/Deserialize` for `()`.
+- #166 (ark-ff) Add a `to_bytes()` method to `BigInt`.
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/ec/src/msm/fixed_base.rs
+++ b/ec/src/msm/fixed_base.rs
@@ -65,7 +65,7 @@ impl FixedBaseMSM {
         scalar: &T::ScalarField,
     ) -> T {
         let modulus_size = <T::ScalarField as PrimeField>::Params::MODULUS_BITS as usize;
-        let mut scalar_val = scalar.into_repr().to_bits();
+        let mut scalar_val = scalar.into_repr().to_bits_be();
         scalar_val.reverse();
 
         let mut res = multiples_of_g[0][0].into_projective();

--- a/ec/src/msm/fixed_base.rs
+++ b/ec/src/msm/fixed_base.rs
@@ -65,8 +65,7 @@ impl FixedBaseMSM {
         scalar: &T::ScalarField,
     ) -> T {
         let modulus_size = <T::ScalarField as PrimeField>::Params::MODULUS_BITS as usize;
-        let mut scalar_val = scalar.into_repr().to_bits_be();
-        scalar_val.reverse();
+        let scalar_val = scalar.into_repr().to_bits_le();
 
         let mut res = multiples_of_g[0][0].into_projective();
         for outer in 0..outerc {

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -168,11 +168,7 @@ macro_rules! bigint_impl {
 
             #[inline]
             fn to_bits(&self) -> Vec<bool> {
-                let mut res = Vec::with_capacity($num_limbs * 64);
-                for b in BitIteratorBE::new(self.0) {
-                    res.push(b);
-                }
-                res
+                BigIteratorBE::new(self.0).collect::<Vec<_>>()
             }
 
             #[inline]

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -168,9 +168,28 @@ macro_rules! bigint_impl {
 
             #[inline]
             fn to_bits(&self) -> Vec<bool> {
-                let mut res = Vec::with_capacity(256);
+                let mut res = Vec::with_capacity($num_limbs * 64);
                 for b in BitIteratorBE::new(self.0) {
                     res.push(b);
+                }
+                res
+            }
+
+            #[inline]
+            fn to_bytes(&self) -> Vec<u8> {
+                let mut res = Vec::with_capacity($num_limbs * 8);
+                let mut cur_byte = 0u8;
+                let mut bit_num_mod_8 = 0;
+                for b in BitIteratorBE::new(self.0) {
+                    cur_byte = (cur_byte * 2) + (b as u8);
+                    bit_num_mod_8 = (bit_num_mod_8 + 1) % 8;
+                    if bit_num_mod_8 == 0 { 
+                        res.push(cur_byte);
+                        cur_byte = 0u8;
+                    }
+                }
+                if bit_num_mod_8 != 0 {
+                    res.push(cur_byte);
                 }
                 res
             }

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -170,7 +170,7 @@ macro_rules! bigint_impl {
                 let mut res = Self::default();
                 let mut acc: u64 = 0;
 
-                let mut bits = bits.to_vec();
+                let bits = bits.to_vec();
                 for (i, bits64) in bits.chunks(64).enumerate() {
                     for bit in bits64.iter().rev() {
                         acc <<= 1;

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -183,16 +183,6 @@ macro_rules! bigint_impl {
             }
 
             #[inline]
-            fn to_bits_be(&self) -> Vec<bool> {
-                BitIteratorBE::new(self.0).collect::<Vec<_>>()
-            }
-
-            #[inline]
-            fn to_bits_le(&self) -> Vec<bool> {
-                BitIteratorLE::new(self.0).collect::<Vec<_>>()
-            }
-
-            #[inline]
             fn to_bytes_be(&self) -> Vec<u8> {
                 let mut le_bytes = self.to_bytes_le();
                 le_bytes.reverse();

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -183,7 +183,7 @@ macro_rules! bigint_impl {
                 for b in BitIteratorBE::new(self.0) {
                     cur_byte = (cur_byte * 2) + (b as u8);
                     bit_num_mod_8 = (bit_num_mod_8 + 1) % 8;
-                    if bit_num_mod_8 == 0 { 
+                    if bit_num_mod_8 == 0 {
                         res.push(cur_byte);
                         cur_byte = 0u8;
                     }

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -149,7 +149,7 @@ macro_rules! bigint_impl {
             }
 
             #[inline]
-            fn from_bits(bits: &[bool]) -> Self {
+            fn from_bits_be(bits: &[bool]) -> Self {
                 let mut res = Self::default();
                 let mut acc: u64 = 0;
 
@@ -166,26 +166,45 @@ macro_rules! bigint_impl {
                 res
             }
 
-            #[inline]
-            fn to_bits(&self) -> Vec<bool> {
-                BigIteratorBE::new(self.0).collect::<Vec<_>>()
+            fn from_bits_le(bits: &[bool]) -> Self {
+                let mut res = Self::default();
+                let mut acc: u64 = 0;
+
+                let mut bits = bits.to_vec();
+                for (i, bits64) in bits.chunks(64).enumerate() {
+                    for bit in bits64.iter().rev() {
+                        acc <<= 1;
+                        acc += *bit as u64;
+                    }
+                    res.0[i] = acc;
+                    acc = 0;
+                }
+                res
             }
 
             #[inline]
-            fn to_bytes(&self) -> Vec<u8> {
-                let mut res = Vec::with_capacity($num_limbs * 8);
-                let mut cur_byte = 0u8;
-                let mut bit_num_mod_8 = 0;
-                for b in BitIteratorBE::new(self.0) {
-                    cur_byte = (cur_byte * 2) + (b as u8);
-                    bit_num_mod_8 = (bit_num_mod_8 + 1) % 8;
-                    if bit_num_mod_8 == 0 {
-                        res.push(cur_byte);
-                        cur_byte = 0u8;
-                    }
-                }
-                if bit_num_mod_8 != 0 {
-                    res.push(cur_byte);
+            fn to_bits_be(&self) -> Vec<bool> {
+                BitIteratorBE::new(self.0).collect::<Vec<_>>()
+            }
+
+            #[inline]
+            fn to_bits_le(&self) -> Vec<bool> {
+                BitIteratorLE::new(self.0).collect::<Vec<_>>()
+            }
+
+            #[inline]
+            fn to_bytes_be(&self) -> Vec<u8> {
+                let mut le_bytes = self.to_bytes_le();
+                le_bytes.reverse();
+                le_bytes
+            }
+
+            #[inline]
+            fn to_bytes_le(&self) -> Vec<u8> {
+                let array_map = self.0.iter().map(|limb| limb.to_le_bytes());
+                let mut res = Vec::<u8>::new();
+                for limb in array_map {
+                    res.extend_from_slice(&limb);
                 }
                 res
             }

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -118,8 +118,8 @@ pub trait BigInteger:
     /// with leading zeros.
     fn to_bytes_be(&self) -> Vec<u8>;
 
-    /// Returns the byte representation in a big endian byte array,
-    /// with leading zeros.
+    /// Returns the byte representation in a little endian byte array,
+    /// with trailing zeros.
     fn to_bytes_le(&self) -> Vec<u8>;
 
     /// Returns a vector for wnaf.

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -104,11 +104,15 @@ pub trait BigInteger:
 
     /// Returns the bit representation in a big endian boolean array,
     /// with leading zeroes.
-    fn to_bits_be(&self) -> Vec<bool>;
+    fn to_bits_be(&self) -> Vec<bool> {
+        BitIteratorBE::new(self).collect::<Vec<_>>()
+    }
 
     /// Returns the bit representation in a little endian boolean array,
     /// with trailing zeroes.
-    fn to_bits_le(&self) -> Vec<bool>;
+    fn to_bits_le(&self) -> Vec<bool> {
+        BitIteratorLE::new(self).collect::<Vec<_>>()
+    }
 
     /// Returns the byte representation in a big endian byte array,
     /// with leading zeros.

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bytes::{FromBytes, ToBytes},
-    fields::BitIteratorBE,
+    fields::{BitIteratorBE, BitIteratorLE},
     UniformRand,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
@@ -96,15 +96,27 @@ pub trait BigInteger:
 
     /// Returns the big integer representation of a given big endian boolean
     /// array.
-    fn from_bits(bits: &[bool]) -> Self;
+    fn from_bits_be(bits: &[bool]) -> Self;
+
+    /// Returns the big integer representation of a given little endian boolean
+    /// array.
+    fn from_bits_le(bits: &[bool]) -> Self;
 
     /// Returns the bit representation in a big endian boolean array,
     /// with leading zeroes.
-    fn to_bits(&self) -> Vec<bool>;
+    fn to_bits_be(&self) -> Vec<bool>;
+
+    /// Returns the bit representation in a little endian boolean array,
+    /// with trailing zeroes.
+    fn to_bits_le(&self) -> Vec<bool>;
 
     /// Returns the byte representation in a big endian byte array,
     /// with leading zeros.
-    fn to_bytes(&self) -> Vec<u8>;
+    fn to_bytes_be(&self) -> Vec<u8>;
+
+    /// Returns the byte representation in a big endian byte array,
+    /// with leading zeros.
+    fn to_bytes_le(&self) -> Vec<u8>;
 
     /// Returns a vector for wnaf.
     fn find_wnaf(&self) -> Vec<i64>;

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -98,12 +98,12 @@ pub trait BigInteger:
     /// array.
     fn from_bits(bits: &[bool]) -> Self;
 
-    /// Returns the bit representation in a big endian boolean array, without
-    /// leading zeros.
+    /// Returns the bit representation in a big endian boolean array,
+    /// with leading zeroes.
     fn to_bits(&self) -> Vec<bool>;
 
-    /// Returns the byte representation in a big endian byte array, without
-    /// leading zeros.
+    /// Returns the byte representation in a big endian byte array,
+    /// with leading zeros.
     fn to_bytes(&self) -> Vec<u8>;
 
     /// Returns a vector for wnaf.

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -102,6 +102,10 @@ pub trait BigInteger:
     /// leading zeros.
     fn to_bits(&self) -> Vec<bool>;
 
+    /// Returns the byte representation in a big endian byte array, without
+    /// leading zeros.
+    fn to_bytes(&self) -> Vec<u8>;
+
     /// Returns a vector for wnaf.
     fn find_wnaf(&self) -> Vec<i64>;
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds a simple `to_bytes` method to `bigint`. Currently there is `to_bits` and `write`, and `write` is a bit awkward to use if you're not concerned with efficiency of the serialization.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
