### PR TITLE
Improve documentation for BN curve parameter `ATE_LOOP_COUNT`

### DIFF
--- a/ec/src/models/bn/mod.rs
+++ b/ec/src/models/bn/mod.rs
@@ -23,7 +23,7 @@ pub trait BnParameters: 'static {
     // Whether or not `X` is negative.
     const X_IS_NEGATIVE: bool;
 
-    // The absolute value of `6X + 2`
+    // The absolute value of `6X + 2`.
     const ATE_LOOP_COUNT: &'static [i8];
     // Whether or not `6X + 2` is negative. `6X + 2` is negative often when `X` is negative.
     const ATE_LOOP_COUNT_IS_NEGATIVE: bool;

--- a/ec/src/models/bn/mod.rs
+++ b/ec/src/models/bn/mod.rs
@@ -18,10 +18,16 @@ pub enum TwistType {
 }
 
 pub trait BnParameters: 'static {
+    // The absolute value of the BN curve parameter `X` (as in `q = 36 X^4 + 36 X^3 + 24 X^2 + 6 X + 1`).
     const X: &'static [u64];
+    // Whether or not `X` is negative.
     const X_IS_NEGATIVE: bool;
+
+    // The absolute value of `6X + 2`
     const ATE_LOOP_COUNT: &'static [i8];
+    // Whether or not `6X + 2` is negative. `6X + 2` is negative often when `X` is negative.
     const ATE_LOOP_COUNT_IS_NEGATIVE: bool;
+
     const TWIST_TYPE: TwistType;
     const TWIST_MUL_BY_Q_X: Fp2<Self::Fp2Params>;
     const TWIST_MUL_BY_Q_Y: Fp2<Self::Fp2Params>;


### PR DESCRIPTION
## Description

This PR is to clarify that `ATE_LOOP_COUNT` is `6 X + 2` instead of `|6 X + 2|`, a possible confusion.

This is related to #274 and arkworks-rs/curves#54.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Updated relevant documentation in the code
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
