### PR TITLE
Let ark-ff specify the same `num-bigint` version as the rest of the repos

### DIFF
--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -23,7 +23,7 @@ num-traits = { version = "0.2", default-features = false }
 paste = "1.0"
 rayon = { version = "1", optional = true }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
-num-bigint = { version = "0.4.0", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
 
 [build-dependencies]
 rustc_version = "0.4"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This is related to #316 but is not expected to be a solution.

There is a pending "unstable feature" in Rust 1.56 beta that requires `num-bigint` to be bumped up to `0.4.2` or higher to be able to compile.

My local test seems to show that the compiler would always retrieve the `0.4.2` version (since arkwork-rs never uses Cargo.lock). So this seems to be an issue for downstream applications to handle.

Nevertheless, we can improve the current code: only the `algebra` and `r1cs-std` repos use `num-bigint`, and `ark-ff` is the only one that is specifying `0.4.0`, while the rest are all using `0.4`.

This PR changes what `ark-ff` specifies in the Cargo.toml to 0.4, thereby keeping it consistent with the rest.

This does not closes #316. We will see whether more changes will be needed due to potential Rust changes.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
