### PR TITLE
Resolve linter failure on PRs from external repos

### DIFF
--- a/.github/workflows/mdlinter.yml
+++ b/.github/workflows/mdlinter.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker://github/super-linter:latest
         env:
           LINTER_RULES_PATH: .github
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_MD: true


### PR DESCRIPTION
## Description

As discussed in #286, we discovered that in a number of PRs where the base repo is external, the linter fails.

This seems to be a bug of the super-linter, but fixing it is beyond our capacity. We noticed that the problem is related to `VALIDATE_ALL_CODEBASE = false`, in which case the super-linter will switch branches and find files that have been changed, and the super-linter will only perform linting on those files. The failure happens during the branch switch.

This PR, therefore, changes `VALIDATE_ALL_CODEBASE` to `true`. We expect that this change can get rid of such failures.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`