### PR TITLE
Fix the definition of PairingFriendlyCycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,6 @@ The main features of this release are:
 - #165 (ark-ff) Enforce in the type system that an extension fields `BaseField` extends from the correct `BasePrimeField`.
 - #184 Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 - #192 Fix a bug in the assembly backend for finite field arithmetic.
-- #217 (ark-ec) fix the definition of PairingFriendlyCycle introduced in #190.
+- #217 (ark-ec) Fix the definition of PairingFriendlyCycle introduced in #190.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,6 @@ The main features of this release are:
 - #165 (ark-ff) Enforce in the type system that an extension fields `BaseField` extends from the correct `BasePrimeField`.
 - #184 Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 - #192 Fix a bug in the assembly backend for finite field arithmetic.
-- #217 (ark-ec) Fix the definition of PairingFriendlyCycle introduced in #190.
+- #217 (ark-ec) Fix the definition of `PairingFriendlyCycle` introduced in #190.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,5 +96,6 @@ The main features of this release are:
 - #165 (ark-ff) Enforce in the type system that an extension fields `BaseField` extends from the correct `BasePrimeField`.
 - #184 Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 - #192 Fix a bug in the assembly backend for finite field arithmetic.
+- #217 (ark-ec) fix the definition of PairingFriendlyCycle introduced in #190.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -347,8 +347,8 @@ pub trait PairingFriendlyCycle: CurveCycle {
     >;
 
     type Engine2: PairingEngine<
-        G2Affine = Self::E2,
-        G2Projective = <Self::E2 as AffineCurve>::Projective,
+        G1Affine = Self::E2,
+        G1Projective = <Self::E2 as AffineCurve>::Projective,
         Fq = <Self::E2 as AffineCurve>::BaseField,
         Fr = <Self::E2 as AffineCurve>::ScalarField,
     >;


### PR DESCRIPTION
## Description

The current definition of PairingFriendlyCycle has a small problem that `Engine2::G2Affine = E2`, which would not be able to represent the MNT4/6 cycle under the current representation (where G_1 resides the matching groups). This PR modifies the definition as `Engine2::G1Affine = E2` so that it works with the correct pairing representation of MNT4/6.

closes: #216 

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
