### PR TITLE
Only check CI against some curves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,4 +215,12 @@ jobs:
             command: test
             args: "--workspace \
                    --all-features \
+                   -p ark-bls12-377 \
+                   -p ark-bls12-381 \
+                   -p ark-bn254 \
+                   -p ark-pallas \
+                   -p ark-bw6-761 \
+                   -p ark-mnt4-298 \
+                   -p ark-mnt6-298 \
+                   -p ark-ed-on-bls12-377 \
                    --exclude curve-benches"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,15 @@ jobs:
       RUSTFLAGS: -Dwarnings
     strategy:
       matrix:
+        curve:
+          - bls12_377
+          - bls12_381
+          - bn254
+          - pallas
+          - bw6_761
+          - mnt4_298
+          - mnt6_298
+          - ed_on_bls12_377
         rust:
           - stable
           - nightly
@@ -175,7 +184,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: arkworks-rs/curves
-    
+
       - name: Checkout algebra
         uses: actions/checkout@v2
         with:
@@ -197,7 +206,7 @@ jobs:
             algebra/target
             target
           key: ${{ runner.os }}-cargo-curves-${{ hashFiles('**/Cargo.lock') }}
-          
+
       - name: Patch cargo.toml
         run: |
           echo                                                                             >> Cargo.toml
@@ -208,19 +217,6 @@ jobs:
           echo      "ark-ff-asm = { path = 'algebra/ff-asm' }"                             >> Cargo.toml
           echo      "ark-ec = { path = 'algebra/ec' }"                                     >> Cargo.toml
           echo      "ark-algebra-test-templates = { path = 'algebra/test-templates' }"     >> Cargo.toml
-        
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-            command: test
-            args: "--workspace \
-                   --all-features \
-                   -p ark-bls12-377 \
-                   -p ark-bls12-381 \
-                   -p ark-bn254 \
-                   -p ark-pallas \
-                   -p ark-bw6-761 \
-                   -p ark-mnt4-298 \
-                   -p ark-mnt6-298 \
-                   -p ark-ed-on-bls12-377 \
-                   --exclude curve-benches"
+
+      - name: Test on ${{ matrix.curve }}
+        run: "cd ${{ matrix.curve }} && cargo test --all-features"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,9 +176,6 @@ jobs:
           - mnt4_298
           - mnt6_298
           - ed_on_bls12_377
-        rust:
-          - stable
-          - nightly
     steps:
       - name: Checkout curves
         uses: actions/checkout@v2
@@ -191,26 +188,17 @@ jobs:
           repository: arkworks-rs/algebra
           path: algebra
 
-      - name: Install Rust (${{ matrix.rust }})
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           override: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            algebra/target
-            target
-          key: ${{ runner.os }}-cargo-curves-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Patch cargo.toml
         run: |
           echo                                                                             >> Cargo.toml
-          echo      "[patch.'https://github.com/arkworks-rs/algebra']"                     >> Cargo.toml
+          echo      "[patch.crates-io]"                                                    >> Cargo.toml
           echo      "ark-ff = { path = 'algebra/ff' }"                                     >> Cargo.toml
           echo      "ark-serialize = { path = 'algebra/serialize' }"                       >> Cargo.toml
           echo      "ark-ff-macros = { path = 'algebra/ff-macros' }"                       >> Cargo.toml


### PR DESCRIPTION
I picked the following curves as they probably most of the field and curve instantiations we care about
- `ark-bls12-377`
- `ark-bls12-381`
- `ark-bn254`
- `ark-pallas`
- `ark-bw6-761`
- `ark-mnt4-298`
- `ark-mnt6-298`
- `ark-ed-on-bls12-377`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
