### PR TITLE
Unroll loops and use in-place ops for faster `ff` and `ec` arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,9 @@ The main features of this release are:
 - #166 (ark-ff) Add a `to_bytes_be()` and `to_bytes_le` methods to `BigInt`.
 - #169 (ark-poly) Improve radix-2 FFTs by moving to a faster algorithm by Riad S. Wahby.
 - #171, #173, #176 (ark-poly) Apply significant further speedups to the new radix-2 FFT.
-- #188 (ark-ec) Make Short Weierstrass random sampling result in an element with unknown discrete log
+- #188 (ark-ec) Make Short Weierstrass random sampling result in an element with unknown discrete log.
 - #190 (ark-ec) Add curve cycle trait and extended pairing cycle trait for all types of ec cycles.
+- #199 (ark-ff, ark-ec) Unroll some loops in biginteger arithmetic, and prefer in-place operations in field and curve arithmetic.
 - #201 (ark-ec, ark-ff, ark-test-curves, ark-test-templates) Remove the dependency on `rand_xorshift`
 
 ### Bug fixes

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -260,7 +260,6 @@ impl<P: Parameters> Default for GroupAffine<P> {
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
-    Eq(bound = "P: Parameters"),
     Debug(bound = "P: Parameters"),
     Hash(bound = "P: Parameters")
 )]
@@ -279,6 +278,7 @@ impl<P: Parameters> Display for GroupProjective<P> {
     }
 }
 
+impl<P: Parameters> Eq for GroupProjective<P> {}
 impl<P: Parameters> PartialEq for GroupProjective<P> {
     fn eq(&self, other: &Self) -> bool {
         if self.is_zero() {
@@ -581,10 +581,9 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
     type Output = Self;
 
     #[inline]
-    fn add(self, other: &'a Self) -> Self {
-        let mut copy = self;
-        copy += other;
-        copy
+    fn add(mut self, other: &'a Self) -> Self {
+        self += other;
+        self
     }
 }
 
@@ -657,10 +656,9 @@ impl<'a, P: Parameters> Sub<&'a Self> for GroupProjective<P> {
     type Output = Self;
 
     #[inline]
-    fn sub(self, other: &'a Self) -> Self {
-        let mut copy = self;
-        copy -= other;
-        copy
+    fn sub(mut self, other: &'a Self) -> Self {
+        self -= other;
+        self
     }
 }
 

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -121,8 +121,15 @@ impl<P: Parameters> GroupAffine<P> {
             true
         } else {
             // Check that the point is on the curve
-            let y2 = self.y.square();
-            let x3b = P::add_b(&((self.x.square() * &self.x) + &P::mul_by_a(&self.x)));
+            // y2 = y^2
+            let mut y2 = self.y;
+            y2.square_in_place();
+            // x3b = x^3 + Ax + b
+            let mut x3b = self.x;
+            x3b.square_in_place();
+            x3b *= &self.x;
+            x3b += P::mul_by_a(&self.x);
+            x3b = P::add_b(&x3b);
             y2 == x3b
         }
     }
@@ -292,13 +299,22 @@ impl<P: Parameters> PartialEq for GroupProjective<P> {
         // The points (X, Y, Z) and (X', Y', Z')
         // are equal when (X * Z^2) = (X' * Z'^2)
         // and (Y * Z^3) = (Y' * Z'^3).
-        let z1z1 = self.z.square();
-        let z2z2 = other.z.square();
+        let mut z1z1 = self.z;
+        z1z1.square_in_place();
+        let mut z2z2 = other.z;
+        z2z2.square_in_place();
 
         if self.x * &z2z2 != other.x * &z1z1 {
             false
         } else {
-            self.y * &(z2z2 * &other.z) == other.y * &(z1z1 * &self.z)
+            let mut lhs = self.y;
+            lhs *= z2z2;
+            lhs *= &other.z;
+            let mut rhs = other.y;
+            rhs *= z1z1;
+            rhs *= &self.z;
+
+            lhs == rhs
         }
     }
 }
@@ -430,63 +446,98 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
 
         if P::COEFF_A.is_zero() {
             // A = X1^2
-            let mut a = self.x.square();
+            let mut a = self.x;
+            a.square_in_place();
 
             // B = Y1^2
-            let b = self.y.square();
+            let mut b = self.y;
+            b.square_in_place();
 
             // C = B^2
-            let mut c = b.square();
+            let mut c = b;
+            c.square_in_place();
 
             // D = 2*((X1+B)2-A-C)
-            let d = ((self.x + &b).square() - &a - &c).double();
+            let mut d = self.x;
+            d += &b;
+            d.square_in_place();
+            d -= &a;
+            d -= &c;
+            d.double_in_place();
 
             // E = 3*A
-            let e = a + &*a.double_in_place();
+            let mut e = a;
+            e += &*a.double_in_place();
 
             // F = E^2
-            let f = e.square();
+            let mut f = e;
+            f.square_in_place();
 
             // Z3 = 2*Y1*Z1
             self.z *= &self.y;
             self.z.double_in_place();
 
             // X3 = F-2*D
-            self.x = f - &d - &d;
+            self.x = -d;
+            self.x.double_in_place();
+            self.x += f;
 
             // Y3 = E*(D-X3)-8*C
-            self.y = (d - &self.x) * &e - &*c.double_in_place().double_in_place().double_in_place();
+            self.y = d;
+            self.y -= &self.x;
+            self.y *= e;
+            self.y -= &*c.double_in_place().double_in_place().double_in_place();
             self
         } else {
             // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l
             // XX = X1^2
-            let xx = self.x.square();
+            let mut xx = self.x;
+            xx.square_in_place();
 
             // YY = Y1^2
-            let yy = self.y.square();
+            let mut yy = self.y;
+            yy.square_in_place();
 
             // YYYY = YY^2
-            let mut yyyy = yy.square();
+            let mut yyyy = yy;
+            yyyy.square_in_place();
 
             // ZZ = Z1^2
-            let zz = self.z.square();
+            let mut zz = self.z;
+            zz.square_in_place();
 
             // S = 2*((X1+YY)^2-XX-YYYY)
-            let s = ((self.x + &yy).square() - &xx - &yyyy).double();
+            let mut s = self.x;
+            s += &yy;
+            s.square_in_place();
+            s -= &xx;
+            s -= &yyyy;
+            s.double_in_place();
 
             // M = 3*XX+a*ZZ^2
-            let m = xx + &xx + &xx + &P::mul_by_a(&zz.square());
+            let mut m = xx;
+            m.double_in_place();
+            m += xx;
+            m += &P::mul_by_a(&zz.square());
 
             // T = M^2-2*S
-            let t = m.square() - &s.double();
+            let mut t = m;
+            t.square_in_place();
+            t -= &s.double();
 
             // X3 = T
             self.x = t;
-            // Y3 = M*(S-T)-8*YYYY
-            let old_y = self.y;
-            self.y = m * &(s - &t) - &*yyyy.double_in_place().double_in_place().double_in_place();
             // Z3 = (Y1+Z1)^2-YY-ZZ
-            self.z = (old_y + &self.z).square() - &yy - &zz;
+            self.z += &self.y;
+            self.z.square_in_place();
+            self.z -= &yy;
+            self.z -= &zz;
+            // Y3 = M*(S-T)-8*YYYY
+            self.y = s;
+            self.y -= &t;
+            self.y *= m;
+            self.y -= &*yyyy.double_in_place().double_in_place().double_in_place();
+
             self
         }
     }
@@ -507,13 +558,17 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         // Works for all curves.
 
         // Z1Z1 = Z1^2
-        let z1z1 = self.z.square();
+        let mut z1z1 = self.z;
+        z1z1.square_in_place();
 
         // U2 = X2*Z1Z1
-        let u2 = other.x * &z1z1;
+        let mut u2 = other.x;
+        u2 *= &z1z1;
 
         // S2 = Y2*Z1*Z1Z1
-        let s2 = (other.y * &self.z) * &z1z1;
+        let mut s2 = other.y;
+        s2 *= &self.z;
+        s2 *= &z1z1;
 
         if self.x == u2 && self.y == s2 {
             // The two points are equal, so we double.
@@ -522,26 +577,33 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
             // If we're adding -a and a together, self.z becomes zero as H becomes zero.
 
             // H = U2-X1
-            let h = u2 - &self.x;
+            let mut h = u2;
+            h -= &self.x;
 
             // HH = H^2
-            let hh = h.square();
+            let mut hh = h;
+            hh.square_in_place();
 
             // I = 4*HH
             let mut i = hh;
             i.double_in_place().double_in_place();
 
             // J = H*I
-            let mut j = h * &i;
+            let mut j = h;
+            j *= &i;
 
             // r = 2*(S2-Y1)
-            let r = (s2 - &self.y).double();
+            let mut r = s2;
+            r -= &self.y;
+            r.double_in_place();
 
             // V = X1*I
-            let v = self.x * &i;
+            let mut v = self.x;
+            v *= &i;
 
             // X3 = r^2 - J - 2*V
-            self.x = r.square();
+            self.x = r;
+            self.x.square_in_place();
             self.x -= &j;
             self.x -= &v;
             self.x -= &v;
@@ -549,7 +611,8 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
             // Y3 = r*(V-X3)-2*Y1*J
             j *= &self.y; // J = 2*Y1*J
             j.double_in_place();
-            self.y = v - &self.x;
+            self.y = v;
+            self.y -= &self.x;
             self.y *= &r;
             self.y -= &j;
 
@@ -602,22 +665,30 @@ impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
         // Works for all curves.
 
         // Z1Z1 = Z1^2
-        let z1z1 = self.z.square();
+        let mut z1z1 = self.z;
+        z1z1.square_in_place();
 
         // Z2Z2 = Z2^2
-        let z2z2 = other.z.square();
+        let mut z2z2 = other.z;
+        z2z2.square_in_place();
 
         // U1 = X1*Z2Z2
-        let u1 = self.x * &z2z2;
+        let mut u1 = self.x;
+        u1 *= &z2z2;
 
         // U2 = X2*Z1Z1
-        let u2 = other.x * &z1z1;
+        let mut u2 = other.x;
+        u2 *= &z1z1;
 
         // S1 = Y1*Z2*Z2Z2
-        let s1 = self.y * &other.z * &z2z2;
+        let mut s1 = self.y;
+        s1 *= &other.z;
+        s1 *= &z2z2;
 
         // S2 = Y2*Z1*Z1Z1
-        let s2 = other.y * &self.z * &z1z1;
+        let mut s2 = other.y;
+        s2 *= &self.z;
+        s2 *= &z1z1;
 
         if u1 == u2 && s1 == s2 {
             // The two points are equal, so we double.
@@ -626,28 +697,45 @@ impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
             // If we're adding -a and a together, self.z becomes zero as H becomes zero.
 
             // H = U2-U1
-            let h = u2 - &u1;
+            let mut h = u2;
+            h -= &u1;
 
             // I = (2*H)^2
-            let i = (h.double()).square();
+            let mut i = h;
+            i.double_in_place();
+            i.square_in_place();
 
             // J = H*I
-            let j = h * &i;
+            let mut j = h;
+            j *= &i;
 
             // r = 2*(S2-S1)
-            let r = (s2 - &s1).double();
+            let mut r = s2;
+            r -= &s1;
+            r.double_in_place();
 
             // V = U1*I
-            let v = u1 * &i;
+            let mut v = u1;
+            v *= &i;
 
             // X3 = r^2 - J - 2*V
-            self.x = r.square() - &j - &(v.double());
+            self.x = r;
+            self.x.square_in_place();
+            self.x -= &j;
+            self.x -= &v.double();
 
             // Y3 = r*(V - X3) - 2*S1*J
-            self.y = r * &(v - &self.x) - &*(s1 * &j).double_in_place();
+            self.y = v;
+            self.y -= &self.x;
+            self.y *= r;
+            self.y -= &*(s1 * &j).double_in_place();
 
             // Z3 = ((Z1+Z2)^2 - Z1Z1 - Z2Z2)*H
-            self.z = ((self.z + &other.z).square() - &z1z1 - &z2z2) * &h;
+            self.z += &other.z;
+            self.z.square_in_place();
+            self.z -= z1z1;
+            self.z -= z2z2;
+            self.z *= &h;
         }
     }
 }
@@ -700,13 +788,17 @@ impl<P: Parameters> From<GroupProjective<P>> for GroupAffine<P> {
         } else {
             // Z is nonzero, so it must have an inverse in a field.
             let zinv = p.z.inverse().unwrap();
-            let zinv_squared = zinv.square();
+            let mut zinv_squared = zinv;
+            zinv_squared.square_in_place();
 
             // X/Z^2
-            let x = p.x * &zinv_squared;
+            let mut x = p.x;
+            x *= &zinv_squared;
 
             // Y/Z^3
-            let y = p.y * &(zinv_squared * &zinv);
+            let mut y = p.y;
+            y *= zinv_squared;
+            y *= zinv;
 
             GroupAffine::new(x, y, false)
         }

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -544,63 +544,64 @@ ark_ff::impl_additive_ops_from_ref!(GroupProjective, Parameters);
 
 impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
     type Output = Self;
-    fn add(self, other: &'a Self) -> Self {
-        let mut copy = self;
-        copy += other;
-        copy
+    fn add(mut self, other: &'a Self) -> Self {
+        self += other;
+        self
     }
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
     fn add_assign(&mut self, other: &'a Self) {
-        // See "Twisted Edwards Curves Revisited" (https://eprint.iacr.org/2008/522.pdf)
-        // by Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson
+        // See "Twisted Edwards Curves Revisited"
+        // Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson
         // 3.1 Unified Addition in E^e
+        // Source: https://www.hyperelliptic.org/EFD/g1p/data/twisted/extended/addition/madd-2008-hwcd
 
-        // A = x1 * x2
-        let a = self.x * &other.x;
+        // A = X1*X2
+        let mut a = self.x;
+        a *= &other.x;
+        // B = Y1*Y2
+        let mut b = self.y;
+        b *= &other.y;
+        // C = T1*d*T2
+        let mut c = P::COEFF_D;
+        c *= &self.t;
+        c *= &other.t;
 
-        // B = y1 * y2
-        let b = self.y * &other.y;
+        // D = Z1 * Z2
+        let mut d = self.z;
+        d *= other.z;
 
-        // C = d * t1 * t2
-        let c = P::COEFF_D * &self.t * &other.t;
-
-        // D = z1 * z2
-        let d = self.z * &other.z;
-
-        // H = B - aA
-        let h = b - &P::mul_by_a(&a);
-
-        // E = (x1 + y1) * (x2 + y2) - A - B
-        let e = (self.x + &self.y) * &(other.x + &other.y) - &a - &b;
-
-        // F = D - C
+        // E = (X1+Y1)*(X2+Y2)-A-B
+        let mut e = (self.x + &self.y) * &(other.x + &other.y);
+        e -= &a;
+        e -= &b;
+        // F = D-C
         let f = d - &c;
-
-        // G = D + C
+        // G = D+C
         let g = d + &c;
-
-        // x3 = E * F
-        self.x = e * &f;
-
-        // y3 = G * H
-        self.y = g * &h;
-
-        // t3 = E * H
-        self.t = e * &h;
-
-        // z3 = F * G
-        self.z = f * &g;
+        // H = B-a*A
+        let h = b - &P::mul_by_a(&a);
+        // X3 = E*F
+        self.x = e;
+        self.x *= &f;
+        // Y3 = G*H
+        self.y = g;
+        self.y *= &h;
+        // T3 = E*H
+        self.t = e;
+        self.t *= &h;
+        // Z3 = F*G
+        self.z = f;
+        self.z *= &g;
     }
 }
 
 impl<'a, P: Parameters> Sub<&'a Self> for GroupProjective<P> {
     type Output = Self;
-    fn sub(self, other: &'a Self) -> Self {
-        let mut copy = self;
-        copy -= other;
-        copy
+    fn sub(mut self, other: &'a Self) -> Self {
+        self -= other;
+        self
     }
 }
 

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -470,15 +470,22 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         // Source: https://www.hyperelliptic.org/EFD/g1p/data/twisted/extended/doubling/dbl-2008-hwcd
 
         // A = X1^2
-        let a = self.x.square();
+        let mut a = self.x;
+        a.square_in_place();
         // B = Y1^2
-        let b = self.y.square();
+        let mut b = self.y;
+        b.square_in_place();
         // C = 2 * Z1^2
-        let c = self.z.square().double();
+        let mut c = self.z;
+        c.square_in_place();
+        c.double_in_place();
         // D = a * A
         let d = P::mul_by_a(&a);
         // E = (X1 + Y1)^2 - A - B
-        let e = (self.x + &self.y).square() - &a - &b;
+        let mut e = self.x + &self.y;
+        e.square_in_place();
+        e -= &a;
+        e -= &b;
         // G = D + B
         let g = d + &b;
         // F = G - C
@@ -504,30 +511,39 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         // Source: https://www.hyperelliptic.org/EFD/g1p/data/twisted/extended/addition/madd-2008-hwcd
 
         // A = X1*X2
-        let a = self.x * &other.x;
+        let mut a = self.x;
+        a *= &other.x;
         // B = Y1*Y2
-        let b = self.y * &other.y;
+        let mut b = self.y;
+        b *= &other.y;
         // C = T1*d*T2
-        let c = P::COEFF_D * &self.t * &other.x * &other.y;
+        let mut c = P::COEFF_D;
+        c *= &self.t;
+        c *= &other.x;
+        c *= &other.y;
 
-        // D = Z1
-        let d = self.z;
         // E = (X1+Y1)*(X2+Y2)-A-B
-        let e = (self.x + &self.y) * &(other.x + &other.y) - &a - &b;
+        let mut e = (self.x + &self.y) * &(other.x + &other.y);
+        e -= &a;
+        e -= &b;
         // F = D-C
-        let f = d - &c;
+        let f = self.z - &c;
         // G = D+C
-        let g = d + &c;
+        let g = self.z + &c;
         // H = B-a*A
         let h = b - &P::mul_by_a(&a);
         // X3 = E*F
-        self.x = e * &f;
+        self.x = e;
+        self.x *= &f;
         // Y3 = G*H
-        self.y = g * &h;
+        self.y = g;
+        self.y *= &h;
         // T3 = E*H
-        self.t = e * &h;
+        self.t = e;
+        self.t *= &h;
         // Z3 = F*G
-        self.z = f * &g;
+        self.z = f;
+        self.z *= &g;
     }
 }
 

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -104,7 +104,6 @@ macro_rules! impl_field_square_in_place {
                 let _no_carry: bool = !(first_bit_set || all_bits_set);
 
                 if $limbs <= 6 && _no_carry {
-                    assert!($limbs <= 6);
                     ark_ff_asm::x86_64_asm_square!($limbs, (self.0).0);
                     self.reduce();
                     return self;

--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -233,7 +233,7 @@ macro_rules! impl_Fp {
         }
 
         impl<P: $FpParameters> $Fp<P> {
-            #[inline]
+            #[inline(always)]
             pub(crate) fn is_valid(&self) -> bool {
                 self.0 < P::MODULUS
             }
@@ -605,7 +605,7 @@ macro_rules! impl_Fp {
             #[must_use]
             fn neg(self) -> Self {
                 if !self.is_zero() {
-                    let mut tmp = P::MODULUS.clone();
+                    let mut tmp = P::MODULUS;
                     tmp.sub_noborrow(&self.0);
                     $Fp::<P>(tmp, PhantomData)
                 } else {
@@ -618,10 +618,9 @@ macro_rules! impl_Fp {
             type Output = Self;
 
             #[inline]
-            fn add(self, other: &Self) -> Self {
-                let mut result = self.clone();
-                result.add_assign(other);
-                result
+            fn add(mut self, other: &Self) -> Self {
+                self.add_assign(other);
+                self
             }
         }
 
@@ -629,10 +628,9 @@ macro_rules! impl_Fp {
             type Output = Self;
 
             #[inline]
-            fn sub(self, other: &Self) -> Self {
-                let mut result = self.clone();
-                result.sub_assign(other);
-                result
+            fn sub(mut self, other: &Self) -> Self {
+                self.sub_assign(other);
+                self
             }
         }
 
@@ -640,10 +638,9 @@ macro_rules! impl_Fp {
             type Output = Self;
 
             #[inline]
-            fn mul(self, other: &Self) -> Self {
-                let mut result = self.clone();
-                result.mul_assign(other);
-                result
+            fn mul(mut self, other: &Self) -> Self {
+                self.mul_assign(other);
+                self
             }
         }
 
@@ -651,10 +648,9 @@ macro_rules! impl_Fp {
             type Output = Self;
 
             #[inline]
-            fn div(self, other: &Self) -> Self {
-                let mut result = self.clone();
-                result.mul_assign(&other.inverse().unwrap());
-                result
+            fn div(mut self, other: &Self) -> Self {
+                self.mul_assign(&other.inverse().unwrap());
+                self
             }
         }
 

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -372,8 +372,11 @@ impl<P: CubicExtParameters> FromBytes for CubicExtField<P> {
 impl<P: CubicExtParameters> Neg for CubicExtField<P> {
     type Output = Self;
     #[inline]
-    fn neg(self) -> Self {
-        Self::new(self.c0.neg(), self.c1.neg(), self.c2.neg())
+    fn neg(mut self) -> Self {
+        self.c0 = -self.c0;
+        self.c1 = -self.c1;
+        self.c2 = -self.c2;
+        self
     }
 }
 
@@ -392,10 +395,9 @@ impl<'a, P: CubicExtParameters> Add<&'a CubicExtField<P>> for CubicExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn add(self, other: &Self) -> Self {
-        let mut result = self;
-        result.add_assign(other);
-        result
+    fn add(mut self, other: &Self) -> Self {
+        self.add_assign(other);
+        self
     }
 }
 
@@ -403,10 +405,9 @@ impl<'a, P: CubicExtParameters> Sub<&'a CubicExtField<P>> for CubicExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn sub(self, other: &Self) -> Self {
-        let mut result = self;
-        result.sub_assign(other);
-        result
+    fn sub(mut self, other: &Self) -> Self {
+        self.sub_assign(other);
+        self
     }
 }
 
@@ -414,10 +415,9 @@ impl<'a, P: CubicExtParameters> Mul<&'a CubicExtField<P>> for CubicExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn mul(self, other: &Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
-        result
+    fn mul(mut self, other: &Self) -> Self {
+        self.mul_assign(other);
+        self
     }
 }
 
@@ -425,10 +425,9 @@ impl<'a, P: CubicExtParameters> Div<&'a CubicExtField<P>> for CubicExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn div(self, other: &Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other.inverse().unwrap());
-        result
+    fn div(mut self, other: &Self) -> Self {
+        self.mul_assign(&other.inverse().unwrap());
+        self
     }
 }
 

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -204,13 +204,18 @@ impl<P: CubicExtParameters> Field for CubicExtField<P> {
         let b = self.c1;
         let c = self.c2;
 
-        let s0 = a.square();
+        let mut s0 = a;
+        s0.square_in_place();
         let ab = a * &b;
-        let s1 = ab.double();
-        let s2 = (a - &b + &c).square();
+        let mut s1 = ab;
+        s1.double_in_place();
+        let mut s2 = a - &b + &c;
+        s2.square_in_place();
         let bc = b * &c;
-        let s3 = bc.double();
-        let s4 = c.square();
+        let mut s3 = bc;
+        s3.double_in_place();
+        let mut s4 = c;
+        s4.square_in_place();
 
         self.c0 = s0 + &P::mul_base_field_by_nonresidue(&s3);
         self.c1 = s1 + &P::mul_base_field_by_nonresidue(&s4);
@@ -225,21 +230,33 @@ impl<P: CubicExtParameters> Field for CubicExtField<P> {
             // From "High-Speed Software Implementation of the Optimal Ate AbstractPairing
             // over
             // Barreto-Naehrig Curves"; Algorithm 17
-            let t0 = self.c0.square();
-            let t1 = self.c1.square();
-            let t2 = self.c2.square();
-            let t3 = self.c0 * &self.c1;
-            let t4 = self.c0 * &self.c2;
-            let t5 = self.c1 * &self.c2;
+            let mut t0 = self.c0;
+            t0.square_in_place();
+            let mut t1 = self.c1;
+            t1.square_in_place();
+            let mut t2 = self.c2;
+            t2.square_in_place();
+            let mut t3 = self.c0;
+            t3 *= &self.c1;
+            let mut t4 = self.c0;
+            t4 *= &self.c2;
+            let mut t5 = self.c1;
+            t5 *= &self.c2;
             let n5 = P::mul_base_field_by_nonresidue(&t5);
 
-            let s0 = t0 - &n5;
-            let s1 = P::mul_base_field_by_nonresidue(&t2) - &t3;
-            let s2 = t1 - &t4; // typo in paper referenced above. should be "-" as per Scott, but is "*"
+            let mut s0 = t0;
+            s0 -= &n5;
+            let mut s1 = P::mul_base_field_by_nonresidue(&t2);
+            s1 -= &t3;
+            let mut s2 = t1;
+            s2 -= &t4; // typo in paper referenced above. should be "-" as per Scott, but is "*"
 
-            let a1 = self.c2 * &s1;
-            let a2 = self.c1 * &s2;
-            let mut a3 = a1 + &a2;
+            let mut a1 = self.c2;
+            a1 *= &s1;
+            let mut a2 = self.c1;
+            a2 *= &s2;
+            let mut a3 = a1;
+            a3 += &a2;
             a3 = P::mul_base_field_by_nonresidue(&a3);
             let t6 = (self.c0 * &s0 + &a3).inverse().unwrap();
 
@@ -467,16 +484,39 @@ impl<'a, P: CubicExtParameters> MulAssign<&'a Self> for CubicExtField<P> {
         let e = self.c1;
         let f = self.c2;
 
-        let ad = d * &a;
-        let be = e * &b;
-        let cf = f * &c;
+        let mut ad = d;
+        ad *= &a;
+        let mut be = e;
+        be *= &b;
+        let mut cf = f;
+        cf *= &c;
 
-        let x = (e + &f) * &(b + &c) - &be - &cf;
-        let y = (d + &e) * &(a + &b) - &ad - &be;
-        let z = (d + &f) * &(a + &c) - &ad + &be - &cf;
+        // x = (e + f) * (b + c) - be - cf;
+        let mut x = e;
+        x += &f;
+        x *= &(b + &c);
+        x -= &be;
+        x -= &cf;
 
-        self.c0 = ad + &P::mul_base_field_by_nonresidue(&x);
-        self.c1 = y + &P::mul_base_field_by_nonresidue(&cf);
+        // y = (d + e) * (a + b) - ad - be;
+        let mut y = d;
+        y += &e;
+        y *= &(a + &b);
+        y -= &ad;
+        y -= &be;
+
+        // z = (d + f) * (a + c) - ad + be - cf;
+        let mut z = d;
+        z += &f;
+        z *= &(a + &c);
+        z -= &ad;
+        z += &be;
+        z -= &cf;
+
+        self.c0 = ad;
+        self.c0 += &P::mul_base_field_by_nonresidue(&x);
+        self.c1 = y;
+        self.c1 += &P::mul_base_field_by_nonresidue(&cf);
         self.c2 = z;
     }
 }

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -49,7 +49,9 @@ pub trait QuadExtParameters: 'static + Send + Sync + Sized {
     /// and in complex squaring.
     #[inline(always)]
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {
-        Self::NONRESIDUE * fe
+        let mut result = Self::NONRESIDUE;
+        result *= fe;
+        result
     }
 
     /// A specializable method for multiplying an element of the base field by
@@ -68,7 +70,7 @@ pub trait QuadExtParameters: 'static + Send + Sync + Sized {
 
         for &value in naf.iter().rev() {
             if found_nonzero {
-                res = res.square();
+                res.square_in_place();
             }
 
             if value != 0 {
@@ -420,8 +422,10 @@ impl<P: QuadExtParameters> Neg for QuadExtField<P> {
     type Output = Self;
     #[inline]
     #[must_use]
-    fn neg(self) -> Self {
-        Self::new(-self.c0, -self.c1)
+    fn neg(mut self) -> Self {
+        self.c0 = -self.c0;
+        self.c1 = -self.c1;
+        self
     }
 }
 
@@ -436,10 +440,9 @@ impl<'a, P: QuadExtParameters> Add<&'a QuadExtField<P>> for QuadExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn add(self, other: &Self) -> Self {
-        let mut result = self;
-        result.add_assign(other);
-        result
+    fn add(mut self, other: &Self) -> Self {
+        self.add_assign(other);
+        self
     }
 }
 
@@ -447,10 +450,9 @@ impl<'a, P: QuadExtParameters> Sub<&'a QuadExtField<P>> for QuadExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn sub(self, other: &Self) -> Self {
-        let mut result = self;
-        result.sub_assign(other);
-        result
+    fn sub(mut self, other: &Self) -> Self {
+        self.sub_assign(other);
+        self
     }
 }
 
@@ -458,10 +460,9 @@ impl<'a, P: QuadExtParameters> Mul<&'a QuadExtField<P>> for QuadExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn mul(self, other: &Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
-        result
+    fn mul(mut self, other: &Self) -> Self {
+        self.mul_assign(other);
+        self
     }
 }
 
@@ -469,26 +470,25 @@ impl<'a, P: QuadExtParameters> Div<&'a QuadExtField<P>> for QuadExtField<P> {
     type Output = Self;
 
     #[inline]
-    fn div(self, other: &Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other.inverse().unwrap());
-        result
+    fn div(mut self, other: &Self) -> Self {
+        self.mul_assign(&other.inverse().unwrap());
+        self
     }
 }
 
 impl<'a, P: QuadExtParameters> AddAssign<&'a Self> for QuadExtField<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
-        self.c0.add_assign(&other.c0);
-        self.c1.add_assign(&other.c1);
+        self.c0 += &other.c0;
+        self.c1 += &other.c1;
     }
 }
 
 impl<'a, P: QuadExtParameters> SubAssign<&'a Self> for QuadExtField<P> {
     #[inline]
     fn sub_assign(&mut self, other: &Self) {
-        self.c0.sub_assign(&other.c0);
-        self.c1.sub_assign(&other.c1);
+        self.c0 -= &other.c0;
+        self.c1 -= &other.c1;
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* *BigInteger*: unroll loops in `add_nocarry`, `sub_noborrow`, `mul2`, `div2`, and `cmp`
* **SW** & **TE**: use in-place ops in mixed addition and doubling
* Extension fields: use in-place ops in mul and square

Overall, these changes provide a ~10% speedup to the relevant ops.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
