### PR TITLE
Tiny-const-generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In addition, the [`curves`](https://github.com/arkworks-rs/curves) repository co
 
 ## Build guide
 
-The library compiles on the `stable` toolchain of the Rust compiler. To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
+The library compiles on the `stable` toolchain of the Rust compiler (v 1.51+). To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
 ```bash
 rustup install stable
 ```

--- a/ff/build.rs
+++ b/ff/build.rs
@@ -1,5 +1,5 @@
 extern crate rustc_version;
-use rustc_version::{version_meta, Channel};
+use rustc_version::{version, version_meta, Channel, Version};
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -14,5 +14,11 @@ fn main() {
     )) && is_nightly;
     if should_use_asm {
         println!("cargo:rustc-cfg=use_asm");
+    }
+
+    // TODO: remove this once RFC 2495 ships
+    if version().expect("Installed rustc version unparseable!") < Version::parse("1.51.0").unwrap()
+    {
+        panic!("This code base uses const generics and requires a Rust compiler version greater or equal to 1.51.0");
     }
 }

--- a/ff/src/bytes.rs
+++ b/ff/src/bytes.rs
@@ -14,151 +14,113 @@ pub trait FromBytes: Sized {
     fn read<R: Read>(reader: R) -> IoResult<Self>;
 }
 
-macro_rules! array_bytes {
-    ($N:expr) => {
-        impl ToBytes for [u8; $N] {
-            #[inline]
-            fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-                writer.write_all(self)
-            }
-        }
-
-        impl FromBytes for [u8; $N] {
-            #[inline]
-            fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-                let mut arr = [0u8; $N];
-                reader.read_exact(&mut arr)?;
-                Ok(arr)
-            }
-        }
-
-        impl ToBytes for [u16; $N] {
-            #[inline]
-            fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-                for num in self {
-                    writer.write_all(&num.to_le_bytes())?;
-                }
-                Ok(())
-            }
-        }
-
-        impl FromBytes for [u16; $N] {
-            #[inline]
-            fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-                let mut res = [0u16; $N];
-                for num in res.iter_mut() {
-                    let mut bytes = [0u8; 2];
-                    reader.read_exact(&mut bytes)?;
-                    *num = u16::from_le_bytes(bytes);
-                }
-                Ok(res)
-            }
-        }
-
-        impl ToBytes for [u32; $N] {
-            #[inline]
-            fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-                for num in self {
-                    writer.write_all(&num.to_le_bytes())?;
-                }
-                Ok(())
-            }
-        }
-
-        impl FromBytes for [u32; $N] {
-            #[inline]
-            fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-                let mut res = [0u32; $N];
-                for num in res.iter_mut() {
-                    let mut bytes = [0u8; 4];
-                    reader.read_exact(&mut bytes)?;
-                    *num = u32::from_le_bytes(bytes);
-                }
-                Ok(res)
-            }
-        }
-
-        impl ToBytes for [u64; $N] {
-            #[inline]
-            fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-                for num in self {
-                    writer.write_all(&num.to_le_bytes())?;
-                }
-                Ok(())
-            }
-        }
-
-        impl FromBytes for [u64; $N] {
-            #[inline]
-            fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-                let mut res = [0u64; $N];
-                for num in res.iter_mut() {
-                    let mut bytes = [0u8; 8];
-                    reader.read_exact(&mut bytes)?;
-                    *num = u64::from_le_bytes(bytes);
-                }
-                Ok(res)
-            }
-        }
-
-        impl ToBytes for [u128; $N] {
-            #[inline]
-            fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-                for num in self {
-                    writer.write_all(&num.to_le_bytes())?;
-                }
-                Ok(())
-            }
-        }
-
-        impl FromBytes for [u128; $N] {
-            #[inline]
-            fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-                let mut res = [0u128; $N];
-                for num in res.iter_mut() {
-                    let mut bytes = [0u8; 16];
-                    reader.read_exact(&mut bytes)?;
-                    *num = u128::from_le_bytes(bytes);
-                }
-                Ok(res)
-            }
-        }
-    };
+impl<const N: usize> ToBytes for [u8; N] {
+    #[inline]
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        writer.write_all(self)
+    }
 }
 
-array_bytes!(0);
-array_bytes!(1);
-array_bytes!(2);
-array_bytes!(3);
-array_bytes!(4);
-array_bytes!(5);
-array_bytes!(6);
-array_bytes!(7);
-array_bytes!(8);
-array_bytes!(9);
-array_bytes!(10);
-array_bytes!(11);
-array_bytes!(12);
-array_bytes!(13);
-array_bytes!(14);
-array_bytes!(15);
-array_bytes!(16);
-array_bytes!(17);
-array_bytes!(18);
-array_bytes!(19);
-array_bytes!(20);
-array_bytes!(21);
-array_bytes!(22);
-array_bytes!(23);
-array_bytes!(24);
-array_bytes!(25);
-array_bytes!(26);
-array_bytes!(27);
-array_bytes!(28);
-array_bytes!(29);
-array_bytes!(30);
-array_bytes!(31);
-array_bytes!(32);
+impl<const N: usize> FromBytes for [u8; N] {
+    #[inline]
+    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+        let mut arr = [0u8; N];
+        reader.read_exact(&mut arr)?;
+        Ok(arr)
+    }
+}
+
+impl<const N: usize> ToBytes for [u16; N] {
+    #[inline]
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        for num in self {
+            writer.write_all(&num.to_le_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl<const N: usize> FromBytes for [u16; N] {
+    #[inline]
+    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+        let mut res = [0u16; N];
+        for num in res.iter_mut() {
+            let mut bytes = [0u8; 2];
+            reader.read_exact(&mut bytes)?;
+            *num = u16::from_le_bytes(bytes);
+        }
+        Ok(res)
+    }
+}
+
+impl<const N: usize> ToBytes for [u32; N] {
+    #[inline]
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        for num in self {
+            writer.write_all(&num.to_le_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl<const N: usize> FromBytes for [u32; N] {
+    #[inline]
+    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+        let mut res = [0u32; N];
+        for num in res.iter_mut() {
+            let mut bytes = [0u8; 4];
+            reader.read_exact(&mut bytes)?;
+            *num = u32::from_le_bytes(bytes);
+        }
+        Ok(res)
+    }
+}
+
+impl<const N: usize> ToBytes for [u64; N] {
+    #[inline]
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        for num in self {
+            writer.write_all(&num.to_le_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl<const N: usize> FromBytes for [u64; N] {
+    #[inline]
+    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+        let mut res = [0u64; N];
+        for num in res.iter_mut() {
+            let mut bytes = [0u8; 8];
+            reader.read_exact(&mut bytes)?;
+            *num = u64::from_le_bytes(bytes);
+        }
+        Ok(res)
+    }
+}
+
+impl<const N: usize> ToBytes for [u128; N] {
+    #[inline]
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        for num in self {
+            writer.write_all(&num.to_le_bytes())?;
+        }
+        Ok(())
+    }
+}
+
+impl<const N: usize> FromBytes for [u128; N] {
+    #[inline]
+    fn read<R: Read>(mut reader: R) -> IoResult<Self> {
+        let mut res = [0u128; N];
+        for num in res.iter_mut() {
+            let mut bytes = [0u8; 16];
+            reader.read_exact(&mut bytes)?;
+            *num = u128::from_le_bytes(bytes);
+        }
+        Ok(res)
+    }
+}
 
 /// Takes as input a sequence of structs, and converts them to a series of
 /// bytes. All traits that implement `Bytes` can be automatically converted to


### PR DESCRIPTION
This is an easy initial fragment of #186 aimed at breaking off one easy part out of that big PR, and get us started on the path to `min_const_generics`. Props to @jon-chuang for the actual work.

(#186 needs a bit of bespoke specialization to achieve performance parity, so this just aims for code simplification) 

bench on master:
https://gist.github.com/413013073c2c81e8999e77c1cb37c5b8
bench on this PR:
https://gist.github.com/1f1cc7a70d02709889b9a0dfa180f2cd

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
