### PR TITLE
Fix prime field sampling when REPR_SHIFT_BITS is 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Improvements
 
+### Bug fixes
+- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64.
+
 
 ## v0.2.0
 
@@ -111,6 +114,5 @@ The main features of this release are:
 - [\#184](https://github.com/arkworks-rs/algebra/pull/184) Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 - [\#192](https://github.com/arkworks-rs/algebra/pull/192) Fix a bug in the assembly backend for finite field arithmetic.
 - [\#217](https://github.com/arkworks-rs/algebra/pull/217) (ark-ec) Fix the definition of `PairingFriendlyCycle` introduced in #190.
-- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,5 +111,6 @@ The main features of this release are:
 - [\#184](https://github.com/arkworks-rs/algebra/pull/184) Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 - [\#192](https://github.com/arkworks-rs/algebra/pull/192) Fix a bug in the assembly backend for finite field arithmetic.
 - [\#217](https://github.com/arkworks-rs/algebra/pull/217) (ark-ec) Fix the definition of `PairingFriendlyCycle` introduced in #190.
+- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,6 @@ The main features of this release are:
 - [\#184](https://github.com/arkworks-rs/algebra/pull/184) Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 - [\#192](https://github.com/arkworks-rs/algebra/pull/192) Fix a bug in the assembly backend for finite field arithmetic.
 - [\#217](https://github.com/arkworks-rs/algebra/pull/217) (ark-ec) Fix the definition of `PairingFriendlyCycle` introduced in #190.
-- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64
+- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64.
 
 ## v0.1.0 (Initial release of arkworks/algebra)

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -202,17 +202,14 @@ macro_rules! impl_prime_field_standard_sample {
                         rng.sample(ark_std::rand::distributions::Standard),
                         PhantomData,
                     );
-                    
+
                     // Mask away the unused bits at the beginning.
                     let mask = if P::REPR_SHAVE_BITS == 64 {
                         0
                     } else {
                         core::u64::MAX >> P::REPR_SHAVE_BITS
                     };
-                    tmp.0
-                        .as_mut()
-                        .last_mut()
-                        .map(|val| *val &= mask);                    
+                    tmp.0.as_mut().last_mut().map(|val| *val &= mask);
 
                     if tmp.is_valid() {
                         return tmp;

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -204,6 +204,7 @@ macro_rules! impl_prime_field_standard_sample {
                     );
 
                     // Mask away the unused bits at the beginning.
+                    assert!(P::REPR_SHAVE_BITS <= 64);
                     let mask = if P::REPR_SHAVE_BITS == 64 {
                         0
                     } else {

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -202,11 +202,17 @@ macro_rules! impl_prime_field_standard_sample {
                         rng.sample(ark_std::rand::distributions::Standard),
                         PhantomData,
                     );
+                    
                     // Mask away the unused bits at the beginning.
+                    let mask = if P::REPR_SHAVE_BITS == 64 {
+                        0
+                    } else {
+                        core::u64::MAX >> P::REPR_SHAVE_BITS
+                    };
                     tmp.0
                         .as_mut()
                         .last_mut()
-                        .map(|val| *val &= core::u64::MAX >> P::REPR_SHAVE_BITS);
+                        .map(|val| *val &= mask);                    
 
                     if tmp.is_valid() {
                         return tmp;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixed a bug in sampling when the field has REPR_SHIFT_BITS equal to 64 (the entire last limb is leftover bits used only for overflow)

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
