### PR TITLE
Discuss: should we panic when powering 0 by 0?

### DIFF
--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -178,6 +178,12 @@ pub trait Field:
     /// least significant limb first.
     #[must_use]
     fn pow<S: AsRef<[u64]>>(&self, exp: S) -> Self {
+        // handle the special case when self = 0 and exp = 0
+        if self.is_zero() {
+            assert_ne!(exp.as_ref().iter().filter(|x| **x != 0u64).count(), 0);
+            return Self::zero();
+        }
+
         let mut res = Self::one();
 
         for i in BitIteratorBE::without_leading_zeros(exp) {
@@ -796,5 +802,15 @@ mod no_std_tests {
             let actual = Fr::from_be_bytes_mod_order(&i);
             assert_eq!(expected, actual, "failed on test {:?}", i);
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn pow_zero_by_zero() {
+        use crate::test_field::Fr;
+        use crate::Field;
+        use ark_std::Zero;
+
+        let _ = Fr::zero().pow(&[0u64, 0u64, 0u64, 0u64]);
     }
 }


### PR DESCRIPTION
## Description

This is half PR half discussion.

For `pow` function, there is a corner case when the base is zero and the pow is also zero. 

There are two ways to handle it:
1. panic, as in this PR
2. let it be "1", which is indeed an accepted practice in some fields. 

Note that this treatment is sort of for "soundness". It is hard to imagine a concrete application where the developer wants to power a value by "0".

Any opinions? Note that letting it be "1" is simpler. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Re-reviewed `Files changed` in the Github PR explorer

not ready:
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`