### PR TITLE
Generalised version of improved fp2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The main features of this release are:
 - #190 (ark-ec) Add curve cycle trait and extended pairing cycle trait for all types of ec cycles.
 - #201 (ark-ec, ark-ff, ark-test-curves, ark-test-templates) Remove the dependency on `rand_xorshift`
 - #205 (ark-ec, ark-ff) Unroll loops and conditionally use intrinsics in `biginteger` arithmetic, and reduce copies in `ff` and `ec` arithmetic.
+- #207 (ark-ff) Improve performance of extension fields when the non-residue is negative. (Improves fq2, fq12, and g2 speed on bls12 and bn curves)
 
 ### Bug fixes
 - #36 (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -339,6 +339,33 @@ pub trait PrimeField:
     type Params: FpParameters<BigInt = Self::BigInt>;
     type BigInt: BigInteger;
 
+    #[inline(always)]
+    fn mul_by_i8(mut self, i: i8) -> Self {
+        self.mul_assign_by_i8(i);
+        self
+    }
+
+    #[inline(always)]
+    #[ark_ff_asm::unroll_for_loops]
+    fn mul_assign_by_i8(&mut self, i: i8) {
+        if i < 0 {
+            *self = self.neg();
+        }
+        let i = i.abs();
+
+        let tmp = *self;
+
+        for j in 1..7 {
+            if i >= 1 << (7 - j) {
+                self.double_in_place();
+                // if the next bit is 1
+                if (i >> (6 - j)) % 2 == 1 {
+                    *self += tmp;
+                }
+            }
+        }
+    }
+
     /// Returns a prime field element from its underlying representation.
     fn from_repr(repr: Self::BigInt) -> Option<Self>;
 

--- a/ff/src/fields/models/fp2.rs
+++ b/ff/src/fields/models/fp2.rs
@@ -1,17 +1,21 @@
 use super::quadratic_extension::*;
-use crate::fields::PrimeField;
+use crate::{fields::PrimeField, Field};
 use core::marker::PhantomData;
+use num_traits::Zero;
 
 pub trait Fp2Parameters: 'static + Send + Sync {
     type Fp: PrimeField;
 
     const NONRESIDUE: Self::Fp;
 
+    const NONRESIDUE_I64: Option<i64> = None;
+
     const QUADRATIC_NONRESIDUE: (Self::Fp, Self::Fp);
 
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_FP2_C1: &'static [Self::Fp];
 
+    /// Return `fe * Self::NONRESIDUE`.
     #[inline(always)]
     fn mul_fp_by_nonresidue(fe: &Self::Fp) -> Self::Fp {
         Self::NONRESIDUE * fe
@@ -29,15 +33,56 @@ impl<P: Fp2Parameters> QuadExtParameters for Fp2ParamsWrapper<P> {
 
     const NONRESIDUE: Self::BaseField = P::NONRESIDUE;
 
-    const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP2_C1;
+    const NONRESIDUE_I64: Option<i64> = P::NONRESIDUE_I64;
 
-    #[inline(always)]
-    fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {
-        P::mul_fp_by_nonresidue(fe)
-    }
+    const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP2_C1;
 
     fn mul_base_field_by_frob_coeff(fe: &mut Self::BaseField, power: usize) {
         *fe *= &Self::FROBENIUS_COEFF_C1[power % Self::DEGREE_OVER_BASE_PRIME_FIELD];
+    }
+
+    #[inline(always)]
+    #[ark_ff_asm::unroll_for_loops]
+    fn op_and_mul_base_field_by_nonresidue(
+        other: &Self::BaseField,
+        fe: &Self::BaseField,
+        mode: MulNonResidueMode,
+    ) -> Self::BaseField {
+        if let Some(mut i) = Self::NONRESIDUE_I64 {
+            if mode == MulNonResidueMode::PlusAddOne {
+                i += 1;
+            }
+            if i.abs() < (1 << 5) {
+                if i == 0 {
+                    return Self::BaseField::zero();
+                }
+                let neg = mode == MulNonResidueMode::Minus;
+                let add = i >= 0 && !neg || i < 0 && neg;
+                let i = i.abs() as u64;
+
+                let mut res = *fe;
+
+                for j in 1..5 {
+                    if i >= 1 << (5 - j) {
+                        res.double_in_place();
+                        // if the next bit is 1
+                        if (i >> (4 - j)) % 2 == 1 {
+                            res += fe;
+                        }
+                    }
+                }
+                if add {
+                    return *other + res;
+                } else {
+                    return *other - res;
+                }
+            }
+        }
+        match mode {
+            MulNonResidueMode::Minus => *other - P::mul_fp_by_nonresidue(fe),
+            MulNonResidueMode::Plus => *other + P::mul_fp_by_nonresidue(fe),
+            MulNonResidueMode::PlusAddOne => *other + P::mul_fp_by_nonresidue(fe) + fe,
+        }
     }
 }
 

--- a/ff/src/fields/models/fp3.rs
+++ b/ff/src/fields/models/fp3.rs
@@ -7,6 +7,8 @@ pub trait Fp3Parameters: 'static + Send + Sync {
 
     const NONRESIDUE: Self::Fp;
 
+    const NONRESIDUE_SMALL: Option<i8> = None;
+
     const FROBENIUS_COEFF_FP3_C1: &'static [Self::Fp];
     const FROBENIUS_COEFF_FP3_C2: &'static [Self::Fp];
 
@@ -18,6 +20,9 @@ pub trait Fp3Parameters: 'static + Send + Sync {
 
     #[inline(always)]
     fn mul_fp_by_nonresidue(fe: &Self::Fp) -> Self::Fp {
+        if let Some(i) = Self::NONRESIDUE_SMALL {
+            return fe.mul_by_i8(i);
+        }
         Self::NONRESIDUE * fe
     }
 }

--- a/ff/src/fields/models/fp4.rs
+++ b/ff/src/fields/models/fp4.rs
@@ -18,7 +18,7 @@ pub trait Fp4Parameters: 'static + Send + Sync {
     fn mul_fp2_by_nonresidue(fe: &Fp2<Self::Fp2Params>) -> Fp2<Self::Fp2Params> {
         // see [[DESD06, Section 5.1]](https://eprint.iacr.org/2006/471.pdf).
         Fp2::new(
-            <Self::Fp2Params as Fp2Parameters>::NONRESIDUE * &fe.c1,
+            <Self::Fp2Params as Fp2Parameters>::mul_fp_by_nonresidue(&fe.c1),
             fe.c0,
         )
     }

--- a/ff/src/fields/models/fp6_2over3.rs
+++ b/ff/src/fields/models/fp6_2over3.rs
@@ -14,12 +14,11 @@ pub trait Fp6Parameters: 'static + Send + Sync {
 
     #[inline(always)]
     fn mul_fp3_by_nonresidue(fe: &Fp3<Self::Fp3Params>) -> Fp3<Self::Fp3Params> {
-        let mut res = *fe;
-        res.c0 = fe.c2;
-        res.c1 = fe.c0;
-        res.c2 = fe.c1;
-        res.c0 = <Self::Fp3Params as Fp3Parameters>::mul_fp_by_nonresidue(&res.c0);
-        res
+        Fp3::<Self::Fp3Params>::new(
+             <Self::Fp3Params as Fp3Parameters>::mul_fp_by_nonresidue(&fe.c2),
+             fe.c0,
+             fe.c1,
+        )
     }
 }
 

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -68,10 +68,11 @@ pub trait QuadExtParameters: 'static + Send + Sync + Sized {
         fe: &Self::BaseField,
         mode: MulNonResidueMode,
     ) -> Self::BaseField {
+        let t0 = Self::mul_base_field_by_nonresidue(fe);
         match mode {
-            MulNonResidueMode::Minus => *other - (Self::NONRESIDUE * fe),
-            MulNonResidueMode::Plus => *other + (Self::NONRESIDUE * fe),
-            MulNonResidueMode::PlusAddOne => *other + fe + (Self::NONRESIDUE * fe),
+            MulNonResidueMode::Minus => *other - t0,
+            MulNonResidueMode::Plus => *other + t0,
+            MulNonResidueMode::PlusAddOne => *other + fe + t0,
         }
     }
 

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -60,7 +60,7 @@ pub trait QuadExtParameters: 'static + Send + Sync + Sized {
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {
         Self::NONRESIDUE * fe
     }
-  
+
     #[inline(always)]
     #[ark_ff_asm::unroll_for_loops]
     fn op_and_mul_base_field_by_nonresidue(
@@ -73,40 +73,6 @@ pub trait QuadExtParameters: 'static + Send + Sync + Sized {
             MulNonResidueMode::Plus => *other + (Self::NONRESIDUE * fe),
             MulNonResidueMode::PlusAddOne => *other + fe + (Self::NONRESIDUE * fe),
         }
-    }
-
-    /// A specializable method for computing x + mul_base_field_by_nonresidue(y)
-    /// This allows for optimizations when the non-residue is
-    /// canonically negative in the field.
-    #[inline(always)]
-    fn add_and_mul_base_field_by_nonresidue(
-        x: &Self::BaseField,
-        y: &Self::BaseField,
-    ) -> Self::BaseField {
-        *x + Self::mul_base_field_by_nonresidue(y)
-    }
-
-    /// A specializable method for computing x + mul_base_field_by_nonresidue(y) + y
-    /// This allows for optimizations when the non-residue is not -1.
-    #[inline(always)]
-    fn add_and_mul_base_field_by_nonresidue_plus_one(
-        x: &Self::BaseField,
-        y: &Self::BaseField,
-    ) -> Self::BaseField {
-        let mut tmp = *x;
-        tmp += y;
-        Self::add_and_mul_base_field_by_nonresidue(&tmp, &y)
-    }
-
-    /// A specializable method for computing x - mul_base_field_by_nonresidue(y)
-    /// This allows for optimizations when the non-residue is
-    /// canonically negative in the field.
-    #[inline(always)]
-    fn sub_and_mul_base_field_by_nonresidue(
-        x: &Self::BaseField,
-        y: &Self::BaseField,
-    ) -> Self::BaseField {
-        *x - Self::mul_base_field_by_nonresidue(y)
     }
 
     /// A specializable method for multiplying an element of the base field by
@@ -187,14 +153,8 @@ impl<P: QuadExtParameters> QuadExtField<P> {
     pub fn norm(&self) -> P::BaseField {
         let t0 = self.c0.square();
         // t1 = t0 - P::NON_RESIDUE * c1^2
-<<<<<<< HEAD
         let t1 = self.c1.square();
         P::op_and_mul_base_field_by_nonresidue(&t0, &t1, MulNonResidueMode::Minus)
-=======
-        let mut t1 = self.c1.square();
-        t1 = P::sub_and_mul_base_field_by_nonresidue(&t0, &t1);
-        t1
->>>>>>> master
     }
 
     pub fn mul_assign_by_basefield(&mut self, element: &P::BaseField) {
@@ -307,15 +267,11 @@ impl<P: QuadExtParameters> Field for QuadExtField<P> {
             // v0 = c0 - c1
             let mut v0 = self.c0 - &self.c1;
             // v3 = c0 - beta * c1
-<<<<<<< HEAD
             let v3 = P::op_and_mul_base_field_by_nonresidue(
                 &self.c0,
                 &self.c1,
                 MulNonResidueMode::Minus,
             );
-=======
-            let v3 = P::sub_and_mul_base_field_by_nonresidue(&self.c0, &self.c1);
->>>>>>> master
             // v2 = c0 * c1
             let v2 = self.c0 * &self.c1;
 
@@ -330,12 +286,8 @@ impl<P: QuadExtParameters> Field for QuadExtField<P> {
             // result.c0 = (c0^2 - beta * c0 * c1 - c0 * c1 + beta * c1^2) + ((beta + 1) c0 * c1)
             // result.c0 = (c0^2 - beta * c0 * c1 + beta * c1^2) + (beta * c0 * c1)
             // result.c0 = c0^2 + beta * c1^2
-<<<<<<< HEAD
             self.c0 =
                 P::op_and_mul_base_field_by_nonresidue(&v0, &v2, MulNonResidueMode::PlusAddOne);
-=======
-            self.c0 = P::add_and_mul_base_field_by_nonresidue_plus_one(&v0, &v2);
->>>>>>> master
 
             self
         }
@@ -349,15 +301,11 @@ impl<P: QuadExtParameters> Field for QuadExtField<P> {
             // v1 = c1.square()
             let v1 = self.c1.square();
             // v0 = c0.square() - beta * v1
-<<<<<<< HEAD
             let v0 = P::op_and_mul_base_field_by_nonresidue(
                 &self.c0.square(),
                 &v1,
                 MulNonResidueMode::Minus,
             );
-=======
-            let v0 = P::sub_and_mul_base_field_by_nonresidue(&self.c0.square(), &v1);
->>>>>>> master
 
             v0.inverse().map(|v1| {
                 let c0 = self.c0 * &v1;
@@ -620,11 +568,7 @@ impl<'a, P: QuadExtParameters> MulAssign<&'a Self> for QuadExtField<P> {
         self.c1 *= &(other.c0 + &other.c1);
         self.c1 -= &v0;
         self.c1 -= &v1;
-<<<<<<< HEAD
         self.c0 = P::op_and_mul_base_field_by_nonresidue(&v0, &v1, MulNonResidueMode::Plus);
-=======
-        self.c0 = P::add_and_mul_base_field_by_nonresidue(&v0, &v1);
->>>>>>> master
     }
 }
 

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -48,7 +48,7 @@ pub trait QuadExtParameters: 'static + Send + Sync + Sized {
     /// The quadratic non-residue used to construct the extension.
     const NONRESIDUE: Self::BaseField;
 
-    const NONRESIDUE_I64: Option<i64> = None;
+    const NONRESIDUE_SMALL: Option<i8> = None;
 
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff];


### PR DESCRIPTION
Related to #207 

The main contribution of this PR is to get rid of multiple redundant functions, and to unify all mul by small const methods into default implementations.

Results vis a vis pre #207:
![Screenshot from 2021-02-07 07-51-02](https://user-images.githubusercontent.com/9093549/107132521-af892900-691a-11eb-8ee6-7a705aba34e4.png)

Often, we get speedups for free (for instance for bw6). I'm still investigating why this is.

mnt4_298's residue is G2 basefield non-residue is 17, so it's not worthwhile.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
