### PR TITLE
Replace `rand` with `ark_std::rand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The main features of this release are:
 - #171, #173, #176 (ark-poly) Apply significant further speedups to the new radix-2 FFT.
 - #188 (ark-ec) Make Short Weierstrass random sampling result in an element with unknown discrete log
 - #190 (ark-ec) Add curve cycle trait and extended pairing cycle trait for all types of ec cycles.
+- #201 (ark-ec, ark-ff, ark-test-curves, ark-test-templates) Remove the dependency on `rand_xorshift`
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -18,12 +18,8 @@ ark-serialize = { path = "../serialize", default-features = false }
 ark-ff = { path = "../ff", default-features = false }
 derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
-rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
-
-[dev-dependencies]
-rand_xorshift = "0.2"
 
 [features]
 default = []

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -21,7 +21,7 @@ use crate::{models::SWModelParameters as Parameters, AffineCurve, ProjectiveCurv
 use num_traits::{One, Zero};
 use zeroize::Zeroize;
 
-use rand::{
+use ark_std::rand::{
     distributions::{Distribution, Standard},
     Rng,
 };

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -14,7 +14,7 @@ use ark_std::{
     vec::Vec,
 };
 use num_traits::{One, Zero};
-use rand::{
+use ark_std::rand::{
     distributions::{Distribution, Standard},
     Rng,
 };

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -6,6 +6,10 @@ use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, EdwardsFlags, SerializationError,
 };
+use ark_std::rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use ark_std::{
     fmt::{Display, Formatter, Result as FmtResult},
     io::{Read, Result as IoResult, Write},
@@ -14,10 +18,6 @@ use ark_std::{
     vec::Vec,
 };
 use num_traits::{One, Zero};
-use ark_std::rand::{
-    distributions::{Distribution, Standard},
-    Rng,
-};
 use zeroize::Zeroize;
 
 use ark_ff::{

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -20,7 +20,6 @@ ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = fal
 ark-serialize = { path = "../serialize", default-features = false }
 derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
-rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
@@ -28,7 +27,6 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 rustc_version = "0.3"
 
 [dev-dependencies]
-rand_xorshift = "0.2"
 num-bigint = { version = "0.3.0", default-features = false }
 
 [features]

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -4,14 +4,14 @@ use crate::{
     UniformRand,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use ark_std::{
     fmt::{Debug, Display},
     io::{Read, Result as IoResult, Write},
     vec::Vec,
-};
-use ark_std::rand::{
-    distributions::{Distribution, Standard},
-    Rng,
 };
 use zeroize::Zeroize;
 

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -9,7 +9,7 @@ use ark_std::{
     io::{Read, Result as IoResult, Write},
     vec::Vec,
 };
-use rand::{
+use ark_std::rand::{
     distributions::{Distribution, Standard},
     Rng,
 };

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -1,6 +1,4 @@
 use crate::{biginteger::BigInteger, UniformRand};
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 
 fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
     // zero == zero
@@ -51,7 +49,7 @@ fn biginteger_bits_test<B: BigInteger>() {
 
 fn biginteger_bytes_test<B: BigInteger>() {
     let mut bytes = [0u8; 256];
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     let x: B = UniformRand::rand(&mut rng);
     x.write(bytes.as_mut()).unwrap();
     let y = B::read(bytes.as_ref()).unwrap();
@@ -59,7 +57,7 @@ fn biginteger_bytes_test<B: BigInteger>() {
 }
 
 fn test_biginteger<B: BigInteger>(zero: B) {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     let a: B = UniformRand::rand(&mut rng);
     let b: B = UniformRand::rand(&mut rng);
     biginteger_arithmetic_test(a, b, zero);

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -198,7 +198,10 @@ macro_rules! impl_prime_field_standard_sample {
             #[inline]
             fn sample<R: ark_std::rand::Rng + ?Sized>(&self, rng: &mut R) -> $field<P> {
                 loop {
-                    let mut tmp = $field(rng.sample(ark_std::rand::distributions::Standard), PhantomData);
+                    let mut tmp = $field(
+                        rng.sample(ark_std::rand::distributions::Standard),
+                        PhantomData,
+                    );
                     // Mask away the unused bits at the beginning.
                     tmp.0
                         .as_mut()

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -192,13 +192,13 @@ macro_rules! impl_field_bigint_conv {
 
 macro_rules! impl_prime_field_standard_sample {
     ($field: ident, $params: ident) => {
-        impl<P: $params> rand::distributions::Distribution<$field<P>>
-            for rand::distributions::Standard
+        impl<P: $params> ark_std::rand::distributions::Distribution<$field<P>>
+            for ark_std::rand::distributions::Standard
         {
             #[inline]
-            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $field<P> {
+            fn sample<R: ark_std::rand::Rng + ?Sized>(&self, rng: &mut R) -> $field<P> {
                 loop {
-                    let mut tmp = $field(rng.sample(rand::distributions::Standard), PhantomData);
+                    let mut tmp = $field(rng.sample(ark_std::rand::distributions::Standard), PhantomData);
                     // Mask away the unused bits at the beginning.
                     tmp.0
                         .as_mut()

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -659,7 +659,7 @@ mod no_std_tests {
         // TODO: Eventually generate all the test vector bytes via computation with the modulus
         use ark_std::string::ToString;
         use num_bigint::BigUint;
-        use rand::Rng;
+        use ark_std::rand::Rng;
 
         let ref_modulus =
             BigUint::from_bytes_be(&<Fr as PrimeField>::Params::MODULUS.to_bytes_be());

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -657,9 +657,9 @@ mod no_std_tests {
         // and its tested by parsing it with from_bytes_mod_order, and the num-bigint library.
         // The bytes are currently generated from scripts/test_vectors.py.
         // TODO: Eventually generate all the test vector bytes via computation with the modulus
+        use ark_std::rand::Rng;
         use ark_std::string::ToString;
         use num_bigint::BigUint;
-        use ark_std::rand::Rng;
 
         let ref_modulus =
             BigUint::from_bytes_be(&<Fr as PrimeField>::Params::MODULUS.to_bytes_be());

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -14,7 +14,7 @@ use ark_std::{
 use num_traits::{One, Zero};
 use zeroize::Zeroize;
 
-use rand::{
+use ark_std::rand::{
     distributions::{Distribution, Standard},
     Rng,
 };

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -14,7 +14,7 @@ use ark_std::{
 use num_traits::{One, Zero};
 use zeroize::Zeroize;
 
-use rand::{
+use ark_std::rand::{
     distributions::{Distribution, Standard},
     Rng,
 };

--- a/ff/src/rand.rs
+++ b/ff/src/rand.rs
@@ -3,13 +3,13 @@
     note = "please use `ark_std::{UniformRand, test_rng}` instead of ark_ff::{UniformRand, test_rng}"
 )]
 /// Should be used only for tests, not for any real world usage.
-pub fn test_rng() -> rand::rngs::StdRng {
-    use rand::SeedableRng;
+pub fn test_rng() -> ark_std::rand::rngs::StdRng {
+    use ark_std::rand::SeedableRng;
 
     // arbitrary seed
     let seed = [
         1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0,
     ];
-    rand::rngs::StdRng::from_seed(seed)
+    ark_std::rand::rngs::StdRng::from_seed(seed)
 }

--- a/poly-benches/Cargo.toml
+++ b/poly-benches/Cargo.toml
@@ -14,7 +14,6 @@ ark-poly = { path = "../poly" }
 ark-std = {  git = "https://github.com/arkworks-rs/utils", default-features = false }
 ark-test-curves = { path = "../test-curves", default-features = false, features = [ "bls12_381_scalar_field", "mnt4_753_curve" ] }
 criterion = "0.3.1"
-rand = "0.7"
 rayon = { version = "1", optional = true }
 
 [features]

--- a/poly-benches/benches/dense_uv_polynomial.rs
+++ b/poly-benches/benches/dense_uv_polynomial.rs
@@ -1,5 +1,3 @@
-use rand;
-
 extern crate criterion;
 
 use ark_ff::Field;

--- a/poly-benches/benches/dense_uv_polynomial.rs
+++ b/poly-benches/benches/dense_uv_polynomial.rs
@@ -39,7 +39,7 @@ fn setup_bench<F: Field>(c: &mut Criterion, name: &str, bench_fn: fn(&mut Benche
 
 fn bench_poly_evaluate<F: Field>(b: &mut Bencher, degree: &usize) {
     // Per benchmark setup
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let poly = DensePolynomial::<F>::rand(*degree, &mut rng);
     b.iter(|| {
         // Per benchmark iteration
@@ -50,7 +50,7 @@ fn bench_poly_evaluate<F: Field>(b: &mut Bencher, degree: &usize) {
 
 fn bench_poly_add<F: Field>(b: &mut Bencher, degree: &usize) {
     // Per benchmark setup
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let poly_one = DensePolynomial::<F>::rand(*degree, &mut rng);
     let poly_two = DensePolynomial::<F>::rand(*degree, &mut rng);
     b.iter(|| {
@@ -61,7 +61,7 @@ fn bench_poly_add<F: Field>(b: &mut Bencher, degree: &usize) {
 
 fn bench_poly_add_assign<F: Field>(b: &mut Bencher, degree: &usize) {
     // Per benchmark setup
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let mut poly_one = DensePolynomial::<F>::rand(*degree, &mut rng);
     let poly_two = DensePolynomial::<F>::rand(*degree, &mut rng);
     b.iter(|| {

--- a/poly-benches/benches/fft.rs
+++ b/poly-benches/benches/fft.rs
@@ -1,4 +1,4 @@
-use rand;
+use ark_std::rand;
 
 extern crate criterion;
 

--- a/poly-benches/benches/fft.rs
+++ b/poly-benches/benches/fft.rs
@@ -1,5 +1,3 @@
-use ark_std::rand;
-
 extern crate criterion;
 
 use ark_ff::FftField;

--- a/poly-benches/benches/fft.rs
+++ b/poly-benches/benches/fft.rs
@@ -41,7 +41,7 @@ fn setup_bench(c: &mut Criterion, name: &str, bench_fn: fn(&mut Bencher, &usize)
 }
 
 fn fft_common_setup<F: FftField, D: EvaluationDomain<F>>(degree: usize) -> (D, Vec<F>) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let domain = D::new(degree).unwrap();
     let a = DensePolynomial::<F>::rand(degree - 1, &mut rng)
         .coeffs()

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -16,10 +16,9 @@ edition = "2018"
 ark-ff = { path = "../ff", default-features = false }
 ark-serialize = { path = "../serialize", default-features = false, features = ["derive"] }
 ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = false }
-rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
 derivative = { version = "2", default-features = false, features = [ "use_core" ] }
-hashbrown = {version = "0.9.1"}
+hashbrown = { version = "0.9.1"}
 
 [dev-dependencies]
 ark-test-curves = { path = "../test-curves", default-features = false, features = [ "bls12_381_curve", "bn384_small_two_adicity_curve"] }

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -266,7 +266,7 @@ mod tests {
     use ark_std::test_rng;
     use ark_test_curves::bls12_381::Fr;
     use ark_test_curves::bn384_small_two_adicity::Fr as BNFr;
-    use rand::Rng;
+    use ark_std::rand::Rng;
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -263,10 +263,10 @@ mod tests {
     use crate::polynomial::Polynomial;
     use crate::{EvaluationDomain, GeneralEvaluationDomain};
     use ark_ff::Zero;
+    use ark_std::rand::Rng;
     use ark_std::test_rng;
     use ark_test_curves::bls12_381::Fr;
     use ark_test_curves::bn384_small_two_adicity::Fr as BNFr;
-    use ark_std::rand::Rng;
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -410,7 +410,7 @@ mod tests {
     use ark_ff::{Field, Zero};
     use ark_std::test_rng;
     use ark_test_curves::bn384_small_two_adicity::Fq as Fr;
-    use rand::Rng;
+    use ark_std::rand::Rng;
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -408,9 +408,9 @@ mod tests {
     use crate::polynomial::Polynomial;
     use crate::{EvaluationDomain, MixedRadixEvaluationDomain};
     use ark_ff::{Field, Zero};
+    use ark_std::rand::Rng;
     use ark_std::test_rng;
     use ark_test_curves::bn384_small_two_adicity::Fq as Fr;
-    use ark_std::rand::Rng;
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -10,7 +10,7 @@
 use ark_ff::FftField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{fmt, hash, vec::Vec};
-use rand::Rng;
+use ark_std::rand::Rng;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -9,8 +9,8 @@
 
 use ark_ff::FftField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::{fmt, hash, vec::Vec};
 use ark_std::rand::Rng;
+use ark_std::{fmt, hash, vec::Vec};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -214,9 +214,9 @@ mod tests {
     use crate::polynomial::{univariate::*, Polynomial, UVPolynomial};
     use crate::{EvaluationDomain, Radix2EvaluationDomain};
     use ark_ff::{FftField, Field, One, UniformRand, Zero};
+    use ark_std::rand::Rng;
     use ark_std::test_rng;
     use ark_test_curves::bls12_381::Fr;
-    use ark_std::rand::Rng;
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -216,7 +216,7 @@ mod tests {
     use ark_ff::{FftField, Field, One, UniformRand, Zero};
     use ark_std::test_rng;
     use ark_test_curves::bls12_381::Fr;
-    use rand::Rng;
+    use ark_std::rand::Rng;
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -6,9 +6,9 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, Serializatio
 use ark_std::fmt;
 use ark_std::fmt::Formatter;
 use ark_std::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
+use ark_std::rand::Rng;
 use ark_std::slice::{Iter, IterMut};
 use ark_std::vec::Vec;
-use ark_std::rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -8,7 +8,7 @@ use ark_std::fmt::Formatter;
 use ark_std::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 use ark_std::slice::{Iter, IterMut};
 use ark_std::vec::Vec;
-use rand::Rng;
+use ark_std::rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/poly/src/evaluations/multivariate/multilinear/mod.rs
+++ b/poly/src/evaluations/multivariate/multilinear/mod.rs
@@ -12,7 +12,7 @@ use ark_std::vec::Vec;
 use ark_ff::{Field, Zero};
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use rand::Rng;
+use ark_std::rand::Rng;
 
 /// This trait describes an interface for the multilinear extension
 /// of an array.

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -11,7 +11,7 @@ use ark_std::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
 use ark_std::vec::Vec;
 use ark_std::{fmt, UniformRand};
 use hashbrown::HashMap;
-use rand::Rng;
+use ark_std::rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -8,10 +8,10 @@ use ark_std::collections::BTreeMap;
 use ark_std::fmt::{Debug, Formatter};
 use ark_std::iter::FromIterator;
 use ark_std::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
+use ark_std::rand::Rng;
 use ark_std::vec::Vec;
 use ark_std::{fmt, UniformRand};
 use hashbrown::HashMap;
-use ark_std::rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/poly/src/polynomial/mod.rs
+++ b/poly/src/polynomial/mod.rs
@@ -1,13 +1,13 @@
 //! Modules for working with univariate or multivariate polynomials.
 use ark_ff::{Field, Zero};
 use ark_serialize::*;
+use ark_std::rand::Rng;
 use ark_std::{
     fmt::Debug,
     hash::Hash,
     ops::{Add, AddAssign, Neg, SubAssign},
     vec::Vec,
 };
-use ark_std::rand::Rng;
 
 pub mod multivariate;
 pub mod univariate;

--- a/poly/src/polynomial/mod.rs
+++ b/poly/src/polynomial/mod.rs
@@ -7,7 +7,7 @@ use ark_std::{
     ops::{Add, AddAssign, Neg, SubAssign},
     vec::Vec,
 };
-use rand::Rng;
+use ark_std::rand::Rng;
 
 pub mod multivariate;
 pub mod univariate;

--- a/poly/src/polynomial/multivariate/sparse.rs
+++ b/poly/src/polynomial/multivariate/sparse.rs
@@ -12,7 +12,7 @@ use ark_std::{
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
-use rand::Rng;
+use ark_std::rand::Rng;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/poly/src/polynomial/multivariate/sparse.rs
+++ b/poly/src/polynomial/multivariate/sparse.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use ark_ff::{Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::rand::Rng;
 use ark_std::{
     cmp::Ordering,
     fmt,
@@ -12,7 +13,6 @@ use ark_std::{
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
-use ark_std::rand::Rng;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -10,7 +10,7 @@ use ark_std::{
 };
 
 use ark_ff::{FftField, Field, Zero};
-use rand::Rng;
+use ark_std::rand::Rng;
 
 #[cfg(feature = "parallel")]
 use ark_std::cmp::max;

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -280,7 +280,7 @@ mod tests {
     use ark_std::ops::Mul;
     use ark_std::test_rng;
     use ark_test_curves::bls12_381::Fr;
-    use rand::Rng;
+    use ark_std::rand::Rng;
 
     // probability of rand sparse polynomial having a particular coefficient be 0
     const ZERO_COEFF_PROBABILITY: f64 = 0.8f64;

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -278,9 +278,9 @@ mod tests {
     use ark_ff::{UniformRand, Zero};
     use ark_std::cmp::max;
     use ark_std::ops::Mul;
+    use ark_std::rand::Rng;
     use ark_std::test_rng;
     use ark_test_curves::bls12_381::Fr;
-    use ark_std::rand::Rng;
 
     // probability of rand sparse polynomial having a particular coefficient be 0
     const ZERO_COEFF_PROBABILITY: f64 = 0.8f64;

--- a/poly/src/test.rs
+++ b/poly/src/test.rs
@@ -11,7 +11,7 @@ fn fft_composition() {
     fn test_fft_composition<
         F: PrimeField,
         T: DomainCoeff<F> + UniformRand + core::fmt::Debug + Eq,
-        R: rand::Rng,
+        R: ark_std::rand::Rng,
         D: EvaluationDomain<F>,
     >(
         rng: &mut R,

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -16,9 +16,6 @@ edition = "2018"
 ark-serialize-derive = { path = "../serialize-derive", optional = true }
 ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = false }
 
-[dev-dependencies]
-rand = { version = "0.7", default-features = false }
-
 [features]
 default = []
 std = [ "ark-std/std" ]

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -815,8 +815,8 @@ impl<T: CanonicalDeserialize + Ord> CanonicalDeserialize for BTreeSet<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ark_std::vec;
     use ark_std::rand::RngCore;
+    use ark_std::vec;
 
     #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
     struct Dummy;

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -816,7 +816,7 @@ impl<T: CanonicalDeserialize + Ord> CanonicalDeserialize for BTreeSet<T> {
 mod test {
     use super::*;
     use ark_std::vec;
-    use rand::{RngCore, SeedableRng};
+    use ark_std::rand::RngCore;
 
     #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
     struct Dummy;
@@ -909,13 +909,7 @@ mod test {
         data: T,
         valid_mutation: fn(&[u8]) -> bool,
     ) {
-        // Seed copied from StdRng tests,
-        // https://rust-random.github.io/rand/src/rand/rngs/std.rs.html#87
-        let seed = [
-            1, 0, 0, 0, 23, 0, 0, 0, 200, 1, 0, 0, 210, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0,
-        ];
-        let mut r = rand::rngs::StdRng::from_seed(seed);
+        let mut r = ark_std::test_rng();
         let mut serialized = vec![0; data.serialized_size()];
         r.fill_bytes(&mut serialized);
         while !valid_mutation(&serialized) {

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -16,9 +16,6 @@ ark-ec = { path = "../ec", default-features = false }
 [dev-dependencies]
 ark-serialize = { path = "../serialize", default-features = false }
 ark-algebra-test-templates = { path = "../test-templates", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
-
 
 [features]
 default = []

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -1,17 +1,16 @@
 #![allow(unused_imports)]
 use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{One, UniformRand, Zero};
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
 
 use crate::bls12_381::{g1, Fq, FqParameters, Fr, G1Affine, G1Projective};
 use ark_algebra_test_templates::{curves::*, fields::*, groups::*};
+use ark_std::rand::Rng;
 
 pub(crate) const ITERATIONS: usize = 5;
 
 #[test]
 fn test_fr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let a: Fr = UniformRand::rand(&mut rng);
         let b: Fr = UniformRand::rand(&mut rng);
@@ -23,7 +22,7 @@ fn test_fr() {
 
 #[test]
 fn test_fq() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let a: Fq = UniformRand::rand(&mut rng);
         let b: Fq = UniformRand::rand(&mut rng);

--- a/test-curves/src/bn384_small_two_adicity/tests.rs
+++ b/test-curves/src/bn384_small_two_adicity/tests.rs
@@ -1,8 +1,7 @@
 #![allow(unused_imports)]
 use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{One, UniformRand, Zero};
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use ark_std::rand::Rng;
 
 use crate::bn384_small_two_adicity::{g1, Fq, FqParameters, Fr, G1Affine, G1Projective};
 use ark_algebra_test_templates::{curves::*, fields::*, groups::*};
@@ -11,7 +10,7 @@ pub(crate) const ITERATIONS: usize = 5;
 
 #[test]
 fn test_fr() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let a: Fr = UniformRand::rand(&mut rng);
         let b: Fr = UniformRand::rand(&mut rng);
@@ -23,7 +22,7 @@ fn test_fr() {
 
 #[test]
 fn test_fq() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     for _ in 0..ITERATIONS {
         let a: Fq = UniformRand::rand(&mut rng);
         let b: Fq = UniformRand::rand(&mut rng);

--- a/test-templates/Cargo.toml
+++ b/test-templates/Cargo.toml
@@ -17,8 +17,6 @@ ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = fal
 ark-serialize = { path = "../serialize", default-features = false }
 ark-ff = { path = "../ff", default-features = false }
 ark-ec = { path = "../ec", default-features = false }
-rand = { version = "0.7", default-features = false}
-rand_xorshift = { version = "0.2", default-features = false}
 
 [features]
 default = []

--- a/test-templates/src/curves.rs
+++ b/test-templates/src/curves.rs
@@ -5,13 +5,11 @@ use ark_ec::{
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SWFlags, SerializationError};
 use ark_std::{io::Cursor, vec::Vec};
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 
 pub const ITERATIONS: usize = 10;
 
 fn random_addition_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = G::rand(&mut rng);
@@ -90,7 +88,7 @@ fn random_addition_test<G: ProjectiveCurve>() {
 }
 
 fn random_multiplication_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let mut a = G::rand(&mut rng);
@@ -122,7 +120,7 @@ fn random_multiplication_test<G: ProjectiveCurve>() {
 }
 
 fn random_doubling_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let mut a = G::rand(&mut rng);
@@ -149,7 +147,7 @@ fn random_doubling_test<G: ProjectiveCurve>() {
 }
 
 fn random_negation_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let r = G::rand(&mut rng);
@@ -178,7 +176,7 @@ fn random_negation_test<G: ProjectiveCurve>() {
 }
 
 fn random_transformation_test<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let g = G::rand(&mut rng);
@@ -193,7 +191,7 @@ fn random_transformation_test<G: ProjectiveCurve>() {
             .map(|_| G::rand(&mut rng).double())
             .collect::<Vec<_>>();
 
-        use rand::distributions::{Distribution, Uniform};
+        use ark_std::rand::distributions::{Distribution, Uniform};
         let between = Uniform::from(0..ITERATIONS);
         // Sprinkle in some normalized points
         for _ in 0..5 {
@@ -219,7 +217,7 @@ fn random_transformation_test<G: ProjectiveCurve>() {
 }
 
 pub fn curve_tests<G: ProjectiveCurve>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     // Negation edge case with zero.
     {
@@ -296,7 +294,7 @@ pub fn sw_from_random_bytes<P: SWModelParameters>() {
 
     let buf_size = GroupAffine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = GroupProjective::<P>::rand(&mut rng);
@@ -319,7 +317,7 @@ pub fn sw_curve_serialization_test<P: SWModelParameters>() {
 
     let buf_size = GroupAffine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = GroupProjective::<P>::rand(&mut rng);
@@ -431,7 +429,7 @@ where
 
     let buf_size = GroupAffine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = GroupProjective::<P>::rand(&mut rng);
@@ -466,7 +464,7 @@ pub fn edwards_curve_serialization_test<P: TEModelParameters>() {
 
     let buf_size = GroupAffine::<P>::zero().serialized_size();
 
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = GroupProjective::<P>::rand(&mut rng);

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -2,8 +2,7 @@
 use ark_ff::fields::{FftField, FftParameters, Field, LegendreSymbol, PrimeField, SquareRootField};
 use ark_serialize::{buffer_bit_byte_size, Flags, SWFlags};
 use ark_std::io::Cursor;
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
+use ark_std::rand::Rng;
 
 pub const ITERATIONS: u32 = 40;
 
@@ -154,7 +153,7 @@ fn random_expansion_tests<F: Field, R: Rng>(rng: &mut R) {
 }
 
 fn random_field_tests<F: Field>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     random_negation_tests::<F, _>(&mut rng);
     random_addition_tests::<F, _>(&mut rng);
@@ -189,7 +188,7 @@ fn random_field_tests<F: Field>() {
 }
 
 fn random_sqrt_tests<F: SquareRootField>() {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = F::rand(&mut rng);
@@ -219,7 +218,7 @@ fn random_sqrt_tests<F: SquareRootField>() {
 
 pub fn from_str_test<F: PrimeField>() {
     {
-        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+        let mut rng = ark_std::test_rng();
 
         for _ in 0..ITERATIONS {
             let n: u64 = rng.gen();
@@ -357,7 +356,7 @@ pub fn sqrt_field_test<F: SquareRootField>(elem: F) {
 }
 
 pub fn frobenius_test<F: Field, C: AsRef<[u64]>>(characteristic: C, maxpower: usize) {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = F::rand(&mut rng);
@@ -378,7 +377,7 @@ pub fn frobenius_test<F: Field, C: AsRef<[u64]>>(characteristic: C, maxpower: us
 }
 
 pub fn field_serialization_test<F: Field>(buf_size: usize) {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
 
     for _ in 0..ITERATIONS {
         let a = F::rand(&mut rng);

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -1,11 +1,9 @@
 #![allow(unused)]
 use ark_ec::group::Group;
 use ark_ff::{One, UniformRand, Zero};
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 
 pub fn group_test<G: Group>(a: G, mut b: G) {
-    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+    let mut rng = ark_std::test_rng();
     let zero = G::zero();
     let fr_zero = G::ScalarField::zero();
     let fr_one = G::ScalarField::one();

--- a/test-templates/src/msm.rs
+++ b/test-templates/src/msm.rs
@@ -1,7 +1,5 @@
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{PrimeField, UniformRand, Zero};
-use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
 
 fn naive_var_base_msm<G: AffineCurve>(
     bases: &[G],
@@ -18,7 +16,7 @@ fn naive_var_base_msm<G: AffineCurve>(
 pub fn test_var_base_msm<G: AffineCurve>() {
     const SAMPLES: usize = 1 << 10;
 
-    let mut rng = XorShiftRng::seed_from_u64(234872845u64);
+    let mut rng = ark_std::test_rng();
 
     let v = (0..SAMPLES - 1)
         .map(|_| G::ScalarField::rand(&mut rng).into_repr())


### PR DESCRIPTION
## Description

This PR replaces all the use of `rand` with `ark_std::rand`.

In addition, `XorShiftRng` is likely outdated and should be replaced by `ark_std::test_rng`. This PR also makes this change.

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
