### PR TITLE
Move model-specific methods and types back into model-specific traits

### DIFF
--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -155,11 +155,7 @@ pub trait ProjectiveCurve:
     + for<'a> core::iter::Sum<&'a Self>
     + From<<Self as ProjectiveCurve>::Affine>
 {
-    type Parameters: ModelParameters<
-        ScalarField = Self::ScalarField,
-        BaseField = Self::BaseField,
-        Affine = Self::Affine,
-    >;
+    type Parameters: ModelParameters<ScalarField = Self::ScalarField, BaseField = Self::BaseField>;
     type ScalarField: PrimeField + SquareRootField;
     type BaseField: Field;
     type Affine: AffineCurve<
@@ -259,11 +255,7 @@ pub trait AffineCurve:
     + for<'a> core::iter::Sum<&'a Self>
     + From<<Self as AffineCurve>::Projective>
 {
-    type Parameters: ModelParameters<
-        ScalarField = Self::ScalarField,
-        BaseField = Self::BaseField,
-        Affine = Self,
-    >;
+    type Parameters: ModelParameters<ScalarField = Self::ScalarField, BaseField = Self::BaseField>;
     type ScalarField: PrimeField + SquareRootField + Into<<Self::ScalarField as PrimeField>::BigInt>;
     type BaseField: Field;
     type Projective: ProjectiveCurve<

--- a/ec/src/models/mod.rs
+++ b/ec/src/models/mod.rs
@@ -55,7 +55,6 @@ pub trait SWModelParameters: ModelParameters {
 pub trait TEModelParameters: ModelParameters {
     const COEFF_A: Self::BaseField;
     const COEFF_D: Self::BaseField;
-    type Affine: AffineCurve<BaseField = Self::BaseField, ScalarField = Self::ScalarField>;
     const AFFINE_GENERATOR_COEFFS: (Self::BaseField, Self::BaseField);
 
     type MontgomeryModelParameters: MontgomeryModelParameters<BaseField = Self::BaseField>;

--- a/ec/src/models/mod.rs
+++ b/ec/src/models/mod.rs
@@ -13,23 +13,13 @@ pub mod twisted_edwards_extended;
 pub trait ModelParameters: Send + Sync + Sized + 'static {
     type BaseField: Field + SquareRootField;
     type ScalarField: PrimeField + SquareRootField + Into<<Self::ScalarField as PrimeField>::BigInt>;
-    type Affine: AffineCurve<BaseField = Self::BaseField, ScalarField = Self::ScalarField>;
 
     const COFACTOR: &'static [u64];
     const COFACTOR_INV: Self::ScalarField;
-
-    /// Checks that the current point is in the prime order subgroup given
-    /// the point on the curve.
-    fn is_in_correct_subgroup_assuming_on_curve(item: &Self::Affine) -> bool {
-        item.mul_bits(BitIteratorBE::new(Self::ScalarField::characteristic()))
-            .is_zero()
-    }
 }
 
 /// Model parameters for a Short Weierstrass curve.
-pub trait SWModelParameters:
-    ModelParameters<Affine = short_weierstrass_jacobian::GroupAffine<Self>>
-{
+pub trait SWModelParameters: ModelParameters {
     const COEFF_A: Self::BaseField;
     const COEFF_B: Self::BaseField;
     const AFFINE_GENERATOR_COEFFS: (Self::BaseField, Self::BaseField);
@@ -50,14 +40,22 @@ pub trait SWModelParameters:
         }
         *elem
     }
+
+    /// Checks that the current point is in the prime order subgroup given
+    /// the point on the curve.
+    fn is_in_correct_subgroup_assuming_on_curve(
+        item: &short_weierstrass_jacobian::GroupAffine<Self>,
+    ) -> bool {
+        item.mul_bits(BitIteratorBE::new(Self::ScalarField::characteristic()))
+            .is_zero()
+    }
 }
 
 /// Model parameters for a Twisted Edwards curve.
-pub trait TEModelParameters:
-    ModelParameters<Affine = twisted_edwards_extended::GroupAffine<Self>>
-{
+pub trait TEModelParameters: ModelParameters {
     const COEFF_A: Self::BaseField;
     const COEFF_D: Self::BaseField;
+    type Affine: AffineCurve<BaseField = Self::BaseField, ScalarField = Self::ScalarField>;
     const AFFINE_GENERATOR_COEFFS: (Self::BaseField, Self::BaseField);
 
     type MontgomeryModelParameters: MontgomeryModelParameters<BaseField = Self::BaseField>;
@@ -67,6 +65,15 @@ pub trait TEModelParameters:
         let mut copy = *elem;
         copy *= &Self::COEFF_A;
         copy
+    }
+
+    /// Checks that the current point is in the prime order subgroup given
+    /// the point on the curve.
+    fn is_in_correct_subgroup_assuming_on_curve(
+        item: &twisted_edwards_extended::GroupAffine<Self>,
+    ) -> bool {
+        item.mul_bits(BitIteratorBE::new(Self::ScalarField::characteristic()))
+            .is_zero()
     }
 }
 

--- a/test-curves/src/bls12_381/g1.rs
+++ b/test-curves/src/bls12_381/g1.rs
@@ -14,7 +14,6 @@ pub struct Parameters;
 impl ModelParameters for Parameters {
     type BaseField = Fq;
     type ScalarField = Fr;
-    type Affine = GroupAffine<Self>;
 
     /// COFACTOR = (x - 1)^2 / 3  = 76329603384216526031706109802092473003
     const COFACTOR: &'static [u64] = &[0x8c00aaab0000aaab, 0x396c8c005555e156];

--- a/test-curves/src/bn384_small_two_adicity/g1.rs
+++ b/test-curves/src/bn384_small_two_adicity/g1.rs
@@ -15,7 +15,6 @@ pub struct Parameters;
 impl ModelParameters for Parameters {
     type BaseField = Fq;
     type ScalarField = Fr;
-    type Affine = GroupAffine<Self>;
 
     /// COFACTOR = 1
     const COFACTOR: &'static [u64] = &[1];

--- a/test-curves/src/mnt4_753/g1.rs
+++ b/test-curves/src/mnt4_753/g1.rs
@@ -15,7 +15,6 @@ pub struct Parameters;
 impl ModelParameters for Parameters {
     type BaseField = Fq;
     type ScalarField = Fr;
-    type Affine = GroupAffine<Self>;
 
     /// COFACTOR = 1
     const COFACTOR: &'static [u64] = &[1];


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Makes some changes to arkworks-rs/algebra#365, since we can't actually make `Affine` common to `ModelParameters`. In particular, the same curve can have different models, and hence different `Affine` representations.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
