### PR TITLE
Update `QuadExtField::sqrt` for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Improvements
 
 - [\#339](https://github.com/arkworks-rs/algebra/pull/339) (ark-ff) Remove duplicated code from `test_field` module and replace its usage with `ark-test-curves` crate.
+- [\#352](https://github.com/arkworks-rs/algebra/pull/352) (ark-ff) Update `QuadExtField::sqrt` for better performance.
 
 ### Bugfixes
 

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -418,6 +418,11 @@ pub trait PrimeField:
         Self::Params::T_MINUS_ONE_DIV_TWO
     }
 
+    /// Returns the modulus.
+    fn modulus() -> Self::BigInt {
+        Self::Params::MODULUS
+    }
+
     /// Returns the modulus minus one divided by two.
     fn modulus_minus_one_div_two() -> Self::BigInt {
         Self::Params::MODULUS_MINUS_ONE_DIV_TWO


### PR DESCRIPTION
## Description

Currently, the QuadExtField uses an expensive runtime inverse of two
calculation defined as `P::BaseField::one().double().inverse()`.

With the proposed change, we compute the BigInt `(p+1)/2` that is ~15%
cheaper than the previous method.

Alternatively, we could require a compile-time constant provided by the
user that represents `1/2`. However, having a constant requirement to
satisfy a single use-case isn't ideal.

closes: #210

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

- [ ] Wrote unit tests (tests are already covering this section: `bls12_381::tests::test_fq2`)
