### PR TITLE
Remove Unnecessary PhantomData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Improvements
 
+- [\#310](https://github.com/arkworks-rs/algebra/pull/310) (ark-ec) Remove unnecessary internal `PhantomData`
+- [\#310](https://github.com/arkworks-rs/algebra/pull/310) (ark-ff) Remove unnecessary internal `PhantomData`
+
 ### Bug fixes
 
 ## v0.3.0

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -1,15 +1,13 @@
-use {
-    crate::{
-        models::{ModelParameters, SWModelParameters},
-        PairingEngine,
-    },
-    ark_ff::{
-        fp2::{Fp2, Fp2Parameters},
-        fp4::{Fp4, Fp4Parameters},
-        BitIteratorBE, Field, PrimeField, SquareRootField,
-    },
-    num_traits::{One, Zero},
+use crate::{
+    models::{ModelParameters, SWModelParameters},
+    PairingEngine,
 };
+use ark_ff::{
+    fp2::{Fp2, Fp2Parameters},
+    fp4::{Fp4, Fp4Parameters},
+    BitIteratorBE, Field, PrimeField, SquareRootField,
+};
+use num_traits::{One, Zero};
 
 use core::marker::PhantomData;
 

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -1,15 +1,13 @@
-use {
-    crate::{
-        models::{ModelParameters, SWModelParameters},
-        PairingEngine,
-    },
-    ark_ff::{
-        fp3::{Fp3, Fp3Parameters},
-        fp6_2over3::{Fp6, Fp6Parameters},
-        BitIteratorBE, Field, PrimeField, SquareRootField,
-    },
-    num_traits::{One, Zero},
+use crate::{
+    models::{ModelParameters, SWModelParameters},
+    PairingEngine,
 };
+use ark_ff::{
+    fp3::{Fp3, Fp3Parameters},
+    fp6_2over3::{Fp6, Fp6Parameters},
+    BitIteratorBE, Field, PrimeField, SquareRootField,
+};
+use num_traits::{One, Zero};
 
 use core::marker::PhantomData;
 

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -6,7 +6,6 @@ use ark_std::{
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     io::{Read, Result as IoResult, Write},
-    marker::PhantomData,
     ops::{Add, AddAssign, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -46,8 +45,6 @@ pub struct GroupAffine<P: Parameters> {
     pub x: P::BaseField,
     pub y: P::BaseField,
     pub infinity: bool,
-    #[derivative(Debug = "ignore")]
-    _params: PhantomData<P>,
 }
 
 impl<P: Parameters> PartialEq<GroupProjective<P>> for GroupAffine<P> {
@@ -74,12 +71,7 @@ impl<P: Parameters> Display for GroupAffine<P> {
 
 impl<P: Parameters> GroupAffine<P> {
     pub fn new(x: P::BaseField, y: P::BaseField, infinity: bool) -> Self {
-        Self {
-            x,
-            y,
-            infinity,
-            _params: PhantomData,
-        }
+        Self { x, y, infinity }
     }
 
     /// Multiply `self` by the cofactor of the curve, `P::COFACTOR`.
@@ -88,8 +80,8 @@ impl<P: Parameters> GroupAffine<P> {
         self.mul_bits(cofactor)
     }
 
-    /// Multiplies `self` by the scalar represented by `bits`. `bits` must be a big-endian
-    /// bit-wise decomposition of the scalar.
+    /// Multiplies `self` by the scalar represented by `bits`. `bits` must be a
+    /// big-endian bit-wise decomposition of the scalar.
     pub(crate) fn mul_bits(&self, bits: impl Iterator<Item = bool>) -> GroupProjective<P> {
         let mut res = GroupProjective::zero();
         // Skip leading zeros.
@@ -293,8 +285,8 @@ impl<'a, P: Parameters> core::iter::Sum<&'a Self> for GroupAffine<P> {
     }
 }
 
-/// Jacobian coordinates for a point on an elliptic curve in short Weierstrass form,
-/// over the base field `P::BaseField`. This struct implements arithmetic
+/// Jacobian coordinates for a point on an elliptic curve in short Weierstrass
+/// form, over the base field `P::BaseField`. This struct implements arithmetic
 /// via the Jacobian formulae
 #[derive(Derivative)]
 #[derivative(
@@ -307,8 +299,6 @@ pub struct GroupProjective<P: Parameters> {
     pub x: P::BaseField,
     pub y: P::BaseField,
     pub z: P::BaseField,
-    #[derivative(Debug = "ignore")]
-    _params: PhantomData<P>,
 }
 
 impl<P: Parameters> Display for GroupProjective<P> {
@@ -390,18 +380,12 @@ impl<P: Parameters> Default for GroupProjective<P> {
 
 impl<P: Parameters> GroupProjective<P> {
     pub fn new(x: P::BaseField, y: P::BaseField, z: P::BaseField) -> Self {
-        Self {
-            x,
-            y,
-            z,
-            _params: PhantomData,
-        }
+        Self { x, y, z }
     }
 }
 
 impl<P: Parameters> Zeroize for GroupProjective<P> {
     fn zeroize(&mut self) {
-        // `PhantomData` does not contain any data and thus does not need to be zeroized.
         self.x.zeroize();
         self.y.zeroize();
         self.z.zeroize();
@@ -469,8 +453,8 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
     }
 
     /// Sets `self = 2 * self`. Note that Jacobian formulae are incomplete, and
-    /// so doubling cannot be computed as `self + self`. Instead, this implementation
-    /// uses the following specialized doubling formulae:
+    /// so doubling cannot be computed as `self + self`. Instead, this
+    /// implementation uses the following specialized doubling formulae:
     /// * [`P::A` is zero](http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#doubling-dbl-2009-l)
     /// * [`P::A` is not zero](https://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html#doubling-dbl-2007-bl)
     fn double_in_place(&mut self) -> &mut Self {
@@ -541,8 +525,8 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         }
     }
 
-    /// When `other.is_normalized()` (i.e., `other.z == 1`), we can use a more efficient
-    /// [formula](http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl)
+    /// When `other.is_normalized()` (i.e., `other.z == 1`), we can use a more
+    /// efficient [formula](http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl)
     /// to compute `self + other`.
     fn add_assign_mixed(&mut self, other: &GroupAffine<P>) {
         if other.is_zero() {

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -6,16 +6,15 @@ use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, EdwardsFlags, SerializationError,
 };
-use ark_std::rand::{
-    distributions::{Distribution, Standard},
-    Rng,
-};
 use ark_std::{
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     io::{Read, Result as IoResult, Write},
-    marker::PhantomData,
     ops::{Add, AddAssign, MulAssign, Neg, Sub, SubAssign},
+    rand::{
+        distributions::{Distribution, Standard},
+        Rng,
+    },
     vec::Vec,
 };
 use num_traits::{One, Zero};
@@ -43,8 +42,6 @@ use rayon::prelude::*;
 pub struct GroupAffine<P: Parameters> {
     pub x: P::BaseField,
     pub y: P::BaseField,
-    #[derivative(Debug = "ignore")]
-    _params: PhantomData<P>,
 }
 
 impl<P: Parameters> Display for GroupAffine<P> {
@@ -55,11 +52,7 @@ impl<P: Parameters> Display for GroupAffine<P> {
 
 impl<P: Parameters> GroupAffine<P> {
     pub fn new(x: P::BaseField, y: P::BaseField) -> Self {
-        Self {
-            x,
-            y,
-            _params: PhantomData,
-        }
+        Self { x, y }
     }
 
     #[must_use]
@@ -67,8 +60,8 @@ impl<P: Parameters> GroupAffine<P> {
         self.mul_bits(BitIteratorBE::new(P::COFACTOR))
     }
 
-    /// Multiplies `self` by the scalar represented by `bits`. `bits` must be a big-endian
-    /// bit-wise decomposition of the scalar.
+    /// Multiplies `self` by the scalar represented by `bits`. `bits` must be a
+    /// big-endian bit-wise decomposition of the scalar.
     pub(crate) fn mul_bits(&self, bits: impl Iterator<Item = bool>) -> GroupProjective<P> {
         let mut res = GroupProjective::zero();
         for i in bits.skip_while(|b| !b) {
@@ -311,8 +304,6 @@ pub struct GroupProjective<P: Parameters> {
     pub y: P::BaseField,
     pub t: P::BaseField,
     pub z: P::BaseField,
-    #[derivative(Debug = "ignore")]
-    _params: PhantomData<P>,
 }
 
 impl<P: Parameters> PartialEq<GroupProjective<P>> for GroupAffine<P> {
@@ -398,13 +389,7 @@ impl<P: Parameters> Default for GroupProjective<P> {
 
 impl<P: Parameters> GroupProjective<P> {
     pub fn new(x: P::BaseField, y: P::BaseField, t: P::BaseField, z: P::BaseField) -> Self {
-        Self {
-            x,
-            y,
-            t,
-            z,
-            _params: PhantomData,
-        }
+        Self { x, y, t, z }
     }
 }
 impl<P: Parameters> Zeroize for GroupProjective<P> {
@@ -695,8 +680,6 @@ where
 pub struct MontgomeryGroupAffine<P: MontgomeryParameters> {
     pub x: P::BaseField,
     pub y: P::BaseField,
-    #[derivative(Debug = "ignore")]
-    _params: PhantomData<P>,
 }
 
 impl<P: MontgomeryParameters> Display for MontgomeryGroupAffine<P> {
@@ -707,11 +690,7 @@ impl<P: MontgomeryParameters> Display for MontgomeryGroupAffine<P> {
 
 impl<P: MontgomeryParameters> MontgomeryGroupAffine<P> {
     pub fn new(x: P::BaseField, y: P::BaseField) -> Self {
-        Self {
-            x,
-            y,
-            _params: PhantomData,
-        }
+        Self { x, y }
     }
 }
 

--- a/ec/src/msm/fixed_base.rs
+++ b/ec/src/msm/fixed_base.rs
@@ -1,7 +1,6 @@
 use crate::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, FpParameters, PrimeField};
-use ark_std::vec::Vec;
-use ark_std::{cfg_iter, cfg_iter_mut};
+use ark_std::{cfg_iter, cfg_iter_mut, vec::Vec};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/ff-asm/src/lib.rs
+++ b/ff-asm/src/lib.rs
@@ -157,7 +157,7 @@ fn generate_llvm_asm_mul_string(
 ) -> String {
     let llvm_asm_string = RefCell::new(String::new());
 
-    let begin = || llvm_asm_string.borrow_mut().push_str("\"");
+    let begin = || llvm_asm_string.borrow_mut().push('\"');
 
     let end = || {
         llvm_asm_string.borrow_mut().push_str(

--- a/ff-asm/src/unroll.rs
+++ b/ff-asm/src/unroll.rs
@@ -1,21 +1,25 @@
-//! An attribute-like procedural macro for unrolling for loops with integer literal bounds.
+//! An attribute-like procedural macro for unrolling for loops with integer
+//! literal bounds.
 //!
-//! This crate provides the [`unroll_for_loops`](../attr.unroll_for_loops.html) attribute-like macro that can be applied to
-//! functions containing for-loops with integer bounds. This macro looks for loops to unroll and
-//! unrolls them at compile time.
+//! This crate provides the [`unroll_for_loops`](../attr.unroll_for_loops.html)
+//! attribute-like macro that can be applied to functions containing for-loops
+//! with integer bounds. This macro looks for loops to unroll and unrolls them
+//! at compile time.
 //!
 //!
 //! ## Usage
 //!
-//! Just add `#[unroll_for_loops]` above the function whose for loops you would like to unroll.
-//! Currently all for loops with integer literal bounds will be unrolled, although this macro
-//! currently can't see inside complex code (e.g. for loops within closures).
+//! Just add `#[unroll_for_loops]` above the function whose for loops you would
+//! like to unroll. Currently all for loops with integer literal bounds will be
+//! unrolled, although this macro currently can't see inside complex code (e.g.
+//! for loops within closures).
 //!
 //!
 //! ## Example
 //!
-//! The following function computes a matrix-vector product and returns the result as an array.
-//! Both of the inner for-loops are unrolled when `#[unroll_for_loops]` is applied.
+//! The following function computes a matrix-vector product and returns the
+//! result as an array. Both of the inner for-loops are unrolled when
+//! `#[unroll_for_loops]` is applied.
 //!
 //! ```rust
 //! use ark_ff_asm::unroll_for_loops;
@@ -34,10 +38,9 @@
 //!
 //! This code was adapted from the [`unroll`](https://crates.io/crates/unroll) crate.
 
-use syn::token::Brace;
 use syn::{
-    parse_quote, Block, Expr, ExprBlock, ExprForLoop, ExprIf, ExprLet, ExprLit, ExprRange, Lit,
-    Pat, PatIdent, RangeLimits, Stmt,
+    parse_quote, token::Brace, Block, Expr, ExprBlock, ExprForLoop, ExprIf, ExprLet, ExprLit,
+    ExprRange, Lit, Pat, PatIdent, RangeLimits, Stmt,
 };
 
 /// Routine to unroll for loops within a block
@@ -62,8 +65,8 @@ pub(crate) fn unroll_in_block(block: &Block) -> Block {
     }
 }
 
-/// Routine to unroll a for loop statement, or return the statement unchanged if it's not a for
-/// loop.
+/// Routine to unroll a for loop statement, or return the statement unchanged if
+/// it's not a for loop.
 fn unroll(expr: &Expr) -> Expr {
     // impose a scope that we can break out of so we can return stmt without copying it.
     if let Expr::ForLoop(for_loop) = expr {

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -4,14 +4,14 @@ use crate::{
     UniformRand,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
-use ark_std::rand::{
-    distributions::{Distribution, Standard},
-    Rng,
-};
 use ark_std::{
     convert::TryFrom,
     fmt::{Debug, Display},
     io::{Read, Result as IoResult, Write},
+    rand::{
+        distributions::{Distribution, Standard},
+        Rng,
+    },
     vec::Vec,
 };
 use num_bigint::BigUint;

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -51,18 +51,13 @@ macro_rules! field_new {
         )
     }};
     ($name:ident, $c0:expr, $c1:expr $(,)?) => {
-        $name {
-            c0: $c0,
-            c1: $c1,
-            _parameters: core::marker::PhantomData,
-        }
+        $name { c0: $c0, c1: $c1 }
     };
     ($name:ident, $c0:expr, $c1:expr, $c2:expr $(,)?) => {
         $name {
             c0: $c0,
             c1: $c1,
             c2: $c2,
-            _parameters: core::marker::PhantomData,
         }
     };
 }
@@ -698,11 +693,10 @@ mod no_std_tests {
     #[test]
     fn test_from_be_bytes_mod_order() {
         // Each test vector is a byte array,
-        // and its tested by parsing it with from_bytes_mod_order, and the num-bigint library.
-        // The bytes are currently generated from scripts/test_vectors.py.
+        // and its tested by parsing it with from_bytes_mod_order, and the num-bigint
+        // library. The bytes are currently generated from scripts/test_vectors.py.
         // TODO: Eventually generate all the test vector bytes via computation with the modulus
-        use ark_std::rand::Rng;
-        use ark_std::string::ToString;
+        use ark_std::{rand::Rng, string::ToString};
         use num_bigint::BigUint;
 
         let ref_modulus =

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -6,7 +6,6 @@ use ark_std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt,
     io::{Read, Result as IoResult, Write},
-    marker::PhantomData,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -74,19 +73,11 @@ pub struct CubicExtField<P: CubicExtParameters> {
     pub c0: P::BaseField,
     pub c1: P::BaseField,
     pub c2: P::BaseField,
-    #[derivative(Debug = "ignore")]
-    #[doc(hidden)]
-    pub _parameters: PhantomData<P>,
 }
 
 impl<P: CubicExtParameters> CubicExtField<P> {
     pub fn new(c0: P::BaseField, c1: P::BaseField, c2: P::BaseField) -> Self {
-        CubicExtField {
-            c0,
-            c1,
-            c2,
-            _parameters: PhantomData,
-        }
+        Self { c0, c1, c2 }
     }
 
     pub fn mul_assign_by_base_field(&mut self, value: &P::BaseField) {
@@ -109,12 +100,11 @@ impl<P: CubicExtParameters> CubicExtField<P> {
 
 impl<P: CubicExtParameters> Zero for CubicExtField<P> {
     fn zero() -> Self {
-        CubicExtField {
-            c0: P::BaseField::zero(),
-            c1: P::BaseField::zero(),
-            c2: P::BaseField::zero(),
-            _parameters: PhantomData,
-        }
+        Self::new(
+            P::BaseField::zero(),
+            P::BaseField::zero(),
+            P::BaseField::zero(),
+        )
     }
 
     fn is_zero(&self) -> bool {
@@ -124,12 +114,11 @@ impl<P: CubicExtParameters> Zero for CubicExtField<P> {
 
 impl<P: CubicExtParameters> One for CubicExtField<P> {
     fn one() -> Self {
-        CubicExtField {
-            c0: P::BaseField::one(),
-            c1: P::BaseField::zero(),
-            c2: P::BaseField::zero(),
-            _parameters: PhantomData,
-        }
+        Self::new(
+            P::BaseField::one(),
+            P::BaseField::zero(),
+            P::BaseField::zero(),
+        )
     }
 
     fn is_one(&self) -> bool {

--- a/ff/src/fields/models/fp12_2over3over2.rs
+++ b/ff/src/fields/models/fp12_2over3over2.rs
@@ -3,8 +3,10 @@ use crate::{
     fields::{fp6_3over2::*, Field, Fp2, Fp2Parameters},
     One,
 };
-use core::marker::PhantomData;
-use core::ops::{AddAssign, SubAssign};
+use core::{
+    marker::PhantomData,
+    ops::{AddAssign, SubAssign},
+};
 
 type Fp2Params<P> = <<P as Fp12Parameters>::Fp6Params as Fp6Parameters>::Fp2Params;
 

--- a/ff/src/fields/models/fp6_2over3.rs
+++ b/ff/src/fields/models/fp6_2over3.rs
@@ -1,6 +1,5 @@
 use super::quadratic_extension::*;
-use core::marker::PhantomData;
-use core::ops::MulAssign;
+use core::{marker::PhantomData, ops::MulAssign};
 
 use crate::fields::{Fp3, Fp3Parameters};
 

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -6,7 +6,6 @@ use ark_std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt,
     io::{Read, Result as IoResult, Write},
-    marker::PhantomData,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -134,26 +133,21 @@ pub trait QuadExtParameters: 'static + Send + Sync + Sized {
 pub struct QuadExtField<P: QuadExtParameters> {
     pub c0: P::BaseField,
     pub c1: P::BaseField,
-    #[derivative(Debug = "ignore")]
-    #[doc(hidden)]
-    pub _parameters: PhantomData<P>,
 }
 
 impl<P: QuadExtParameters> QuadExtField<P> {
     pub fn new(c0: P::BaseField, c1: P::BaseField) -> Self {
-        QuadExtField {
-            c0,
-            c1,
-            _parameters: PhantomData,
-        }
+        Self { c0, c1 }
     }
 
-    /// This is only to be used when the element is *known* to be in the cyclotomic subgroup.
+    /// This is only to be used when the element is *known* to be in the
+    /// cyclotomic subgroup.
     pub fn conjugate(&mut self) {
         self.c1 = -self.c1;
     }
 
-    /// This is only to be used when the element is *known* to be in the cyclotomic subgroup.
+    /// This is only to be used when the element is *known* to be in the
+    /// cyclotomic subgroup.
     pub fn cyclotomic_exp(&self, exponent: impl AsRef<[u64]>) -> Self {
         P::cyclotomic_exp(self, exponent)
     }

--- a/ff/src/test_field/mod.rs
+++ b/ff/src/test_field/mod.rs
@@ -69,7 +69,8 @@ pub(crate) mod fr {
 
         /// GENERATOR = 7
         /// Encoded in Montgomery form, so the value here is
-        /// 7 * R % q = 24006497034320510773280787438025867407531605151569380937148207556313189711857
+        /// 7 * R % q =
+        /// 24006497034320510773280787438025867407531605151569380937148207556313189711857
         #[rustfmt::skip]
         const GENERATOR: BigInteger = BigInteger([
             0xefffffff1,
@@ -181,7 +182,8 @@ pub(crate) mod fq {
 
         /// GENERATOR = -5
         /// Encoded in Montgomery form, so the value here is
-        /// (-5 * R) % q = 92261639910053574722182574790803529333160366917737991650341130812388023949653897454961487930322210790384999596794
+        /// (-5 * R) % q =
+        /// 92261639910053574722182574790803529333160366917737991650341130812388023949653897454961487930322210790384999596794
         #[rustfmt::skip]
         const GENERATOR: BigInteger = BigInteger([
             0xfc0b8000000002fa,

--- a/poly-benches/benches/dense_multilinear.rs
+++ b/poly-benches/benches/dense_multilinear.rs
@@ -3,8 +3,7 @@ extern crate criterion;
 
 use ark_ff::Field;
 use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
-use ark_std::ops::Range;
-use ark_std::test_rng;
+use ark_std::{ops::Range, test_rng};
 use ark_test_curves::bls12_381;
 use criterion::{black_box, BenchmarkId, Criterion};
 

--- a/poly-benches/benches/dense_uv_polynomial.rs
+++ b/poly-benches/benches/dense_uv_polynomial.rs
@@ -2,14 +2,13 @@ extern crate criterion;
 
 use ark_ff::Field;
 use ark_poly::{
-    polynomial::univariate::DensePolynomial, polynomial::univariate::SparsePolynomial, Polynomial,
-    UVPolynomial,
+    polynomial::univariate::{DensePolynomial, SparsePolynomial},
+    Polynomial, UVPolynomial,
 };
 use ark_poly_benches::size_range;
 use ark_std::rand::Rng;
 use ark_test_curves::bls12_381::Fr as bls12_381_fr;
-use criterion::BenchmarkId;
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
 
 const BENCHMARK_MIN_DEGREE: usize = 1 << 15;
 const BENCHMARK_MAX_DEGREE: usize = 1 << 17;

--- a/poly-benches/benches/fft.rs
+++ b/poly-benches/benches/fft.rs
@@ -1,13 +1,13 @@
 extern crate criterion;
 
 use ark_ff::FftField;
-use ark_poly::{polynomial::univariate::DensePolynomial, polynomial::UVPolynomial};
-use ark_poly::{EvaluationDomain, MixedRadixEvaluationDomain, Radix2EvaluationDomain};
+use ark_poly::{
+    polynomial::{univariate::DensePolynomial, UVPolynomial},
+    EvaluationDomain, MixedRadixEvaluationDomain, Radix2EvaluationDomain,
+};
 use ark_poly_benches::size_range;
-use ark_test_curves::bls12_381::Fr as bls12_381_fr;
-use ark_test_curves::mnt4_753::Fq as mnt6_753_fr;
-use criterion::BenchmarkId;
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use ark_test_curves::{bls12_381::Fr as bls12_381_fr, mnt4_753::Fq as mnt6_753_fr};
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
 
 // degree bounds to benchmark on
 // e.g. degree bound of 2^{15}, means we do an FFT for a degree (2^{15} - 1) polynomial

--- a/poly-benches/benches/sparse_multilinear.rs
+++ b/poly-benches/benches/sparse_multilinear.rs
@@ -3,8 +3,7 @@ extern crate criterion;
 
 use ark_ff::Field;
 use ark_poly::{MultilinearExtension, SparseMultilinearExtension};
-use ark_std::ops::Range;
-use ark_std::test_rng;
+use ark_std::{ops::Range, test_rng};
 use ark_test_curves::bls12_381;
 use criterion::{black_box, BenchmarkId, Criterion};
 

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -260,13 +260,10 @@ impl<F: FftField> Iterator for GeneralElements<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::polynomial::Polynomial;
-    use crate::{EvaluationDomain, GeneralEvaluationDomain};
+    use crate::{polynomial::Polynomial, EvaluationDomain, GeneralEvaluationDomain};
     use ark_ff::Zero;
-    use ark_std::rand::Rng;
-    use ark_std::test_rng;
-    use ark_test_curves::bls12_381::Fr;
-    use ark_test_curves::bn384_small_two_adicity::Fr as BNFr;
+    use ark_std::{rand::Rng, test_rng};
+    use ark_test_curves::{bls12_381::Fr, bn384_small_two_adicity::Fr as BNFr};
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -405,11 +405,9 @@ pub(crate) fn serial_mixed_radix_fft<T: DomainCoeff<F>, F: FftField>(
 
 #[cfg(test)]
 mod tests {
-    use crate::polynomial::Polynomial;
-    use crate::{EvaluationDomain, MixedRadixEvaluationDomain};
+    use crate::{polynomial::Polynomial, EvaluationDomain, MixedRadixEvaluationDomain};
     use ark_ff::{Field, Zero};
-    use ark_std::rand::Rng;
-    use ark_std::test_rng;
+    use ark_std::{rand::Rng, test_rng};
     use ark_test_curves::bn384_small_two_adicity::Fq as Fr;
 
     #[test]

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -9,8 +9,7 @@
 
 use ark_ff::FftField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::rand::Rng;
-use ark_std::{fmt, hash, vec::Vec};
+use ark_std::{fmt, hash, rand::Rng, vec::Vec};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -1,8 +1,7 @@
 // The code below is a port of the excellent library of https://github.com/kwantam/fffft by Riad S. Wahby
 // to the arkworks APIs
 
-use crate::domain::utils::compute_powers_serial;
-use crate::domain::{radix2::*, DomainCoeff};
+use crate::domain::{radix2::*, utils::compute_powers_serial, DomainCoeff};
 use ark_ff::FftField;
 use ark_std::{cfg_chunks_mut, vec::Vec};
 #[cfg(feature = "parallel")]
@@ -12,9 +11,11 @@ use rayon::prelude::*;
 enum FFTOrder {
     /// Both the input and the output of the FFT must be in-order.
     II,
-    /// The input of the FFT must be in-order, but the output does not have to be.
+    /// The input of the FFT must be in-order, but the output does not have to
+    /// be.
     IO,
-    /// The input of the FFT can be out of order, but the output must be in-order.
+    /// The input of the FFT can be out of order, but the output must be
+    /// in-order.
     OI,
 }
 
@@ -284,8 +285,8 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
 /// is beneficial.
 const MIN_NUM_CHUNKS_FOR_COMPACTION: usize = 1 << 7;
 
-/// The minimum size of a chunk at which parallelization of `butterfly`s is beneficial.
-/// This value was chosen empirically.
+/// The minimum size of a chunk at which parallelization of `butterfly`s is
+/// beneficial. This value was chosen empirically.
 const MIN_GAP_SIZE_FOR_PARALLELISATION: usize = 1 << 10;
 
 // minimum size at which to parallelize.

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -124,8 +124,9 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
         // We then compute L_{i,H}(tau) as `L_{i,H}(tau) = Z_H(tau) * v_i / (tau - h g^i)`
         //
         // However, if tau in H, both the numerator and denominator equal 0
-        // when i corresponds to the value tau equals, and the coefficient is 0 everywhere else.
-        // We handle this case separately, and we can easily detect by checking if the vanishing poly is 0.
+        // when i corresponds to the value tau equals, and the coefficient is 0
+        // everywhere else. We handle this case separately, and we can easily
+        // detect by checking if the vanishing poly is 0.
         let size = self.size();
         // TODO: Make this use the vanishing polynomial
         let z_h_at_tau = tau.pow(&[self.size]) - F::one();
@@ -210,12 +211,13 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::Vec;
-    use crate::polynomial::{univariate::*, Polynomial, UVPolynomial};
-    use crate::{EvaluationDomain, Radix2EvaluationDomain};
+    use crate::{
+        domain::Vec,
+        polynomial::{univariate::*, Polynomial, UVPolynomial},
+        EvaluationDomain, Radix2EvaluationDomain,
+    };
     use ark_ff::{FftField, Field, One, UniformRand, Zero};
-    use ark_std::rand::Rng;
-    use ark_std::test_rng;
+    use ark_std::{rand::Rng, test_rng};
     use ark_test_curves::bls12_381::Fr;
 
     #[test]
@@ -266,7 +268,8 @@ mod tests {
         }
     }
 
-    /// Test that lagrange interpolation for a random polynomial at a random point works.
+    /// Test that lagrange interpolation for a random polynomial at a random
+    /// point works.
     #[test]
     fn non_systematic_lagrange_coefficients_test() {
         for domain_dim in 1..10 {
@@ -293,8 +296,8 @@ mod tests {
     /// Test that lagrange coefficients for a point in the domain is correct
     #[test]
     fn systematic_lagrange_coefficients_test() {
-        // This runs in time O(N^2) in the domain size, so keep the domain dimension low.
-        // We generate lagrange coefficients for each element in the domain.
+        // This runs in time O(N^2) in the domain size, so keep the domain dimension
+        // low. We generate lagrange coefficients for each element in the domain.
         for domain_dim in 1..5 {
             let domain_size = 1 << domain_dim;
             let domain = Radix2EvaluationDomain::<Fr>::new(domain_size).unwrap();

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -148,16 +148,17 @@ pub(crate) fn parallel_fft<T: DomainCoeff<F>, F: FftField>(
             // Where c represents the index of the coset being considered.
             // multiplying by g^{k*i} corresponds to the shift for just being in a different coset.
             //
-            // TODO: Come back and improve the speed, and make this a more 'normal' Cooley-Tukey.
-            // This appears to be an FFT of the polynomial
+            // TODO: Come back and improve the speed, and make this a more 'normal'
+            // Cooley-Tukey. This appears to be an FFT of the polynomial
             // `P(x) = sum_{c in |coset|} a[i + c |coset|] * x^c`
             // onto this coset.
-            // However this is being evaluated in time O(N) instead of time O(|coset|log(|coset|)).
-            // If this understanding is the case, its not doing standard Cooley-Tukey.
-            // At the moment, this has time complexity of at least 2*N field mul's per thread,
-            // so we will be getting pretty bad parallelism.
-            // Exact complexity per thread atm is `2N + (N/num threads)log(N/num threads)` field muls
-            // Compare to the time complexity of serial is Nlog(N) field muls), with log(N) in [15, 25]
+            // However this is being evaluated in time O(N) instead of time
+            // O(|coset|log(|coset|)). If this understanding is the case, its not
+            // doing standard Cooley-Tukey. At the moment, this has time complexity
+            // of at least 2*N field mul's per thread, so we will be getting
+            // pretty bad parallelism. Exact complexity per thread atm is
+            // `2N + (N/num threads)log(N/num threads)` field muls Compare to the time
+            // complexity of serial is Nlog(N) field muls), with log(N) in [15, 25]
             for i in 0..coset_size {
                 for c in 0..num_threads {
                     let idx = i + (c * coset_size);

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -3,12 +3,14 @@
 use crate::evaluations::multivariate::multilinear::{swap_bits, MultilinearExtension};
 use ark_ff::{Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
-use ark_std::fmt;
-use ark_std::fmt::Formatter;
-use ark_std::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
-use ark_std::rand::Rng;
-use ark_std::slice::{Iter, IterMut};
-use ark_std::vec::Vec;
+use ark_std::{
+    fmt,
+    fmt::Formatter,
+    ops::{Add, AddAssign, Index, Neg, Sub, SubAssign},
+    rand::Rng,
+    slice::{Iter, IterMut},
+    vec::Vec,
+};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -23,13 +25,15 @@ pub struct DenseMultilinearExtension<F: Field> {
 
 impl<F: Field> DenseMultilinearExtension<F> {
     /// Construct a new polynomial from a list of evaluations where the index
-    /// represents a point in {0,1}^`num_vars` in little endian form. For example, `0b1011` represents `P(1,1,0,1)`
+    /// represents a point in {0,1}^`num_vars` in little endian form. For
+    /// example, `0b1011` represents `P(1,1,0,1)`
     pub fn from_evaluations_slice(num_vars: usize, evaluations: &[F]) -> Self {
         Self::from_evaluations_vec(num_vars, evaluations.to_vec())
     }
 
     /// Construct a new polynomial from a list of evaluations where the index
-    /// represents a point in {0,1}^`num_vars` in little endian form. For example, `0b1011` represents `P(1,1,0,1)`
+    /// represents a point in {0,1}^`num_vars` in little endian form. For
+    /// example, `0b1011` represents `P(1,1,0,1)`
     pub fn from_evaluations_vec(num_vars: usize, evaluations: Vec<F>) -> Self {
         // assert that the number of variables matches the size of evaluations
         assert_eq!(
@@ -43,7 +47,8 @@ impl<F: Field> DenseMultilinearExtension<F> {
             evaluations,
         }
     }
-    /// Relabel the point inplace by switching `k` scalars from position `a` to position `b`, and from position `b` to position `a` in vector.
+    /// Relabel the point inplace by switching `k` scalars from position `a` to
+    /// position `b`, and from position `b` to position `a` in vector.
     ///
     /// This function turns `P(x_1,...,x_a,...,x_{a+k - 1},...,x_b,...,x_{b+k - 1},...,x_n)`
     /// to `P(x_1,...,x_b,...,x_{b+k - 1},...,x_a,...,x_{a+k - 1},...,x_n)`
@@ -133,7 +138,8 @@ impl<F: Field> Index<usize> for DenseMultilinearExtension<F> {
 
     /// Returns the evaluation of the polynomial at a point represented by index.
     ///
-    /// Index represents a vector in {0,1}^`num_vars` in little endian form. For example, `0b1011` represents `P(1,1,0,1)`
+    /// Index represents a vector in {0,1}^`num_vars` in little endian form. For
+    /// example, `0b1011` represents `P(1,1,0,1)`
     ///
     /// For dense multilinear polynomial, `index` takes constant time.
     fn index(&self, index: usize) -> &Self::Output {
@@ -267,12 +273,9 @@ impl<F: Field> Zero for DenseMultilinearExtension<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::DenseMultilinearExtension;
-    use crate::MultilinearExtension;
+    use crate::{DenseMultilinearExtension, MultilinearExtension};
     use ark_ff::{Field, Zero};
-    use ark_std::ops::Neg;
-    use ark_std::vec::Vec;
-    use ark_std::{test_rng, UniformRand};
+    use ark_std::{ops::Neg, test_rng, vec::Vec, UniformRand};
     use ark_test_curves::bls12_381::Fr;
 
     /// utility: evaluate multilinear extension (in form of data array) at a random point

--- a/poly/src/evaluations/multivariate/multilinear/mod.rs
+++ b/poly/src/evaluations/multivariate/multilinear/mod.rs
@@ -4,10 +4,12 @@ mod sparse;
 pub use dense::DenseMultilinearExtension;
 pub use sparse::SparseMultilinearExtension;
 
-use ark_std::fmt::Debug;
-use ark_std::hash::Hash;
-use ark_std::ops::{Add, AddAssign, Index, Neg, SubAssign};
-use ark_std::vec::Vec;
+use ark_std::{
+    fmt::Debug,
+    hash::Hash,
+    ops::{Add, AddAssign, Index, Neg, SubAssign},
+    vec::Vec,
+};
 
 use ark_ff::{Field, Zero};
 
@@ -16,10 +18,11 @@ use ark_std::rand::Rng;
 
 /// This trait describes an interface for the multilinear extension
 /// of an array.
-/// The latter is a multilinear polynomial represented in terms of its evaluations over
-/// the domain {0,1}^`num_vars` (i.e. the Boolean hypercube).
+/// The latter is a multilinear polynomial represented in terms of its
+/// evaluations over the domain {0,1}^`num_vars` (i.e. the Boolean hypercube).
 ///
-/// Index represents a point, which is a vector in {0,1}^`num_vars` in little endian form. For example, `0b1011` represents `P(1,1,0,1)`
+/// Index represents a point, which is a vector in {0,1}^`num_vars` in little
+/// endian form. For example, `0b1011` represents `P(1,1,0,1)`
 pub trait MultilinearExtension<F: Field>:
     Sized
     + Clone
@@ -44,20 +47,24 @@ pub trait MultilinearExtension<F: Field>:
     /// If the number of variables does not match, return `None`.
     fn evaluate(&self, point: &[F]) -> Option<F>;
 
-    /// Outputs an `l`-variate multilinear extension where value of evaluations are sampled uniformly at random.
+    /// Outputs an `l`-variate multilinear extension where value of evaluations
+    /// are sampled uniformly at random.
     fn rand<R: Rng>(num_vars: usize, rng: &mut R) -> Self;
 
-    /// Relabel the point by swapping `k` scalars from positions `a..a+k` to positions `b..b+k`,
-    /// and from position `b..b+k` to position `a..a+k` in vector.
+    /// Relabel the point by swapping `k` scalars from positions `a..a+k` to
+    /// positions `b..b+k`, and from position `b..b+k` to position `a..a+k`
+    /// in vector.
     ///
     /// This function turns `P(x_1,...,x_a,...,x_{a+k - 1},...,x_b,...,x_{b+k - 1},...,x_n)`
     /// to `P(x_1,...,x_b,...,x_{b+k - 1},...,x_a,...,x_{a+k - 1},...,x_n)`
     fn relabel(&self, a: usize, b: usize, k: usize) -> Self;
 
-    /// Reduce the number of variables of `self` by fixing the `partial_point.len()` variables at `partial_point`.
+    /// Reduce the number of variables of `self` by fixing the
+    /// `partial_point.len()` variables at `partial_point`.
     fn fix_variables(&self, partial_point: &[F]) -> Self;
 
-    /// Returns a list of evaluations over the domain, which is the boolean hypercube.
+    /// Returns a list of evaluations over the domain, which is the boolean
+    /// hypercube.
     fn to_evaluations(&self) -> Vec<F>;
 }
 

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -1,16 +1,21 @@
 //! multilinear polynomial represented in sparse evaluation form.
 
-use crate::evaluations::multivariate::multilinear::swap_bits;
-use crate::{DenseMultilinearExtension, MultilinearExtension};
+use crate::{
+    evaluations::multivariate::multilinear::swap_bits, DenseMultilinearExtension,
+    MultilinearExtension,
+};
 use ark_ff::{Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
-use ark_std::collections::BTreeMap;
-use ark_std::fmt::{Debug, Formatter};
-use ark_std::iter::FromIterator;
-use ark_std::ops::{Add, AddAssign, Index, Neg, Sub, SubAssign};
-use ark_std::rand::Rng;
-use ark_std::vec::Vec;
-use ark_std::{fmt, UniformRand};
+use ark_std::{
+    collections::BTreeMap,
+    fmt,
+    fmt::{Debug, Formatter},
+    iter::FromIterator,
+    ops::{Add, AddAssign, Index, Neg, Sub, SubAssign},
+    rand::Rng,
+    vec::Vec,
+    UniformRand,
+};
 use hashbrown::HashMap;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -47,11 +52,14 @@ impl<F: Field> SparseMultilinearExtension<F> {
         }
     }
 
-    /// Outputs an `l`-variate multilinear extension where value of evaluations are sampled uniformly at random.
-    /// The number of nonzero entries is `num_nonzero_entries` and indices of those nonzero entries are distributed uniformly at random.
+    /// Outputs an `l`-variate multilinear extension where value of evaluations
+    /// are sampled uniformly at random. The number of nonzero entries is
+    /// `num_nonzero_entries` and indices of those nonzero entries are
+    /// distributed uniformly at random.
     ///
-    /// Note that this function uses rejection sampling. As number of nonzero entries approach `2 ^ num_vars`,
-    /// sampling will be very slow due to large number of collisions.
+    /// Note that this function uses rejection sampling. As number of nonzero
+    /// entries approach `2 ^ num_vars`, sampling will be very slow due to
+    /// large number of collisions.
     pub fn rand_with_config<R: Rng>(
         num_vars: usize,
         num_nonzero_entries: usize,
@@ -121,8 +129,10 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
         }
     }
 
-    /// Outputs an `l`-variate multilinear extension where value of evaluations are sampled uniformly at random.
-    /// The number of nonzero entries is `sqrt(2^num_vars)` and indices of those nonzero entries are distributed uniformly at random.
+    /// Outputs an `l`-variate multilinear extension where value of evaluations
+    /// are sampled uniformly at random. The number of nonzero entries is
+    /// `sqrt(2^num_vars)` and indices of those nonzero entries are distributed
+    /// uniformly at random.
     fn rand<R: Rng>(num_vars: usize, rng: &mut R) -> Self {
         Self::rand_with_config(num_vars, 1 << (num_vars / 2), rng)
     }
@@ -203,11 +213,14 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
 impl<F: Field> Index<usize> for SparseMultilinearExtension<F> {
     type Output = F;
 
-    /// Returns the evaluation of the polynomial at a point represented by index.
+    /// Returns the evaluation of the polynomial at a point represented by
+    /// index.
     ///
-    /// Index represents a vector in {0,1}^`num_vars` in little endian form. For example, `0b1011` represents `P(1,1,0,1)`
+    /// Index represents a vector in {0,1}^`num_vars` in little endian form. For
+    /// example, `0b1011` represents `P(1,1,0,1)`
     ///
-    /// For Sparse multilinear polynomial, Lookup_evaluation takes log time to the size of polynomial.
+    /// For Sparse multilinear polynomial, Lookup_evaluation takes log time to
+    /// the size of polynomial.
     fn index(&self, index: usize) -> &Self::Output {
         if let Some(v) = self.evaluations.get(&index) {
             v
@@ -392,13 +405,12 @@ fn hashmap_to_treemap<F: Field>(map: &HashMap<usize, F>) -> BTreeMap<usize, F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::evaluations::multivariate::multilinear::MultilinearExtension;
-    use crate::SparseMultilinearExtension;
+    use crate::{
+        evaluations::multivariate::multilinear::MultilinearExtension, SparseMultilinearExtension,
+    };
     use ark_ff::{One, Zero};
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-    use ark_std::ops::Neg;
-    use ark_std::vec::Vec;
-    use ark_std::{test_rng, UniformRand};
+    use ark_std::{ops::Neg, test_rng, vec::Vec, UniformRand};
     use ark_test_curves::bls12_381::Fr;
     /// Some sanity test to ensure random sparse polynomial make sense.
     #[test]

--- a/poly/src/evaluations/univariate/mod.rs
+++ b/poly/src/evaluations/univariate/mod.rs
@@ -1,7 +1,6 @@
 //! A univariate polynomial represented in evaluations form.
 
-use crate::univariate::DensePolynomial;
-use crate::{EvaluationDomain, GeneralEvaluationDomain, UVPolynomial};
+use crate::{univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain, UVPolynomial};
 use ark_ff::{batch_inversion, FftField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -23,10 +23,12 @@ pub mod polynomial;
 pub use domain::{
     EvaluationDomain, GeneralEvaluationDomain, MixedRadixEvaluationDomain, Radix2EvaluationDomain,
 };
-pub use evaluations::multivariate::multilinear::{
-    DenseMultilinearExtension, MultilinearExtension, SparseMultilinearExtension,
+pub use evaluations::{
+    multivariate::multilinear::{
+        DenseMultilinearExtension, MultilinearExtension, SparseMultilinearExtension,
+    },
+    univariate::Evaluations,
 };
-pub use evaluations::univariate::Evaluations;
 pub use polynomial::{multivariate, univariate, MVPolynomial, Polynomial, UVPolynomial};
 
 #[cfg(test)]

--- a/poly/src/polynomial/mod.rs
+++ b/poly/src/polynomial/mod.rs
@@ -1,11 +1,11 @@
 //! Modules for working with univariate or multivariate polynomials.
 use ark_ff::{Field, Zero};
 use ark_serialize::*;
-use ark_std::rand::Rng;
 use ark_std::{
     fmt::Debug,
     hash::Hash,
     ops::{Add, AddAssign, Neg, SubAssign},
+    rand::Rng,
     vec::Vec,
 };
 

--- a/poly/src/polynomial/multivariate/mod.rs
+++ b/poly/src/polynomial/multivariate/mod.rs
@@ -35,7 +35,8 @@ pub trait Term:
     /// Create a new `Term` from a list of tuples of the form `(variable, power)`
     fn new(term: Vec<(usize, usize)>) -> Self;
 
-    /// Returns the total degree of `self`. This is the sum of all variable powers in `self`
+    /// Returns the total degree of `self`. This is the sum of all variable
+    /// powers in `self`
     fn degree(&self) -> usize;
 
     /// Returns a list of variables in `self`
@@ -52,7 +53,7 @@ pub trait Term:
 }
 
 /// Stores a term (monomial) in a multivariate polynomial.
-/// Each element is of the form `(variable, power)`.  
+/// Each element is of the form `(variable, power)`.
 #[derive(Clone, PartialEq, Eq, Hash, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct SparseTerm(Vec<(usize, usize)>);
 

--- a/poly/src/polynomial/multivariate/sparse.rs
+++ b/poly/src/polynomial/multivariate/sparse.rs
@@ -5,12 +5,12 @@ use crate::{
 };
 use ark_ff::{Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
-use ark_std::rand::Rng;
 use ark_std::{
     cmp::Ordering,
     fmt,
     io::{Read, Write},
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
+    rand::Rng,
     vec::Vec,
 };
 

--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -1,13 +1,14 @@
 //! A dense univariate polynomial represented in coefficient form.
-use crate::univariate::DenseOrSparsePolynomial;
-use crate::{univariate::SparsePolynomial, Polynomial, UVPolynomial};
-use crate::{EvaluationDomain, Evaluations, GeneralEvaluationDomain};
+use crate::{
+    univariate::{DenseOrSparsePolynomial, SparsePolynomial},
+    EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial, UVPolynomial,
+};
 use ark_ff::{FftField, Field, Zero};
 use ark_serialize::*;
-use ark_std::rand::Rng;
 use ark_std::{
     fmt,
     ops::{Add, AddAssign, Deref, DerefMut, Div, Mul, Neg, Sub, SubAssign},
+    rand::Rng,
     vec::Vec,
 };
 
@@ -574,8 +575,7 @@ impl<F: Field> Zero for DensePolynomial<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::polynomial::univariate::*;
-    use crate::{EvaluationDomain, GeneralEvaluationDomain};
+    use crate::{polynomial::univariate::*, EvaluationDomain, GeneralEvaluationDomain};
     use ark_ff::{Field, One, UniformRand, Zero};
     use ark_std::{rand::Rng, test_rng};
     use ark_test_curves::bls12_381::Fr;

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -1,7 +1,9 @@
 //! A sparse polynomial represented in coefficient form.
-use crate::polynomial::Polynomial;
-use crate::univariate::{DenseOrSparsePolynomial, DensePolynomial};
-use crate::{EvaluationDomain, Evaluations, UVPolynomial};
+use crate::{
+    polynomial::Polynomial,
+    univariate::{DenseOrSparsePolynomial, DensePolynomial},
+    EvaluationDomain, Evaluations, UVPolynomial,
+};
 use ark_ff::{FftField, Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{
@@ -122,7 +124,8 @@ impl<'a, 'b, F: Field> Add<&'a SparsePolynomial<F>> for &'b SparsePolynomial<F> 
         let mut self_index = 0;
         let mut other_index = 0;
         loop {
-            // if we've reached the end of one vector, just append the other vector to our result.
+            // if we've reached the end of one vector, just append the other vector to our
+            // result.
             if self_index == self.coeffs.len() && other_index == other.coeffs.len() {
                 return result;
             } else if self_index == self.coeffs.len() {
@@ -316,14 +319,13 @@ impl<F: Field> From<DensePolynomial<F>> for SparsePolynomial<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::polynomial::Polynomial;
-    use crate::univariate::{DensePolynomial, SparsePolynomial};
-    use crate::{EvaluationDomain, GeneralEvaluationDomain};
+    use crate::{
+        polynomial::Polynomial,
+        univariate::{DensePolynomial, SparsePolynomial},
+        EvaluationDomain, GeneralEvaluationDomain,
+    };
     use ark_ff::{UniformRand, Zero};
-    use ark_std::cmp::max;
-    use ark_std::ops::Mul;
-    use ark_std::rand::Rng;
-    use ark_std::test_rng;
+    use ark_std::{cmp::max, ops::Mul, rand::Rng, test_rng};
     use ark_test_curves::bls12_381::Fr;
 
     // probability of rand sparse polynomial having a particular coefficient be 0
@@ -425,8 +427,9 @@ mod tests {
 
     #[test]
     fn mul_polynomial() {
-        // Test multiplying polynomials over their domains, and over the native representation.
-        // The expected result is obtained by comparing against dense polynomial
+        // Test multiplying polynomials over their domains, and over the native
+        // representation. The expected result is obtained by comparing against
+        // dense polynomial
         let mut rng = test_rng();
         for degree_a in 0..20 {
             let sparse_poly_a = rand_sparse_poly(degree_a, &mut rng);
@@ -466,7 +469,8 @@ mod tests {
 
     #[test]
     fn evaluate_over_domain() {
-        // Test that polynomial evaluation over a domain, and interpolation returns the same poly.
+        // Test that polynomial evaluation over a domain, and interpolation returns the
+        // same poly.
         let mut rng = test_rng();
         for poly_degree_dim in 0..5 {
             let poly_degree = (1 << poly_degree_dim) - 1;

--- a/poly/src/test.rs
+++ b/poly/src/test.rs
@@ -1,8 +1,10 @@
 use crate::domain::*;
 use ark_ff::{PrimeField, UniformRand};
 use ark_std::test_rng;
-use ark_test_curves::bls12_381::{Fr, G1Projective};
-use ark_test_curves::bn384_small_two_adicity::Fr as BNFr;
+use ark_test_curves::{
+    bls12_381::{Fr, G1Projective},
+    bn384_small_two_adicity::Fr as BNFr,
+};
 
 // Test multiplying various (low degree) polynomials together and
 // comparing with naive evaluations.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,9 @@
-reorder_imports = true
-wrap_comments = true
-normalize_comments = true
-use_try_shorthand = true
-match_block_trailing_comma = true
-use_field_init_shorthand = true
-edition = "2018"
 condense_wildcard_suffixes = true
-merge_imports = true
+edition = "2018"
+imports_granularity = "Crate"
+match_block_trailing_comma = true
+normalize_comments = true
+reorder_imports = true
+use_field_init_shorthand = true
+use_try_shorthand = true
+wrap_comments = true

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -856,8 +856,7 @@ impl<T: CanonicalDeserialize + Ord> CanonicalDeserialize for BTreeSet<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ark_std::rand::RngCore;
-    use ark_std::vec;
+    use ark_std::{rand::RngCore, vec};
 
     #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
     struct Dummy;

--- a/test-templates/src/curves.rs
+++ b/test-templates/src/curves.rs
@@ -1,8 +1,7 @@
 #![allow(unused)]
-use ark_ec::twisted_edwards_extended::GroupProjective;
-use ark_ec::wnaf::WnafContext;
 use ark_ec::{
-    AffineCurve, MontgomeryModelParameters, ProjectiveCurve, SWModelParameters, TEModelParameters,
+    twisted_edwards_extended::GroupProjective, wnaf::WnafContext, AffineCurve,
+    MontgomeryModelParameters, ProjectiveCurve, SWModelParameters, TEModelParameters,
 };
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SWFlags, SerializationError};

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -2,8 +2,7 @@
 #![allow(clippy::eq_op)]
 use ark_ff::fields::{FftField, FftParameters, Field, LegendreSymbol, PrimeField, SquareRootField};
 use ark_serialize::{buffer_bit_byte_size, Flags, SWFlags};
-use ark_std::io::Cursor;
-use ark_std::rand::Rng;
+use ark_std::{io::Cursor, rand::Rng};
 
 pub const ITERATIONS: u32 = 40;
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR removes unnecessary `PhantomData` in some structures. See the following:
- `GroupAffine`, `GroupProjective` (ec/src/models/short_weierstrass_jacobian.rs)
- `GroupAffine`, `GroupProjective`, `MontgomeryGroupAffine` (ec/src/models/twisted_edwards_extended.rs)
- `CubicExtField` (ff/src/fields/models/cubic_extension.rs)
- `QuadExtField` (ff/src/fields/models/quadratic_extension.rs)

The rest of the changes are `cargo clippy` or `cargo fmt` updates.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] (N/A) Wrote unit tests
- [x] (N/A) Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
