### PR TITLE
Remove ellipsis from readme's asm section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ RUSTFLAGS="-C target-feature=+bmi2,+adx" cargo +nightly test/build/bench --featu
 To enable this in the `Cargo.toml` of your own projects, enable the `asm` feature flag:
 
 ```toml
-...
 ark-ff = { version = "0.1", features = [ "asm" ] }
 ```
 


### PR DESCRIPTION
It is a syntax error for the toml code block and non-std. Other projects typically just put the single line that you copy paste into your toml
