### PR TITLE
Simple cache alignment for serial FFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The main features of this release are:
 - [\#207](https://github.com/arkworks-rs/algebra/pull/207) (ark-ff) Improve performance of extension fields when the non-residue is negative. (Improves fq2, fq12, and g2 speed on bls12 and bn curves)
 - [\#211](https://github.com/arkworks-rs/algebra/pull/211) (ark-ec) Improve performance of BLS12 final exponentiation.
 - [\#214](https://github.com/arkworks-rs/algebra/pull/214) (ark-poly) Utilise a more efficient way of evaluating a polynomial at a single point
+- [\#242](https://github.com/arkworks-rs/algebra/pull/242) (ark-poly) Speedup the sequential radix-2 FFT significantly by making the method in which it accesses roots more cache-friendly.
 
 ### Bug fixes
 - [\#36](https://github.com/arkworks-rs/algebra/pull/36) (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -145,9 +145,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
         let mut roots = self.roots_of_unity(root);
 
         #[cfg(not(feature = "parallel"))]
-        let mut root_len = roots.len();
-        #[cfg(not(feature = "parallel"))]
-        let mut first_iteration = true;
+        let (mut root_len, first_iteration) = (roots.len(), true);
 
         let mut gap = xi.len() / 2;
         while gap > 0 {

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -137,21 +137,53 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
             });
     }
 
+    #[allow(unused)]
     fn io_helper<T: DomainCoeff<F>>(&self, xi: &mut [T], root: F) {
-        let roots = self.roots_of_unity(root);
+        // In the sequential case, we will keep on making the roots cache-aligned,
+        // according to the access pattern that the FFT uses.
+        // It is left as a TODO to implement this for the parallel case
+        let mut roots = self.roots_of_unity(root);
+        let mut root_len = roots.len();
 
         let mut gap = xi.len() / 2;
+        let mut first_iteration = true;
         while gap > 0 {
             // each butterfly cluster uses 2*gap positions
             let chunk_size = 2 * gap;
             let nchunks = xi.len() / chunk_size;
 
-            let butterfly_fn = |(idx, (lo, hi)): (usize, (&mut T, &mut T))| {
+            // Cache align the FFT roots in the sequential case.
+            // In this case, we are aiming to make every root that is accessed one after another,
+            // appear one after another in the list of roots.
+            #[cfg(not(feature = "parallel"))]
+            {
+                // Roots are already cache aligned in the first iteration, so we don't need to do anything.
+                if !first_iteration {
+                    // if the roots are cache aligned in iteration i, then in iteration i+1,
+                    // cache alignment requires selecting every other root. 
+                    // (The even powers relative to the current iterations generator)
+                    for i in 1..(root_len / 2) {
+                        roots[i] = roots[i * 2];
+                    }
+                    root_len /= 2;
+                }
+            }
+
+            let butterfly_fn = |(chunk_index, (lo, hi)): (usize, (&mut T, &mut T))| {
                 let neg = *lo - *hi;
                 *lo += *hi;
 
                 *hi = neg;
-                *hi *= roots[nchunks * idx];
+
+                #[cfg(feature = "parallel")]
+                {
+                    *hi *= roots[nchunks * chunk_index];
+                }
+                #[cfg(not(feature = "parallel"))]
+                {
+                    // Cache-aligned, so the index is just the chunk_index
+                    *hi *= roots[chunk_index];
+                }
             };
 
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {
@@ -167,6 +199,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 }
             });
             gap /= 2;
+            first_iteration = false;
         }
     }
 

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -167,6 +167,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                     roots[i] = roots[i * 2];
                 }
                 root_len /= 2;
+                first_iteration = false;
             }
 
             let butterfly_fn = |(chunk_index, (lo, hi)): (usize, (&mut T, &mut T))| {
@@ -196,10 +197,6 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 }
             });
             gap /= 2;
-            #[cfg(not(feature = "parallel"))]
-            {
-                first_iteration = false;
-            }
         }
     }
 

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -160,7 +160,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 // Roots are already cache aligned in the first iteration, so we don't need to do anything.
                 if !first_iteration {
                     // if the roots are cache aligned in iteration i, then in iteration i+1,
-                    // cache alignment requires selecting every other root. 
+                    // cache alignment requires selecting every other root.
                     // (The even powers relative to the current iterations generator)
                     for i in 1..(root_len / 2) {
                         roots[i] = roots[i * 2];

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -143,6 +143,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
         // It is left as a TODO to implement this for the parallel case
         #[allow(unused_mut)]
         let mut roots = self.roots_of_unity(root);
+
         #[cfg(not(feature = "parallel"))]
         let mut root_len = roots.len();
         #[cfg(not(feature = "parallel"))]
@@ -177,15 +178,11 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 *hi = neg;
 
                 #[cfg(feature = "parallel")]
-                {
-                    *hi *= roots[nchunks * chunk_index];
-                }
-
-                // Cache-aligned, so the index is just the chunk_index
+                let index = nchunks * chunk_index;
                 #[cfg(not(feature = "parallel"))]
-                {
-                    *hi *= roots[chunk_index];
-                }
+                let index = chunk_index;
+
+                *hi *= roots[index];
             };
 
             ark_std::cfg_chunks_mut!(xi, chunk_size).for_each(|cxi| {

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -145,7 +145,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
         let mut roots = self.roots_of_unity(root);
 
         #[cfg(not(feature = "parallel"))]
-        let (mut root_len, first_iteration) = (roots.len(), true);
+        let (mut root_len, mut first_iteration) = (roots.len(), true);
 
         let mut gap = xi.len() / 2;
         while gap > 0 {

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -143,7 +143,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
         // It is left as a TODO to implement this for the parallel case
         #[allow(unused_mut)]
         let mut roots = self.roots_of_unity(root);
-        
+
         #[cfg(not(feature = "parallel"))]
         let (mut root_len, mut first_iteration) = (roots.len(), true);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR adds a simple cache alignment for sequential FFTs. See #177 for more context, but essentially in the FFT at the moment, the roots are accessed in a manner that is cache unfriendly, which causes lots of latency.

It takes the approach of ensuring in the sequential case that the roots are laid out in memory in the exact same form that they are used in, in every iteration.

This provides pretty significant speedups to the algorithm. (They are super-linear in polynomial size, as they have increasingly notable affects at the later round of the FFT).
Here is a list of speedup percentages just at varying sizes, as measured on our benchmark server.
* 2^15 - 3.8%
* 2^16 - 5.8%
* 2^17 - 9.6%
* 2^18 - 11.4%
* 2^19 - 12.8%
* 2^20 - 15.74%
* 2^21 - 19.7%


It is left as a TODO to implement this for the IFFT loop, and to implement this in the parallel case. It is likely that benefits at smaller instance sizes will be more profound on commodity hardware with smaller cache sizes than our benchmark server.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests - covered by existing tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
