### PR TITLE
Implements hashing as a blanket trait for instances of `CanonicalSerialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 - [\#245](https://github.com/arkworks-rs/algebra/pull/245) (ark-poly) Speedup the sequential and parallel radix-2 FFT and IFFT significantly by making the method in which it accesses roots more cache-friendly.
 - [\#258](https://github.com/arkworks-rs/algebra/pull/258) (ark-poly) Add `Mul<F>` implementation for `DensePolynomial`.
 - [\#261](https://github.com/arkworks-rs/algebra/pull/261) (ark-ff) Add support for 448-bit integers and fields.
-- [\#263](https://github.com/arkworks-rs/algebra/pull/263) (ark-ff) Adds `From<iXXX>` implementations to fields.
-- [\#265](https://github.com/arkworks-rs/algebra/pull/265) (ark-serialize) Adds hashing as an extension trait of `CanonicalSerialize`.
+- [\#263](https://github.com/arkworks-rs/algebra/pull/263) (ark-ff) Add `From<iXXX>` implementations to fields.
+- [\#265](https://github.com/arkworks-rs/algebra/pull/265) (ark-serialize) Add hashing as an extension trait of `CanonicalSerialize`.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - [\#245](https://github.com/arkworks-rs/algebra/pull/245) (ark-poly) Speedup the sequential and parallel radix-2 FFT and IFFT significantly by making the method in which it accesses roots more cache-friendly.
 - [\#258](https://github.com/arkworks-rs/algebra/pull/258) (ark-poly) Add `Mul<F>` implementation for `DensePolynomial`.
 - [\#261](https://github.com/arkworks-rs/algebra/pull/261) (ark-ff) Add support for 448-bit integers and fields.
+- [\#263](https://github.com/arkworks-rs/algebra/pull/263) (ark-ff) Adds `From<iXXX>` implementations to fields.
+- [\#265](https://github.com/arkworks-rs/algebra/pull/265) (ark-serialize) Adds hashing as an extension trait of `CanonicalSerialize`.
 
 ### Improvements
 

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -15,8 +15,14 @@ edition = "2018"
 [dependencies]
 ark-serialize-derive = { version = "^0.2.0", path = "../serialize-derive", optional = true }
 ark-std = { version = "0.2.0", default-features = false }
+digest = { version = "0.9", default-features = false }
+
+[dev-dependencies]
+sha2 = { version = "0.9.3", default-features = false}
+sha3 = { version = "0.9.1", default-features = false}
+blake2 = { version = "0.9.1", default-features = false}
 
 [features]
 default = []
-std = [ "ark-std/std" ]
+std = [ "ark-std/std", ]
 derive = [ "ark-serialize-derive" ]

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -20,6 +20,8 @@ pub use flags::*;
 #[doc(hidden)]
 pub use ark_serialize_derive::*;
 
+use digest::{generic_array::GenericArray, Digest};
+
 /// Serializer in little endian format allowing to encode flags.
 pub trait CanonicalSerializeWithFlags: CanonicalSerialize {
     /// Serializes `self` and `flags` into `writer`.
@@ -93,6 +95,37 @@ pub trait CanonicalSerialize {
         self.serialized_size()
     }
 }
+
+// This private struct works around Serialize taking the pre-existing
+// std::io::Write instance of most digest::Digest implementations by value
+struct HashMarshaller<'a, H: Digest>(&'a mut H);
+
+impl<'a, H: Digest> ark_std::io::Write for HashMarshaller<'a, H> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> ark_std::io::Result<usize> {
+        Digest::update(self.0, buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> ark_std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// The CanonicalSerialize induces a natural way to hash the
+/// corresponding value, of which this is the convenience trait.
+pub trait Hash: CanonicalSerialize {
+    fn hash<H: Digest>(&self) -> GenericArray<u8, <H as Digest>::OutputSize> {
+        let mut hasher = H::new();
+        self.serialize(HashMarshaller(&mut hasher))
+            .expect("HashMarshaller::flush should be infaillible!");
+        hasher.finalize()
+    }
+}
+
+/// Hash is a (blanket) extension trait of CanonicalSerialize
+impl<T: CanonicalSerialize> Hash for T {}
 
 /// Deserializer in little endian format allowing flags to be encoded.
 pub trait CanonicalDeserializeWithFlags: Sized {
@@ -897,6 +930,18 @@ mod test {
         assert_eq!(data, de);
     }
 
+    fn test_hash<T: CanonicalSerialize, H: Digest + core::fmt::Debug>(data: T) {
+        let h1 = data.hash::<H>();
+
+        let mut hash = H::new();
+        let mut serialized = vec![0; data.serialized_size()];
+        data.serialize(&mut serialized[..]).unwrap();
+        hash.update(&serialized);
+        let h2 = hash.finalize();
+
+        assert_eq!(h1, h2);
+    }
+
     // Serialize T, randomly mutate the data, and deserialize it.
     // Ensure it fails.
     // Up to the caller to provide a valid mutation criterion
@@ -1023,5 +1068,23 @@ mod test {
     #[test]
     fn test_phantomdata() {
         test_serialize(core::marker::PhantomData::<Dummy>);
+    }
+
+    #[test]
+    fn test_sha2() {
+        test_hash::<_, sha2::Sha256>(Dummy);
+        test_hash::<_, sha2::Sha512>(Dummy);
+    }
+
+    #[test]
+    fn test_blake2() {
+        test_hash::<_, blake2::Blake2b>(Dummy);
+        test_hash::<_, blake2::Blake2s>(Dummy);
+    }
+
+    #[test]
+    fn test_sha3() {
+        test_hash::<_, sha3::Sha3_256>(Dummy);
+        test_hash::<_, sha3::Sha3_512>(Dummy);
     }
 }


### PR DESCRIPTION
- this saves an alllocation w.r.t the issue-suggested approach by implementing `io::Write` on the input instance of `digest::Digest`,
- note that most instances of `digest::Digest` [already](https://gist.github.com/huitseeker/e827161413063e347ce5a496b66ff287) have an [`io::Write` instance](https://github.com/rustcrypto/hashes#hashing-readable-objects), but `CanonicalSerialize` consuming its `io::Write` argument prevents its usage,
- this hence implements `io::Write` on a [cheap newtype wrapper](https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html)

closes: #86 

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
