### PR TITLE
Simplify the function body by using preexisting Fp2 & Fp12 types

### DIFF
--- a/ec/src/models/bls12/mod.rs
+++ b/ec/src/models/bls12/mod.rs
@@ -12,8 +12,6 @@ use core::marker::PhantomData;
 use num_traits::{One, Zero};
 
 #[cfg(feature = "parallel")]
-use ark_ff::{Fp12ParamsWrapper, Fp2ParamsWrapper, QuadExtField};
-#[cfg(feature = "parallel")]
 use ark_std::cfg_iter;
 #[cfg(feature = "parallel")]
 use core::slice::Iter;
@@ -150,13 +148,13 @@ impl<P: Bls12Parameters> PairingEngine for Bls12<P> {
                  coeffs: &Iter<
             '_,
             (
-                QuadExtField<Fp2ParamsWrapper<<P as Bls12Parameters>::Fp2Params>>,
-                QuadExtField<Fp2ParamsWrapper<<P as Bls12Parameters>::Fp2Params>>,
-                QuadExtField<Fp2ParamsWrapper<<P as Bls12Parameters>::Fp2Params>>,
+                Fp2<<P as Bls12Parameters>::Fp2Params>,
+                Fp2<<P as Bls12Parameters>::Fp2Params>,
+                Fp2<<P as Bls12Parameters>::Fp2Params>,
             ),
         >,
-                 mut f: QuadExtField<Fp12ParamsWrapper<<P as Bls12Parameters>::Fp12Params>>|
-         -> QuadExtField<Fp12ParamsWrapper<<P as Bls12Parameters>::Fp12Params>> {
+                 mut f: Fp12<<P as Bls12Parameters>::Fp12Params>|
+         -> Fp12<<P as Bls12Parameters>::Fp12Params> {
             let coeffs = coeffs.as_slice();
             let mut j = 0;
             for i in BitIteratorBE::new(P::X).skip(1) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Simplify the function body by using preexisting Fp2 & Fp12 types.

Fp2 & Fp12 are public and already imported into current scope. Code looks much
cleaner without introducing the confusing wrappers.

I actually was thinking of making the respective ParamsWrappers private w.r.t. the defining crate or even mod (this would be a breaking change), since it's an implementation detail that we don't need to expose. Right now some other arkworks repos are using the ParamsWrappers, so until these can be refactored, I'll leave making it private an exercise for later.

Finally, as for testing this - I ran the benchmarks from the curves repo:
```
cargo bench bls12_381::miller_loop --features "parallel"
```
with the `ec` crate patched to my local copy. This of course only proves that it still runs and as far as I could see, there are no unit tests for a miller loop - and if that's the case I'll create a new issue to remember to write these.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code (N/A)
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` (not sure this is something that would go into changelog, as there's no functionality change - purely cosmetic. Please correct me if I'm wrong)
- [x] Re-reviewed `Files changed` in the Github PR explorer
