### PR TITLE
Fix a couple lints spotted by clippy

### DIFF
--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -601,7 +601,7 @@ fn serial_batch_inversion_and_mul<F: Field>(v: &mut [F], coeff: &F) {
     tmp = tmp.inverse().unwrap(); // Guaranteed to be nonzero.
 
     // Multiply product by coeff, so all inverses will be scaled by coeff
-    tmp = tmp * coeff;
+    tmp *= coeff;
 
     // Second pass: iterate backwards to compute inverses
     for (f, s) in v.iter_mut()

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -621,7 +621,7 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Rc<T> {
 impl CanonicalSerialize for bool {
     #[inline]
     fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
-        Ok((*self as u8).serialize(writer)?)
+        (*self as u8).serialize(writer)
     }
 
     #[inline]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Clippy had a bunch more lints for this repo, but most of them seemed ill-advised to me. (Capitalization of variables, using clone() explicitly in places in stead of relying on copy, using `''` for single character strings, not `""`)

A couple clippy lints seemed potentially helpful, namely 
`warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true`
and
```
warning: methods called `into_*` usually take self by value; consider choosing a less ambiguous name
   --> ec/src/lib.rs:257:24
    |
257 |     fn into_projective(&self) -> Self::Projective {
    |                        ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
```
Not really planning on making a changes to the `into_projective` and `into_affine` methods now, since we should punt that until our Elliptic curve refactor.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
