### PR TITLE
Implement `Into<BigUint>` and `From<BigUint>` for `BigInteger` and `PrimeField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 ### Improvements
 
 ### Bug fixes
-- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64.
 
+- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64.
 
 ## v0.2.0
 
@@ -33,6 +33,7 @@ The main features of this release are:
 - Adding new traits for basic curve cycles and pairing based curve cycles
 
 ### Breaking changes
+
 - [\#20](https://github.com/arkworks-rs/algebra/pull/20) (ark-poly) Move univariate DensePolynomial and SparsePolynomial into a
     univariate sub-crate. Make this change by:
     find w/ regex `ark_poly::(Dense|Sparse)Polynomial`, and replace with `ark_poly::univariate::$1Polynomial`.
@@ -52,18 +53,19 @@ The main features of this release are:
     Importing these from `ark-ff` is still possible, but is deprecated and will be removed in the following release.
 - [\#144](https://github.com/arkworks-rs/algebra/pull/144) (ark-poly) Add `CanonicalSerialize` and `CanonicalDeserialize` trait bounds for `Polynomial`.
 - [\#160](https://github.com/arkworks-rs/algebra/pull/160) (ark-serialize, ark-ff, ark-ec)
-  - Remove `ConstantSerializedSize`; users should use `serialized_size*` (see next).
-  - Add `serialized_size_with_flags` method to `CanonicalSerializeWithFlags`.
-  - Change `from_random_bytes_with_flags` to output `ark_serialize::Flags`.
-  - Change signatures of `Flags::from_u8*` to output `Option`.
-  - Change `Flags::from_u8*` to be more strict about the inputs they accept:
-    if the top bits of the `u8` value do *not* correspond to one of the possible outputs of `Flags::u8_bitmask`, then these methods output `None`, whereas before they output
-    a default value.
+    - Remove `ConstantSerializedSize`; users should use `serialized_size*` (see next).
+    - Add `serialized_size_with_flags` method to `CanonicalSerializeWithFlags`.
+    - Change `from_random_bytes_with_flags` to output `ark_serialize::Flags`.
+    - Change signatures of `Flags::from_u8*` to output `Option`.
+    - Change `Flags::from_u8*` to be more strict about the inputs they accept:
+      if the top bits of the `u8` value do *not* correspond to one of the possible outputs of `Flags::u8_bitmask`, then these methods output `None`, whereas before they output
+      a default value.
   Downstream users other than `ark-curves` should not see breakage unless they rely on these methods/traits explicitly.
 - [\#165](https://github.com/arkworks-rs/algebra/pull/165) (ark-ff) Add `from_base_field_elements` as a method to the `Field` trait.
 - [\#166](https://github.com/arkworks-rs/algebra/pull/166) (ark-ff) Change `BigInt::{from_bytes, to_bits}` to `from_bytes_le, from_bytes_be, to_bits_le, to_bits_be`.
 
 ### Features
+
 - [\#20](https://github.com/arkworks-rs/algebra/pull/20) (ark-poly) Add structs/traits for multivariate polynomials.
 - [\#96](https://github.com/arkworks-rs/algebra/pull/96) (ark-ff) Make the `field_new` macro accept values in integer form, without requiring decomposition into limbs, and without requiring encoding in Montgomery form.
 - [\#106](https://github.com/arkworks-rs/algebra/pull/106) (ark-ff, ark-ec) Add `Zeroize` trait bound to `Field, ProjectiveGroup, AffineGroup` traits.
@@ -73,6 +75,7 @@ The main features of this release are:
 - [\#197](https://github.com/arkworks-rs/algebra/pull/197) (ark-test-curves) Add a BN384 curve with low two-arity for mixed-radix testing.
 
 ### Improvements
+
 - [\#22](https://github.com/arkworks-rs/algebra/pull/22) (ark-ec) Speedup fixed-base MSMs.
 - [\#28](https://github.com/arkworks-rs/algebra/pull/28) (ark-poly) Add `domain()` method on the `evaluations` struct.
 - [\#31](https://github.com/arkworks-rs/algebra/pull/31) (ark-ec) Speedup point doubling on twisted edwards curves.
@@ -110,6 +113,7 @@ The main features of this release are:
 - [\#242](https://github.com/arkworks-rs/algebra/pull/242), [\#244][https://github.com/arkworks-rs/algebra/pull/244] (ark-poly) Speedup the sequential radix-2 FFT significantly by making the method in which it accesses roots more cache-friendly.
 
 ### Bug fixes
+
 - [\#36](https://github.com/arkworks-rs/algebra/pull/36) (ark-ec) In Short-Weierstrass curves, include an infinity bit in `ToConstraintField`.
 - [\#107](https://github.com/arkworks-rs/algebra/pull/107) (ark-serialize) Fix handling of `(de)serialize_uncompressed/unchecked` in various impls of `CanonicalSerialize/Deserialize`.
 - [\#112](https://github.com/arkworks-rs/algebra/pull/112) (ark-serialize) Make `bool`s checked serialization methods non-malleable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# CHANGELOG
+
 ## Pending
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [\#261](https://github.com/arkworks-rs/algebra/pull/261) (ark-ff) Add support for 448-bit integers and fields.
 - [\#263](https://github.com/arkworks-rs/algebra/pull/263) (ark-ff) Add `From<iXXX>` implementations to fields.
 - [\#265](https://github.com/arkworks-rs/algebra/pull/265) (ark-serialize) Add hashing as an extension trait of `CanonicalSerialize`.
-- [\#280](https://github.com/arkworks-rs/algebra/pull/280) (ark-ff) Add `Into<BigUint>` and `From<BigUint>` implementations to `BigInteger`.
+- [\#280](https://github.com/arkworks-rs/algebra/pull/280) (ark-ff) Add `Into<BigUint>` and `From<BigUint>` implementations to `BigInteger` and `PrimeField`.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [\#261](https://github.com/arkworks-rs/algebra/pull/261) (ark-ff) Add support for 448-bit integers and fields.
 - [\#263](https://github.com/arkworks-rs/algebra/pull/263) (ark-ff) Add `From<iXXX>` implementations to fields.
 - [\#265](https://github.com/arkworks-rs/algebra/pull/265) (ark-serialize) Add hashing as an extension trait of `CanonicalSerialize`.
+- [\#280](https://github.com/arkworks-rs/algebra/pull/280) (ark-ff) Add `Into<BigUint>` and `From<BigUint>` implementations to `BigInteger`.
 
 ### Improvements
 

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -22,12 +22,10 @@ derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
 rayon = { version = "1", optional = true }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+num-bigint = { version = "0.4.0", default-features = false }
 
 [build-dependencies]
 rustc_version = "0.3"
-
-[dev-dependencies]
-num-bigint = { version = "0.4.0", default-features = false }
 
 [features]
 default = []

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -352,5 +352,48 @@ macro_rules! bigint_impl {
                 repr
             }
         }
+
+        impl From<BigUint> for $name {
+            #[inline]
+            fn from(val: BigUint) -> $name {
+                use num_traits::ToPrimitive;
+                use num_traits::Zero;
+
+                let mut tmp = val.clone();
+                let mut tmp2 = val.clone();
+
+                let mut limbs = [0u64; $num_limbs];
+
+                for i in 0..$num_limbs {
+                    tmp >>= 64;
+                    tmp <<= 64;
+
+                    limbs[i] = (tmp2 - tmp.clone()).to_u64().unwrap();
+
+                    tmp >>= 64;
+                    tmp2 = tmp.clone();
+                }
+
+                assert!(tmp.is_zero());
+
+                Self(limbs)
+            }
+        }
+
+        impl Into<BigUint> for $name {
+            #[inline]
+            fn into(self) -> BigUint {
+                use num_traits::Zero;
+
+                let mut sum = BigUint::zero();
+
+                for i in (0..$num_limbs).rev() {
+                    sum <<= 64;
+                    sum += self.0[i];
+                }
+
+                sum
+            }
+        }
     };
 }

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -367,8 +367,8 @@ macro_rules! bigint_impl {
                     .enumerate()
                     .for_each(|(i, chunk)| {
                         let mut chunk_padded = [0u8; 8];
-                        for i in 0..chunk.len() {
-                            chunk_padded[i] = chunk[i];
+                        for j in 0..chunk.len() {
+                            chunk_padded[j] = chunk[j];
                         }
                         limbs[i] = u64::from_le_bytes(chunk_padded)
                     });

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -375,9 +375,7 @@ macro_rules! bigint_impl {
                         .enumerate()
                         .for_each(|(i, chunk)| {
                             let mut chunk_padded = [0u8; 8];
-                            for j in 0..chunk.len() {
-                                chunk_padded[j] = chunk[j];
-                            }
+                            chunk_padded[..chunk.len()].copy_from_slice(chunk);
                             limbs[i] = u64::from_le_bytes(chunk_padded)
                         });
 

--- a/ff/src/biginteger/macros.rs
+++ b/ff/src/biginteger/macros.rs
@@ -362,7 +362,7 @@ macro_rules! bigint_impl {
 
                 if bytes.len() > $num_limbs * 8 {
                     Err(format!(
-                        "A BigUint with {} bytes cannot be converted into a {}.",
+                        "A BigUint of {} bytes cannot fit into a {}.",
                         bytes.len(),
                         ark_std::stringify!($name)
                     ))

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -14,6 +14,7 @@ use ark_std::{
     vec::Vec,
 };
 use zeroize::Zeroize;
+use num_bigint::BigUint;
 
 #[macro_use]
 pub mod arithmetic;
@@ -63,6 +64,8 @@ pub trait BigInteger:
     + AsMut<[u64]>
     + AsRef<[u64]>
     + From<u64>
+    + From<BigUint>
+    + Into<BigUint>
 {
     /// Number of limbs.
     const NUM_LIMBS: usize;

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -9,6 +9,7 @@ use ark_std::rand::{
     Rng,
 };
 use ark_std::{
+    convert::TryFrom,
     fmt::{Debug, Display},
     io::{Read, Result as IoResult, Write},
     vec::Vec,
@@ -65,7 +66,7 @@ pub trait BigInteger:
     + AsMut<[u64]>
     + AsRef<[u64]>
     + From<u64>
-    + From<BigUint>
+    + TryFrom<BigUint>
     + Into<BigUint>
 {
     /// Number of limbs.

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -13,8 +13,8 @@ use ark_std::{
     io::{Read, Result as IoResult, Write},
     vec::Vec,
 };
-use zeroize::Zeroize;
 use num_bigint::BigUint;
+use zeroize::Zeroize;
 
 #[macro_use]
 pub mod arithmetic;

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -62,7 +62,7 @@ fn biginteger_conversion_test<B: BigInteger>() {
 
     let x: B = UniformRand::rand(&mut rng);
     let x_bigint: BigUint = x.clone().into();
-    let x_recovered = <B as From<BigUint>>::from(x_bigint);
+    let x_recovered = B::try_from(x_bigint).ok().unwrap();
 
     assert_eq!(x, x_recovered);
 }

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -1,4 +1,5 @@
 use crate::{biginteger::BigInteger, UniformRand};
+use num_bigint::BigUint;
 
 fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
     // zero == zero
@@ -56,6 +57,16 @@ fn biginteger_bytes_test<B: BigInteger>() {
     assert_eq!(x, y);
 }
 
+fn biginteger_conversion_test<B: BigInteger>() {
+    let mut rng = ark_std::test_rng();
+
+    let x: B = UniformRand::rand(&mut rng);
+    let x_bigint: BigUint = x.clone().into();
+    let x_recovered = <B as From<BigUint>>::from(x_bigint);
+
+    assert_eq!(x, x_recovered);
+}
+
 fn test_biginteger<B: BigInteger>(zero: B) {
     let mut rng = ark_std::test_rng();
     let a: B = UniformRand::rand(&mut rng);
@@ -63,6 +74,7 @@ fn test_biginteger<B: BigInteger>(zero: B) {
     biginteger_arithmetic_test(a, b, zero);
     biginteger_bytes_test::<B>();
     biginteger_bits_test::<B>();
+    biginteger_conversion_test::<B>();
 }
 
 #[test]

--- a/ff/src/fields/arithmetic.rs
+++ b/ff/src/fields/arithmetic.rs
@@ -60,6 +60,7 @@ macro_rules! impl_field_into_repr {
     ($limbs:expr, $BigIntegerType:ty) => {
         #[inline]
         #[ark_ff_asm::unroll_for_loops]
+        #[allow(clippy::modulo_one)]
         fn into_repr(&self) -> $BigIntegerType {
             let mut tmp = self.0;
             let mut r = tmp.0;

--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -721,7 +721,7 @@ macro_rules! impl_Fp {
         impl<P: $FpParameters> From<num_bigint::BigUint> for $Fp<P> {
             #[inline]
             fn from(val: num_bigint::BigUint) -> $Fp<P> {
-                $Fp::<P>::from_repr(<$BigIntegerType>::from(val)).unwrap()
+                $Fp::<P>::from_le_bytes_mod_order(&val.to_bytes_le())
             }
         }
 

--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -717,5 +717,19 @@ macro_rules! impl_Fp {
                 self.0.zeroize();
             }
         }
+
+        impl<P: $FpParameters> From<num_bigint::BigUint> for $Fp<P> {
+            #[inline]
+            fn from(val: num_bigint::BigUint) -> $Fp<P> {
+                $Fp::<P>::from_repr(<$BigIntegerType>::from(val)).unwrap()
+            }
+        }
+
+        impl<P: $FpParameters> Into<num_bigint::BigUint> for $Fp<P> {
+            #[inline]
+            fn into(self) -> num_bigint::BigUint {
+                self.into_repr().into()
+            }
+        }
     }
 }

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -647,7 +647,7 @@ mod std_tests {
 #[cfg(test)]
 mod no_std_tests {
     use super::*;
-    use crate::test_field::Fr;
+    use crate::test_field::{Fr, FrParameters};
     use ark_std::test_rng;
 
     #[test]
@@ -673,6 +673,26 @@ mod no_std_tests {
                 rand_multiplier
             );
         }
+    }
+
+    #[test]
+    fn test_from_into_biguint() {
+        let mut rng = ark_std::test_rng();
+
+        let modulus_bits = FrParameters::MODULUS_BITS;
+        let modulus: num_bigint::BigUint = FrParameters::MODULUS.into();
+
+        let mut rand_bytes = Vec::new();
+        for _ in 0..(2 * modulus_bits / 8) {
+            rand_bytes.push(u8::rand(&mut rng));
+        }
+
+        let rand = BigUint::from_bytes_le(&rand_bytes);
+
+        let a: BigUint = Fr::from(rand.clone()).into();
+        let b = rand % modulus;
+
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -354,6 +354,8 @@ pub trait PrimeField:
     + FromStr
     + From<<Self as PrimeField>::BigInt>
     + Into<<Self as PrimeField>::BigInt>
+    + From<BigUint>
+    + Into<BigUint>
 {
     type Params: FpParameters<BigInt = Self::BigInt>;
     type BigInt: BigInteger;
@@ -549,6 +551,7 @@ use crate::biginteger::{
     BigInteger256, BigInteger320, BigInteger384, BigInteger448, BigInteger64, BigInteger768,
     BigInteger832,
 };
+use num_bigint::BigUint;
 
 impl_field_bigint_conv!(Fp64, BigInteger64, Fp64Parameters);
 impl_field_bigint_conv!(Fp256, BigInteger256, Fp256Parameters);


### PR DESCRIPTION
## Description

This PR partially handles the challenges of converting values between different fields, by allowing BigInteger of different sizes to convert between each other, through an intermediate representation `BigUint`. This can also make it easy to print a field element.

More support for field conversions is possible: We could implement the same thing for `PrimeField`, which likely is a simple wrapper of this. 

Note that it is also possible to enable `From<T: To<Uint>> for U: From<Uint>` so this can make the conversion simplest. I feel it is too risky since the enforcement of which field can be applied to which object can prevent certain misuse, and this more aggressive form may sacrifice such enforcement, especially conversions between different fields are, though useful, not occurring in the majority of the code.

closes: #271 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
