### PR TITLE
Fix the Display impl for Fp* instances

### DIFF
--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -607,12 +607,11 @@ macro_rules! impl_Fp {
             }
         }
 
-        /// Outputs a string containing the value of `self`, chunked up into
-        /// 64-bit limbs.
         impl<P: $FpParameters> Display for $Fp<P> {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-                write!(f, stringify!($Fp"({})"), self.into_repr())
+                let value: num_bigint::BigUint = self.into_repr().into();
+                f.write_fmt(format_args!("{}", value))
             }
         }
 

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -230,6 +230,10 @@ pub fn from_str_test<F: PrimeField>() {
             let b = F::from(n);
 
             assert_eq!(a, b);
+            let c = F::from_str(&ark_std::format!("{}", a))
+                .map_err(|_| ())
+                .unwrap();
+            assert_eq!(a, c);
         }
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This change allows the output of the derived `ToString` impl to be used with
the `from_str` functions.  Previously, the `Display` impl output hex.

closes: #320 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- ~~[ ] Wrote unit tests~~
- [x] Updated relevant documentation in the code
- ~~[ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`~~ (I did not do this, to avoid merge conflicts while rebasing)
- ~~[ ] Re-reviewed `Files changed` in the Github PR explorer~~
