### PR TITLE
Hardcode FFT inner loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The main features of this release are:
 - #158 (ark-serialize) Add an impl of `CanonicalSerialize/Deserialize` for `()`.
 - #166 (ark-ff) Add a `to_bytes_be()` and `to_bytes_le` methods to `BigInt`.
 - #169 (ark-poly) Improve radix-2 FFTs by moving to a faster algorithm by Riad S. Wahby.
+- #171, #173 (ark-poly) Apply further speedups to the new radix-2 FFT.
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/poly-benches/benches/fft.rs
+++ b/poly-benches/benches/fft.rs
@@ -14,7 +14,7 @@ use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 // degree bounds to benchmark on
 // e.g. degree bound of 2^{15}, means we do an FFT for a degree (2^{15} - 1) polynomial
 const BENCHMARK_MIN_DEGREE: usize = 1 << 15;
-const BENCHMARK_MAX_DEGREE: usize = 1 << 17;
+const BENCHMARK_MAX_DEGREE: usize = 1 << 22;
 const BENCHMARK_LOG_INTERVAL_DEGREE: usize = 1;
 
 const ENABLE_RADIX2_BENCHES: bool = true;

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -78,7 +78,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             let chunk_size = 2 * gap;
             let nchunks = xi.len() / chunk_size;
 
-            let inner_fn = |(idx, (lo, hi)): (usize, (&mut T, &mut T))| {
+            let butterfly_fn = |(idx, (lo, hi)): (usize, (&mut T, &mut T))| {
                 let neg = *lo - *hi;
                 *lo += *hi;
 
@@ -92,9 +92,9 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
                 if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION {
-                    cfg_iter_mut!(lo).zip(hi).enumerate().for_each(inner_fn);
+                    cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
                 } else {
-                    lo.iter_mut().zip(hi).enumerate().for_each(inner_fn);
+                    lo.iter_mut().zip(hi).enumerate().for_each(butterfly_fn);
                 }
             });
             gap /= 2;
@@ -109,7 +109,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             let chunk_size = 2 * gap;
             let nchunks = xi.len() / chunk_size;
 
-            let inner_fn = |(idx, (lo, hi)): (usize, (&mut T, &mut T))| {
+            let butterfly_fn = |(idx, (lo, hi)): (usize, (&mut T, &mut T))| {
                 *hi *= roots[nchunks * idx];
                 let neg = *lo - *hi;
                 *lo += *hi;
@@ -122,9 +122,9 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
                 if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION {
-                    cfg_iter_mut!(lo).zip(hi).enumerate().for_each(inner_fn);
+                    cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
                 } else {
-                    lo.iter_mut().zip(hi).enumerate().for_each(inner_fn);
+                    lo.iter_mut().zip(hi).enumerate().for_each(butterfly_fn);
                 }
             });
             gap *= 2;

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -86,11 +86,12 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 *hi *= roots[nchunks * idx];
             };
 
-            // If the gap is sufficiently big that parallelism helps,
-            // we parallelize computation of values in the gap.
-            // Notice that the core loops are the same in both cases
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
+                // If the chunk is sufficiently big that parallelism helps,
+                // we parallelize the butterfly operation within the chunk.
+                // 
+                // if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION
                 if gap > MIN_CHUNK_SIZE_FOR_PARALLELIZATION / 2 {
                     cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
                 } else {
@@ -116,11 +117,12 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 *hi = neg;
             };
 
-            // If the gap is sufficiently big that parallelism helps,
-            // we parallelize computation of values in the gap.
-            // Notice that the core loops are the same in both cases
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
+                // If the chunk is sufficiently big that parallelism helps,
+                // we parallelize the butterfly operation within the chunk.
+                // 
+                // if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION
                 if gap > MIN_CHUNK_SIZE_FOR_PARALLELIZATION / 2 {
                     cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
                 } else {

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -118,21 +118,42 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
         let roots = self.roots_of_unity(root);
 
         let mut gap = 1;
+        // This value was chosen empirically.
+        let min_gap_size_for_intra_gap_parallelization = 1024;
         while gap < xi.len() {
             let nchunks = xi.len() / (2 * gap);
 
-            ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
-                let (lo, hi) = cxi.split_at_mut(gap);
-                ark_std::cfg_iter_mut!(lo, 1000) // threshold of 1000 was determined empirically
-                    .zip(hi)
-                    .enumerate()
-                    .for_each(|(idx, (lo, hi))| {
-                        *hi *= roots[nchunks * idx];
-                        let neg = *lo - *hi;
-                        *lo += *hi;
-                        *hi = neg;
-                    });
-            });
+            // If the gap is sufficiently big that parallelism helps,
+            // we parallelize computation of values in the gap.
+            // Notice that the core loops are the same in both cases
+            if gap > min_gap_size_for_intra_gap_parallelization {
+                ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
+                    let (lo, hi) = cxi.split_at_mut(gap);
+                    ark_std::cfg_iter_mut!(lo)
+                        .zip(hi)
+                        .enumerate()
+                        .for_each(|(idx, (lo, hi))| {
+                            *hi *= roots[nchunks * idx];
+                            let neg = *lo - *hi;
+                            *lo += *hi;
+                            *hi = neg;
+                        });
+                });
+            }
+            else {
+                ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
+                    let (lo, hi) = cxi.split_at_mut(gap);
+                    lo.iter_mut()
+                        .zip(hi)
+                        .enumerate()
+                        .for_each(|(idx, (lo, hi))| {
+                            *hi *= roots[nchunks * idx];
+                            let neg = *lo - *hi;
+                            *lo += *hi;
+                            *hi = neg;
+                        });
+                });
+            }
             gap *= 2;
         }
     }

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -3,7 +3,7 @@
 
 use crate::domain::{radix2::*, DomainCoeff};
 use ark_ff::FftField;
-use ark_std::vec::Vec;
+use ark_std::{cfg_iter_mut, vec::Vec};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -91,10 +91,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
                 if gap > MIN_GAP_SIZE_FOR_PARALLELIZATION {
-                    ark_std::cfg_iter_mut!(lo)
-                        .zip(hi)
-                        .enumerate()
-                        .for_each(inner_fn);
+                    cfg_iter_mut!(lo).zip(hi).enumerate().for_each(inner_fn);
                 } else {
                     lo.iter_mut().zip(hi).enumerate().for_each(inner_fn);
                 }
@@ -123,10 +120,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
                 if gap > MIN_GAP_SIZE_FOR_PARALLELIZATION {
-                    ark_std::cfg_iter_mut!(lo)
-                        .zip(hi)
-                        .enumerate()
-                        .for_each(inner_fn);
+                    cfg_iter_mut!(lo).zip(hi).enumerate().for_each(inner_fn);
                 } else {
                     lo.iter_mut().zip(hi).enumerate().for_each(inner_fn);
                 }

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -75,7 +75,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
         let mut gap = xi.len() / 2;
         while gap > 0 {
             // each butterfly cluster uses 2*gap positions
-            let chunk_size = 2*gap;
+            let chunk_size = 2 * gap;
             let nchunks = xi.len() / chunk_size;
 
             let inner_fn = |(idx, (lo, hi)): (usize, (&mut T, &mut T))| {
@@ -106,7 +106,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
 
         let mut gap = 1;
         while gap < xi.len() {
-            let chunk_size = 2*gap;
+            let chunk_size = 2 * gap;
             let nchunks = xi.len() / chunk_size;
 
             let inner_fn = |(idx, (lo, hi)): (usize, (&mut T, &mut T))| {

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -91,7 +91,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             // Notice that the core loops are the same in both cases
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
-                if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION {
+                if gap > MIN_CHUNK_SIZE_FOR_PARALLELIZATION / 2 {
                     cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
                 } else {
                     lo.iter_mut().zip(hi).enumerate().for_each(butterfly_fn);
@@ -121,7 +121,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             // Notice that the core loops are the same in both cases
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
-                if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION {
+                if gap > MIN_CHUNK_SIZE_FOR_PARALLELIZATION / 2 {
                     cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
                 } else {
                     lo.iter_mut().zip(hi).enumerate().for_each(butterfly_fn);

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -90,7 +90,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                         .for_each(|(idx, (lo, hi))| {
                             let neg = *lo - *hi;
                             *lo += *hi;
-    
+
                             *hi = neg;
                             *hi *= roots[nchunks * idx];
                         });
@@ -104,7 +104,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                         .for_each(|(idx, (lo, hi))| {
                             let neg = *lo - *hi;
                             *lo += *hi;
-    
+
                             *hi = neg;
                             *hi *= roots[nchunks * idx];
                         });
@@ -139,8 +139,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                             *hi = neg;
                         });
                 });
-            }
-            else {
+            } else {
                 ark_std::cfg_chunks_mut!(xi, 2 * gap).for_each(|cxi| {
                     let (lo, hi) = cxi.split_at_mut(gap);
                     lo.iter_mut()

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -90,7 +90,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 let (lo, hi) = cxi.split_at_mut(gap);
                 // If the chunk is sufficiently big that parallelism helps,
                 // we parallelize the butterfly operation within the chunk.
-                // 
+                //
                 // if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION
                 if gap > MIN_CHUNK_SIZE_FOR_PARALLELIZATION / 2 {
                     cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
@@ -121,7 +121,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 let (lo, hi) = cxi.split_at_mut(gap);
                 // If the chunk is sufficiently big that parallelism helps,
                 // we parallelize the butterfly operation within the chunk.
-                // 
+                //
                 // if chunk_size > MIN_CHUNK_SIZE_FOR_PARALLELIZATION
                 if gap > MIN_CHUNK_SIZE_FOR_PARALLELIZATION / 2 {
                     cfg_iter_mut!(lo).zip(hi).enumerate().for_each(butterfly_fn);
@@ -136,7 +136,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
 
 // This value controls that when doing a butterfly on a chunk of size c,
 // do you parallelize operations on the chunk.
-// If c > MIN_GAP_SIZE_FOR_PARALLELIZATION,
+// If c > MIN_CHUNK_SIZE_FOR_PARALLELIZATION,
 // then parallelize, else be sequential.
 // This value was chosen empirically.
 const MIN_CHUNK_SIZE_FOR_PARALLELIZATION: usize = 2048;

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -56,7 +56,8 @@ pub(crate) fn compute_powers<F: Field>(size: usize, value: F) -> Vec<F> {
 #[cfg(feature = "parallel")]
 fn compute_powers_recursive<F: Field>(out: &mut [F], log_powers: &[F]) {
     assert_eq!(out.len(), 1 << log_powers.len());
-    // base case: just compute the powers sequentially
+    // base case: just compute the powers sequentially,
+    // g = log_powers[0], out = [1, g, g^2, ...]
     if log_powers.len() <= LOG_PARALLEL_SIZE as usize {
         out[0] = F::one();
         for idx in 1..out.len() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This hardcodes the inner loop to not use parallelism, which does in fact yield better speeds. Below is a summary of the speed difference this PR made on a fresh, 16 core, 32 GB RAM, CPU-optimized Digital Ocean server.

The summary of the speed differences is that at all sizes where the data vector fit into RAM (tested from log_degree = 15 to log_degree=20), this change improved speed by ~10%. 

When the polynomial size was bigger (tested from log_degree = 21, 22), this change improved speed by 5-6%.
At polynomial sizes of log_degree = 23,24,25, speed improved by 8%.

As the FFT is in the critical path, I believe we ought to go with this approach here.

closes: #172 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
