### PR TITLE
Use `rust-version` in all algebra crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     - Move `COFACTOR`, `COFACTOR_INV`, and `is_in_correct_subgroup_assuming_on_curve()` from `{SW,TE}ModelParameters` to `ModelParameters`.
     - Add `mul_bits()` to `AffineCurve` and provide a default implementation of `mul()` using this.
     - Remove duplicate function `scale_by_cofactor()` from `short_weierstrass_jacobian::GroupAffine` and `twisted_edwards_extended::GroupAffine`
+- [\#370](https://github.com/arkworks-rs/algebra/pull/370) (all) Set the minimum `rust-version = 1.56` in the manifests of all crates.
 
 ### Features
 

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 ark-std = { version = "^0.3.0", default-features = false }

--- a/ff-asm/Cargo.toml
+++ b/ff-asm/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 quote = "1.0.0"

--- a/ff-macros/Cargo.toml
+++ b/ff-macros/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 quote = "1.0.0"

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -12,6 +12,7 @@ include = ["Cargo.toml", "build.rs", "src", "README.md", "LICENSE-APACHE", "LICE
 license = "MIT/Apache-2.0"
 edition = "2021"
 build = "build.rs"
+rust-version = "1.56"
 
 [dependencies]
 ark-ff-asm = { version = "^0.3.0", path = "../ff-asm" }

--- a/ff/build.rs
+++ b/ff/build.rs
@@ -1,5 +1,5 @@
 extern crate rustc_version;
-use rustc_version::{version, version_meta, Channel, Version};
+use rustc_version::{version_meta, Channel};
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -14,11 +14,5 @@ fn main() {
     )) && is_nightly;
     if should_use_asm {
         println!("cargo:rustc-cfg=use_asm");
-    }
-
-    // TODO: remove this once RFC 2495 ships
-    if version().expect("Installed rustc version unparseable!") < Version::parse("1.51.0").unwrap()
-    {
-        panic!("This code base uses const generics and requires a Rust compiler version greater or equal to 1.51.0");
     }
 }

--- a/poly-benches/Cargo.toml
+++ b/poly-benches/Cargo.toml
@@ -7,6 +7,7 @@ include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
 publish = false
+rust-version = "1.56"
 
 [dependencies]
 ark-ff = { version = "^0.3.0", path = "../ff" }

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 ark-ff = { version = "^0.3.0", path = "../ff", default-features = false }

--- a/serialize-derive/Cargo.toml
+++ b/serialize-derive/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 ################################# Dependencies ################################
 

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 ark-serialize-derive = { version = "^0.3.0", path = "../serialize-derive", optional = true }

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 ark-std = { version = "^0.3.0", default-features = false }

--- a/test-templates/Cargo.toml
+++ b/test-templates/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 ark-std = { version = "^0.3.0", default-features = false }


### PR DESCRIPTION
## Description

The rust-version field has been available in stable since 1.56. I believe we can aim to support 1.56 at this point. Users can still, if needed, explicitly opt in to ignore the compiler errors when using older versions, see reference below.
[cargo reference](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field).

---
Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
