### PR TITLE
Implement the `Sum` trait for all `AffineCurve`

### DIFF
--- a/.github/.markdownlint.yml
+++ b/.github/.markdownlint.yml
@@ -11,3 +11,4 @@ MD025: false
 MD033: false
 # MD036 no-emphasis-as-heading
 MD036: false
+MD041: false

--- a/.github/workflows/mdlinter.yml
+++ b/.github/workflows/mdlinter.yml
@@ -28,3 +28,8 @@ jobs:
           MARKDOWN_CONFIG_FILE: .markdownlint.yml
           VALIDATE_PROTOBUF: false
           VALIDATE_JSCPD: false
+          # use Python Pylint as the only linter to avoid conflicts
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -12,10 +12,10 @@ problem_files=()
 
 # collect ill-formatted files
 for file in $(git diff --name-only --cached); do
-        if [ ${file: -3} == ".rs" ]; then
-                rustfmt +stable --check $file &>/dev/null
+        if [ "${file: -3}" == ".rs" ]; then
+                rustfmt +stable --check "$file" &>/dev/null
                 if [ $? != 0 ]; then
-                        problem_files+=($file)
+                        problem_files+=("$file")
                 fi
         fi
 done
@@ -26,7 +26,7 @@ if [ ${#problem_files[@]} == 0 ]; then
 else
   # reformat the files that need it and re-stage them.
   printf "[pre_commit] the following files were rustfmt'd before commit: \n"
-  for file in ${problem_files[@]}; do
+  for file in "${problem_files[@]}"; do
     rustfmt +stable $file
     git add $file
     printf "\033[0;32m    $file\033[0m \n"

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-rustfmt --version &>/dev/null
-if [ $? != 0 ]; then
+if rustfmt --version &>/dev/null; then
         printf "[pre_commit] \033[0;31merror\033[0m: \"rustfmt\" not available. \n"
         printf "[pre_commit] \033[0;31merror\033[0m: rustfmt can be installed via - \n"
         printf "[pre_commit] $ rustup component add rustfmt \n"
@@ -13,8 +12,7 @@ problem_files=()
 # collect ill-formatted files
 for file in $(git diff --name-only --cached); do
         if [ "${file: -3}" == ".rs" ]; then
-                rustfmt +stable --check "$file" &>/dev/null
-                if [ $? != 0 ]; then
+                if rustfmt +stable --check "$file" &>/dev/null; then
                         problem_files+=("$file")
                 fi
         fi
@@ -27,9 +25,9 @@ else
   # reformat the files that need it and re-stage them.
   printf "[pre_commit] the following files were rustfmt'd before commit: \n"
   for file in "${problem_files[@]}"; do
-    rustfmt +stable $file
-    git add $file
-    printf "\033[0;32m    $file\033[0m \n"
+    rustfmt +stable "$file"
+    git add "$file"
+    printf "\033[0;32m    %s\033[0m \n" "$file"
   done
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
 - [\#261](https://github.com/arkworks-rs/algebra/pull/261) (ark-ff) Add support for 448-bit integers and fields.
 - [\#263](https://github.com/arkworks-rs/algebra/pull/263) (ark-ff) Add `From<iXXX>` implementations to fields.
 - [\#265](https://github.com/arkworks-rs/algebra/pull/265) (ark-serialize) Add hashing as an extension trait of `CanonicalSerialize`.
-- [\#280](https://github.com/arkworks-rs/algebra/pull/280) (ark-ff) Add `Into<BigUint>` and `From<BigUint>` implementations to `BigInteger` and `PrimeField`.
 - [\#279](https://github.com/arkworks-rs/algebra/pull/279) (ark-ec) Parallelize miller loop operations for BLS12.
+- [\#280](https://github.com/arkworks-rs/algebra/pull/280) (ark-ff) Add `Into<BigUint>` and `From<BigUint>` implementations to `BigInteger` and `PrimeField`.
+- [\#289](https://github.com/arkworks-rs/algebra/pull/289) (ark-ec) Add `Sum` implementation for all `AffineCurve`.
 
 ### Improvements
 - [\#279](https://github.com/arkworks-rs/algebra/pull/279) (ark-ec) Parallelize miller loop operations for BLS12.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@
 - [\#289](https://github.com/arkworks-rs/algebra/pull/289) (ark-ec) Add `Sum` implementation for all `AffineCurve`.
 
 ### Improvements
+
 - [\#279](https://github.com/arkworks-rs/algebra/pull/279) (ark-ec) Parallelize miller loop operations for BLS12.
 
 ### Bug fixes
-- [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64.
 
 - [\#252](https://github.com/arkworks-rs/algebra/pull/252) (ark-ff) Fix prime field sampling when `REPR_SHIFT_BITS` is 64.
 - [\#284](https://github.com/arkworks-rs/algebra/pull/284) (ark-poly-benches) Fix the panic `subgroup_fft_in_place` benchmark for MNT6-753's Fr.

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -239,6 +239,8 @@ pub trait AffineCurve:
     + Zero
     + Neg<Output = Self>
     + Zeroize
+    + core::iter::Sum<Self>
+    + for<'a> core::iter::Sum<&'a Self>
     + From<<Self as AffineCurve>::Projective>
 {
     const COFACTOR: &'static [u64];

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -278,6 +278,22 @@ impl<P: Parameters> Default for GroupAffine<P> {
     }
 }
 
+impl<P: Parameters> core::iter::Sum<Self> for GroupAffine<P> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.map(|x| x.into_projective())
+            .sum::<GroupProjective<P>>()
+            .into()
+    }
+}
+
+impl<'a, P: Parameters> core::iter::Sum<&'a Self> for GroupAffine<P> {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.map(|x| x.into_projective())
+            .sum::<GroupProjective<P>>()
+            .into()
+    }
+}
+
 /// Jacobian coordinates for a point on an elliptic curve in short Weierstrass form,
 /// over the base field `P::BaseField`. This struct implements arithmetic
 /// via the Jacobian formulae

--- a/scripts/linkify_changelog.py
+++ b/scripts/linkify_changelog.py
@@ -1,7 +1,7 @@
-import re
-import sys
 import fileinput
 import os
+import re
+import sys
 
 # Set this to the name of the repo, if you don't want it to be read from the filesystem.
 # It assumes the changelog file is in the root of the repo.
@@ -11,7 +11,7 @@ repo_name = ""
 # with the valid mark down formatted link to it. e.g.
 # " [\#number](https://github.com/arkworks-rs/template/pull/<number>)
 # Note that if the number is for a an issue, github will auto-redirect you when you click the link.
-# It is safe to run the script multiple times in succession. 
+# It is safe to run the script multiple times in succession.
 #
 # Example usage $ python3 linkify_changelog.py ../CHANGELOG.md
 changelog_path = sys.argv[1]
@@ -21,6 +21,10 @@ if repo_name == "":
     repo_name = components[-2]
 
 for line in fileinput.input(inplace=True):
-    line = re.sub(r"\- #([0-9]*)", r"- [\\#\1](https://github.com/arkworks-rs/" + repo_name + r"/pull/\1)", line.rstrip())
+    line = re.sub(
+        r"\- #([0-9]*)",
+        r"- [\#\1](https://github.com/arkworks-rs/" + repo_name + r"/pull/\1)",
+        line.rstrip(),
+    )
     # edits the current file
     print(line)

--- a/scripts/test_vectors.py
+++ b/scripts/test_vectors.py
@@ -1,17 +1,17 @@
-
 def generate_from_bytes_mod_order_test_vector(modulus):
     def gen_vector(number):
         byte_arr = convert_int_to_byte_vec(number)
         # s = str(number % modulus)
         # return "(" + byte_arr + ", \"" + s + "\"),"
         return byte_arr + ","
+
     data = ["vec!["]
-    
-    small_values_to_test = [0, 1, 255, 256, 256*256 + 255]
+
+    small_values_to_test = [0, 1, 255, 256, 256 * 256 + 255]
     modulus_bits = int((len(bin(modulus)[2:]) + 7) / 8) * 8
     values_to_test = small_values_to_test + [
-        modulus >> 8, 
-        (modulus >> 8) + 1, 
+        modulus >> 8,
+        (modulus >> 8) + 1,
         modulus - 1,
         modulus,
         modulus + 1,
@@ -19,28 +19,33 @@ def generate_from_bytes_mod_order_test_vector(modulus):
         modulus * 256,
         17 + (1 << modulus_bits),
         19 + (1 << modulus_bits) + modulus,
-        81 + (1 << modulus_bits) * 256 + modulus]
-    
+        81 + (1 << modulus_bits) * 256 + modulus,
+    ]
+
     for i in values_to_test:
         data += ["// " + str(i)]
         data += [gen_vector(i)]
-    
+
     data += ["];"]
-    return '\n'.join(data)
+    return "\n".join(data)
+
 
 def convert_int_to_byte_vec(number):
     s = bin(number)[2:]
     num_bytes = int((len(s) + 7) / 8)
     s = s.zfill(num_bytes * 8)
-    
+
     byte_arr = []
     for i in range(num_bytes):
-        byte = s[i*8: (i+1)*8]
+        byte = s[i * 8: (i + 1) * 8]
         i = int(byte, 2)
         byte_arr += [str(i) + "u8"]
-    
-    data = ', '.join(byte_arr)
+
+    data = ", ".join(byte_arr)
     return "vec![" + data + "]"
 
-bls12_fr_mod = 52435875175126190479447740508185965837690552500527637822603658699938581184513
+
+bls12_fr_mod = (
+    52435875175126190479447740508185965837690552500527637822603658699938581184513
+)
 print(generate_from_bytes_mod_order_test_vector(bls12_fr_mod))

--- a/scripts/test_vectors.py
+++ b/scripts/test_vectors.py
@@ -37,7 +37,7 @@ def convert_int_to_byte_vec(number):
 
     byte_arr = []
     for i in range(num_bytes):
-        byte = s[i * 8: (i + 1) * 8]
+        byte = s[i * 8 : (i + 1) * 8]
         i = int(byte, 2)
         byte_arr += [str(i) + "u8"]
 

--- a/scripts/test_vectors.py
+++ b/scripts/test_vectors.py
@@ -37,7 +37,7 @@ def convert_int_to_byte_vec(number):
 
     byte_arr = []
     for i in range(num_bytes):
-        byte = s[i * 8:(i + 1) * 8]
+        byte = s[i * 8 : (i + 1) * 8]
         i = int(byte, 2)
         byte_arr += [str(i) + "u8"]
 

--- a/scripts/test_vectors.py
+++ b/scripts/test_vectors.py
@@ -37,7 +37,7 @@ def convert_int_to_byte_vec(number):
 
     byte_arr = []
     for i in range(num_bytes):
-        byte = s[i * 8 : (i + 1) * 8]
+        byte = s[i * 8:(i + 1) * 8]
         i = int(byte, 2)
         byte_arr += [str(i) + "u8"]
 

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+#![allow(clippy::eq_op)]
 use ark_ff::fields::{FftField, FftParameters, Field, LegendreSymbol, PrimeField, SquareRootField};
 use ark_serialize::{buffer_bit_byte_size, Flags, SWFlags};
 use ark_std::io::Cursor;

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -313,11 +313,9 @@ pub fn fft_field_test<F: FftField>() {
     if let Some(small_subgroup_base) = F::FftParams::SMALL_SUBGROUP_BASE {
         let small_subgroup_base_adicity = F::FftParams::SMALL_SUBGROUP_BASE_ADICITY.unwrap();
         let large_subgroup_root_of_unity = F::large_subgroup_root_of_unity().unwrap();
-        assert_eq!(
-            large_subgroup_root_of_unity.pow([(1 << F::FftParams::TWO_ADICITY)
-                * (small_subgroup_base as u64).pow(small_subgroup_base_adicity)]),
-            F::one()
-        );
+        let pow = (1 << F::FftParams::TWO_ADICITY)
+            * (small_subgroup_base as u64).pow(small_subgroup_base_adicity);
+        assert_eq!(large_subgroup_root_of_unity.pow([pow]), F::one());
 
         for i in 0..F::FftParams::TWO_ADICITY {
             for j in 0..small_subgroup_base_adicity {

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+#![allow(clippy::eq_op)]
 use ark_ec::group::Group;
 use ark_ff::{One, UniformRand, Zero};
 


### PR DESCRIPTION
## Description

George Gkitsas mentions that it would be convenient to have a `Sum` trait for `AffineCurve`, specifically SW curve's `GroupAffine`.

This PR adds the requirement that all `AffineCurve` must implement the `Sum` trait. 

It is useful to have this trait: a user who uses `+` or `+=` in SW's AffineCurve indeed would pay performance overhead --- there are unnecessary conversions between ProjectiveCurve and AffineCurve during each addition. A `Sum` trait implementation that avoids such unnecessary conversions can significantly boost the performance.

closes: #288 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

Feels skippable:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
