### PR TITLE
FFT parallelization threshold

### DIFF
--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -78,7 +78,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             let nchunks = xi.len() / (2 * gap);
             ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
-                ark_std::cfg_iter_mut!(lo)
+                ark_std::cfg_iter_mut!(lo, 1000)
                     .zip(hi)
                     .enumerate()
                     .for_each(|(idx, (lo, hi))| {
@@ -102,7 +102,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
 
             ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
-                ark_std::cfg_iter_mut!(lo)
+                ark_std::cfg_iter_mut!(lo, 1000)
                     .zip(hi)
                     .enumerate()
                     .for_each(|(idx, (lo, hi))| {

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -78,7 +78,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             let nchunks = xi.len() / (2 * gap);
             ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
-                ark_std::cfg_iter_mut!(lo, 1000)
+                ark_std::cfg_iter_mut!(lo, 1000) // threshold of 1000 was determined empirically
                     .zip(hi)
                     .enumerate()
                     .for_each(|(idx, (lo, hi))| {
@@ -102,7 +102,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
 
             ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
-                ark_std::cfg_iter_mut!(lo, 1000)
+                ark_std::cfg_iter_mut!(lo, 1000) // threshold of 1000 was determined empirically
                     .zip(hi)
                     .enumerate()
                     .for_each(|(idx, (lo, hi))| {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds a threshold when parallelizing FFTs. Currently the threshold is derived empirically; it gives speedups of between 15-30% compared to the non-threshold version.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
