### PR TITLE
Switch to panic='abort' for safety across FFI boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,5 +86,6 @@ The main features of this release are:
      whose leading coefficients cancel.
 - #160 (ark-serialize, ark-ff, ark-ec) Support serializing when `MODULUS_BITS + FLAG_BITS` is greater than the multiple of 8 just greater than `MODULUS_BITS`, which is the case for the Pasta curves (fixes #47).
 - #165 (ark-ff) Enforce in the type system that an extension fields `BaseField` extends from the correct `BasePrimeField`.
+- #184 Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
 opt-level = 3
 lto = "thin"
 incremental = true
+panic = 'abort'
 
 [profile.bench]
 opt-level = 3
@@ -30,6 +31,7 @@ debug-assertions = false
 
 [profile.dev]
 opt-level = 0
+panic = 'abort'
 
 [profile.test]
 opt-level = 3


### PR DESCRIPTION
Thanks to @daira for pointing out the security impact, and @jon-chuang for raising the issue / pointing out perf improvements.

This still needs to be done in downstream repositories, as this change only applies to the top level crate.

closes: #183
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests - n/a?
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
