### PR TITLE
Add support for 448-bit integers and fields

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -25,6 +25,7 @@ bigint_impl!(BigInteger128, 2);
 bigint_impl!(BigInteger256, 4);
 bigint_impl!(BigInteger320, 5);
 bigint_impl!(BigInteger384, 6);
+bigint_impl!(BigInteger448, 7);
 bigint_impl!(BigInteger768, 12);
 bigint_impl!(BigInteger832, 13);
 

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -90,6 +90,12 @@ fn test_biginteger384() {
 }
 
 #[test]
+fn test_biginteger448() {
+    use crate::biginteger::BigInteger448 as B;
+    test_biginteger(B::new([0u64; 7]));
+}
+
+#[test]
 fn test_biginteger768() {
     use crate::biginteger::BigInteger768 as B;
     test_biginteger(B::new([0u64; 12]));

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -545,13 +545,15 @@ impl<Slice: AsRef<[u64]>> Iterator for BitIteratorLE<Slice> {
 }
 
 use crate::biginteger::{
-    BigInteger256, BigInteger320, BigInteger384, BigInteger64, BigInteger768, BigInteger832,
+    BigInteger256, BigInteger320, BigInteger384, BigInteger448, BigInteger64, BigInteger768,
+    BigInteger832,
 };
 
 impl_field_bigint_conv!(Fp64, BigInteger64, Fp64Parameters);
 impl_field_bigint_conv!(Fp256, BigInteger256, Fp256Parameters);
 impl_field_bigint_conv!(Fp320, BigInteger320, Fp320Parameters);
 impl_field_bigint_conv!(Fp384, BigInteger384, Fp384Parameters);
+impl_field_bigint_conv!(Fp448, BigInteger448, Fp448Parameters);
 impl_field_bigint_conv!(Fp768, BigInteger768, Fp768Parameters);
 impl_field_bigint_conv!(Fp832, BigInteger832, Fp832Parameters);
 

--- a/ff/src/fields/models/mod.rs
+++ b/ff/src/fields/models/mod.rs
@@ -11,7 +11,7 @@ use num_traits::{One, Zero};
 use crate::{
     biginteger::{
         arithmetic as fa, BigInteger as _BigInteger, BigInteger256, BigInteger320, BigInteger384,
-        BigInteger64, BigInteger768, BigInteger832,
+        BigInteger448, BigInteger64, BigInteger768, BigInteger832,
     },
     bytes::{FromBytes, ToBytes},
     fields::{FftField, Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
@@ -22,6 +22,7 @@ impl_Fp!(Fp64, Fp64Parameters, BigInteger64, BigInteger64, 1);
 impl_Fp!(Fp256, Fp256Parameters, BigInteger256, BigInteger256, 4);
 impl_Fp!(Fp320, Fp320Parameters, BigInteger320, BigInteger320, 5);
 impl_Fp!(Fp384, Fp384Parameters, BigInteger384, BigInteger384, 6);
+impl_Fp!(Fp448, Fp448Parameters, BigInteger448, BigInteger448, 7);
 impl_Fp!(Fp768, Fp768Parameters, BigInteger768, BigInteger768, 12);
 impl_Fp!(Fp832, Fp832Parameters, BigInteger832, BigInteger832, 13);
 


### PR DESCRIPTION
## Description

Add support for 448-bit integers and fields. These will be needed for the Pluto and Eris curves
(https://github.com/daira/pluto-eris).

The changes are trivial and amount to applying the existing macros to a length of 448 bits (7 64-bit words).
This interacts with #186, but it should be easy to resolve any conflict.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] ~~Linked to Github issue with discussion and accepted design~~ OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code [not needed]
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
