### PR TITLE
Add `ec:msm:{Fixed,Variable}Base:msm_checked_len`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@
 - [\#338](https://github.com/arkworks-rs/algebra/pull/338) (ark-ec) Add missing `UniformRand` trait bound to `GroupAffine`.
 - [\#338](https://github.com/arkworks-rs/algebra/pull/338) (workspace) Change to Rust 2021 edition.
 - [\#345](https://github.com/arkworks-rs/algebra/pull/345) (arc-ec, ark-serialize) Change the serialization format for Twisted Edwards Curves. We now encode the Y coordinate and take the sign bit of the X co-ordinate, the default flag is also now the Positive X value. The old methods for backwards compatibility are located [here](https://github.com/arkworks-rs/algebra/pull/345/files#diff-3621a48bb33f469144044d8d5fc663f767e103132a764812cda6be6c25877494R860)
+- [\#348](https://github.com/arkworks-rs/algebra/pull/348) (arc-ec) Rename `msm:{Fixed,Variable}BaseMSM:multi_scalar_mul` to `msm:{Fixed,Variable}:msm` to avoid redundancy.
 
 ### Features
 
 - [\#321](https://github.com/arkworks-rs/algebra/pull/321) (ark-ff) Change bigint conversions to impl `From` instead of `Into`.
 - [\#301](https://github.com/arkworks-rs/algebra/pull/301) (ark-ec) Add `GLVParameters` trait definition.
 - [\#312](https://github.com/arkworks-rs/algebra/pull/312) (ark-ec) Add `is_in_correct_subgroup_assuming_on_curve` for all `SWModelParameters`.
+- [\#348](https://github.com/arkworks-rs/algebra/pull/348) (ark-ec) Add `msm:{Fixed,Variable}Base:msm_checked_len`.
 
 ### Improvements
 

--- a/ec/src/msm/fixed_base.rs
+++ b/ec/src/msm/fixed_base.rs
@@ -5,9 +5,9 @@ use ark_std::{cfg_iter, cfg_iter_mut, vec::Vec};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-pub struct FixedBaseMSM;
+pub struct FixedBase;
 
-impl FixedBaseMSM {
+impl FixedBase {
     pub fn get_mul_window_size(num_scalars: usize) -> usize {
         if num_scalars < 32 {
             3
@@ -79,7 +79,9 @@ impl FixedBaseMSM {
         res
     }
 
-    pub fn multi_scalar_mul<T: ProjectiveCurve>(
+    // TODO use const-generics for the scalar size and window
+    // TODO use iterators of iterators of T::Affine instead of taking owned Vec
+    pub fn msm<T: ProjectiveCurve>(
         scalar_size: usize,
         window: usize,
         table: &[Vec<T::Affine>],

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -3,7 +3,7 @@ use ark_ec::{models::SWModelParameters, AffineCurve, PairingEngine, ProjectiveCu
 use ark_ff::{Field, One, UniformRand, Zero};
 
 use crate::bls12_381::{g1, Fq, Fq2, Fq6, FqParameters, Fr, G1Affine, G1Projective};
-use ark_algebra_test_templates::{curves::*, fields::*, groups::*};
+use ark_algebra_test_templates::{curves::*, fields::*, groups::*, msm::*};
 use ark_std::rand::Rng;
 
 pub(crate) const ITERATIONS: usize = 5;
@@ -53,6 +53,11 @@ fn test_fq6() {
         field_test(g, h);
     }
     frobenius_test::<Fq6, _>(Fq::characteristic(), 13);
+}
+
+#[test]
+fn test_g1_affine_curve() {
+    test_var_base_msm::<G1Affine>();
 }
 
 #[test]

--- a/test-curves/src/bn384_small_two_adicity/tests.rs
+++ b/test-curves/src/bn384_small_two_adicity/tests.rs
@@ -4,7 +4,7 @@ use ark_ff::{One, UniformRand, Zero};
 use ark_std::rand::Rng;
 
 use crate::bn384_small_two_adicity::{g1, Fq, FqParameters, Fr, G1Affine, G1Projective};
-use ark_algebra_test_templates::{curves::*, fields::*, groups::*};
+use ark_algebra_test_templates::{curves::*, fields::*, groups::*, msm::*};
 
 pub(crate) const ITERATIONS: usize = 5;
 
@@ -30,6 +30,11 @@ fn test_fq() {
         primefield_test::<Fq>();
         sqrt_field_test(a);
     }
+}
+
+#[test]
+fn test_g1_affine_curve() {
+    test_var_base_msm::<G1Affine>();
 }
 
 #[test]

--- a/test-templates/src/msm.rs
+++ b/test-templates/src/msm.rs
@@ -1,4 +1,4 @@
-use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
+use ark_ec::{msm::VariableBase, AffineCurve, ProjectiveCurve};
 use ark_ff::{PrimeField, UniformRand, Zero};
 
 fn naive_var_base_msm<G: AffineCurve>(
@@ -27,7 +27,7 @@ pub fn test_var_base_msm<G: AffineCurve>() {
     let g = <G::Projective as ProjectiveCurve>::batch_normalization_into_affine(&g);
 
     let naive = naive_var_base_msm(g.as_slice(), v.as_slice());
-    let fast = VariableBaseMSM::multi_scalar_mul(g.as_slice(), v.as_slice());
+    let fast = VariableBase::msm(g.as_slice(), v.as_slice());
 
     assert_eq!(naive.into_affine(), fast.into_affine());
 }


### PR DESCRIPTION
## Description

Add the new methods for checked fixed and variable base multi-scalar
multiplication. They will return `None` if the arguments don't have the
same length.

This way, the users may confidently call this function without having to
check the length themselves.

Also, `ec:msm:{Fixed,Variable}BaseMSM` was renamed to
`ec:msm::{Fixed,Variable}Base` to avoid redundancy. The import path
contained `msm` several times, and now it contains only one incidence
for the type resolution and one for the function call.

Closes #319

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
