### PR TITLE
Fix assembly backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,17 @@ jobs:
                    --exclude ark-poly-benches \
                    --exclude ark-test-templates"
 
+      - name: Test assembly on nightly
+        env:
+          RUSTFLAGS: -C target-feature=+bmi2,+adx
+        uses: actions-rs/cargo@v1
+        with:
+            command: test
+            args: "--workspace \
+                   --package ark-test-curves \
+                   --all-features"
+        if: matrix.rust == 'nightly'
+
   check_no_std:
     name: Check no_std
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Test assembly on nightly
         env:
-          RUSTFLAGS: -C target-feature=+bmi2,+adx
+          RUSTFLAGS: -C target-cpu=native
         uses: actions-rs/cargo@v1
         with:
             command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The main features of this release are:
 - Some speedups to `sqrt`
 - Small speedups to MSMs
 - Big speedups to radix-2 FFTs
+- Fix in the assembly arithmetic backend
 
 ### Breaking changes
 - #20 (ark-poly) Move univariate DensePolynomial and SparsePolynomial into a 
@@ -88,5 +89,6 @@ The main features of this release are:
 - #160 (ark-serialize, ark-ff, ark-ec) Support serializing when `MODULUS_BITS + FLAG_BITS` is greater than the multiple of 8 just greater than `MODULUS_BITS`, which is the case for the Pasta curves (fixes #47).
 - #165 (ark-ff) Enforce in the type system that an extension fields `BaseField` extends from the correct `BasePrimeField`.
 - #184 Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
+- #192 Fix a bug in the assembly backend for finite field arithmetic.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/ff-asm/src/lib.rs
+++ b/ff-asm/src/lib.rs
@@ -87,7 +87,7 @@ pub fn x86_64_asm_mul(input: TokenStream) -> TokenStream {
 
         let inner_ts: Expr = syn::parse_str(&impl_block).unwrap();
         let ts = quote::quote! {
-            let mut a = #a;
+            let a = &mut #a;
             let b = #b;
             #inner_ts
         };
@@ -138,7 +138,7 @@ pub fn x86_64_asm_square(input: TokenStream) -> TokenStream {
 
         let inner_ts: Expr = syn::parse_str(&impl_block).unwrap();
         let ts = quote::quote! {
-            let mut a = #a;
+            let a = &mut #a;
             #inner_ts
         };
         ts.into()
@@ -288,7 +288,7 @@ fn generate_llvm_asm_mul_string(
 
 fn generate_impl(num_limbs: usize, is_mul: bool) -> String {
     let mut ctx = Context::new();
-    ctx.add_declaration("a", "r", "&mut a");
+    ctx.add_declaration("a", "r", "a");
     if is_mul {
         ctx.add_declaration("b", "r", "&b");
     }

--- a/ff-asm/src/lib.rs
+++ b/ff-asm/src/lib.rs
@@ -87,7 +87,7 @@ pub fn x86_64_asm_mul(input: TokenStream) -> TokenStream {
 
         let inner_ts: Expr = syn::parse_str(&impl_block).unwrap();
         let ts = quote::quote! {
-            let a = &mut #a;
+            let mut a = #a;
             let b = #b;
             #inner_ts
         };
@@ -138,7 +138,7 @@ pub fn x86_64_asm_square(input: TokenStream) -> TokenStream {
 
         let inner_ts: Expr = syn::parse_str(&impl_block).unwrap();
         let ts = quote::quote! {
-            let a = &mut #a;
+            let mut a = #a;
             #inner_ts
         };
         ts.into()
@@ -288,7 +288,7 @@ fn generate_llvm_asm_mul_string(
 
 fn generate_impl(num_limbs: usize, is_mul: bool) -> String {
     let mut ctx = Context::new();
-    ctx.add_declaration("a", "r", "a");
+    ctx.add_declaration("a", "r", "&mut a");
     if is_mul {
         ctx.add_declaration("b", "r", "&b");
     }

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -23,6 +23,8 @@ rand_xorshift = "0.2"
 [features]
 default = []
 
+asm = [ "ark-ff/asm" ]
+
 parallel = [ "ark-ff/parallel", "ark-ec/parallel", "ark-std/parallel" ]
 
 bls12_381_scalar_field = []


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fix assembly backend to actually reduce the result of squaring/multiplication. Depending on the available CI runner, also runs tests with the assembly backend.

The bug arises because the assembly backend (before this PR) did something like the following:
```rust
fn square_in_place(&mut self) {
	let mut a = (self.0).0; // `a` is a *copy* of the data in `self`.
	// do assembly stuff with `a`
	// this is where the bug arose: all assembly operations happened on `a`, 
	// but we didn't write the result back to `self`.
}
```
In this PR, we fix the above code so that operations do indeed happen *in* place.
```rust
fn square_in_place(&mut self) {
	let a = &mut (self.0).0; // Now `a` is a mutable reference to the contents of `self`.
	// do assembly stuff with `a`
}
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
