### PR TITLE
Add array serialization impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [\#312](https://github.com/arkworks-rs/algebra/pull/312) (ark-ec) Add `is_in_correct_subgroup_assuming_on_curve` for all `SWModelParameters`.
 - [\#348](https://github.com/arkworks-rs/algebra/pull/348) (ark-ec) Add `msm:{Fixed,Variable}Base:msm_checked_len`.
 - [\#364](https://github.com/arkworks-rs/algebra/pull/364) (ark-ec) Add `ChunkedPippenger` to variable-base MSM.
+- [\#371](https://github.com/arkworks-rs/algebra/pull/371) (ark-serialize) Add serialization impls for arrays
 
 ### Improvements
 

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -313,85 +313,73 @@ impl<T: CanonicalSerialize> CanonicalSerialize for [T] {
     }
 }
 
-// Macro for implementing serialize for arrays up to size 32.
-macro_rules! impl_arrays {
-    ($($count:tt)+) => {
-        $(
-            impl<T: CanonicalSerialize> CanonicalSerialize for [T; $count] {
-                #[inline]
-                fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-                    for item in self.iter() {
-                        item.serialize(&mut writer)?;
-                    }
-                    Ok(())
-                }
+impl<T: CanonicalSerialize, const N: usize> CanonicalSerialize for [T; N] {
+    #[inline]
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        for item in self.iter() {
+            item.serialize(&mut writer)?;
+        }
+        Ok(())
+    }
 
-                #[inline]
-                fn serialized_size(&self) -> usize {
-                    self.iter().map(|item| item.serialized_size()).sum::<usize>()
-                }
+    #[inline]
+    fn serialized_size(&self) -> usize {
+        self.iter().map(|item| item.serialized_size()).sum::<usize>()
+    }
 
-                #[inline]
-                fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-                    for item in self.iter() {
-                        item.serialize_uncompressed(&mut writer)?;
-                    }
-                    Ok(())
-                }
+    #[inline]
+    fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        for item in self.iter() {
+            item.serialize_uncompressed(&mut writer)?;
+        }
+        Ok(())
+    }
 
-                #[inline]
-                fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-                    for item in self.iter() {
-                        item.serialize_unchecked(&mut writer)?;
-                    }
-                    Ok(())
-                }
+    #[inline]
+    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        for item in self.iter() {
+            item.serialize_unchecked(&mut writer)?;
+        }
+        Ok(())
+    }
 
-                #[inline]
-                fn uncompressed_size(&self) -> usize {
-                    self
-                        .iter()
-                        .map(|item| item.uncompressed_size())
-                        .sum::<usize>()
-                }
-            }
-
-            impl<T: CanonicalDeserialize + Copy + Default> CanonicalDeserialize for [T; $count] {
-                #[inline]
-                fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-                    let mut values = [T::default(); $count];
-                    for val in values.iter_mut() {
-                        *val = T::deserialize(&mut reader)?;
-                    }
-                    Ok(values)
-                }
-
-                #[inline]
-                fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-                    let mut values = [T::default(); $count];
-                    for val in values.iter_mut() {
-                        *val = T::deserialize_uncompressed(&mut reader)?;
-                    }
-                    Ok(values)
-                }
-
-                #[inline]
-                fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-                    let mut values = [T::default(); $count];
-                    for val in values.iter_mut() {
-                        *val = T::deserialize_unchecked(&mut reader)?;
-                    }
-                    Ok(values)
-                }
-            }
-        )+
-    };
+    #[inline]
+    fn uncompressed_size(&self) -> usize {
+        self
+            .iter()
+            .map(|item| item.uncompressed_size())
+            .sum::<usize>()
+    }
 }
 
-impl_arrays!(01 02 03 04 05 06 07 08 09 10
-             11 12 13 14 15 16 17 18 19 20
-             21 22 23 24 25 26 27 28 29 30
-             31 32);
+impl<T: CanonicalDeserialize + Default + Copy, const N: usize> CanonicalDeserialize for [T; N] {
+    #[inline]
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let mut values = [T::default(); N];
+        for val in values.iter_mut() {
+            *val = T::deserialize(&mut reader)?;
+        }
+        Ok(values)
+    }
+
+    #[inline]
+    fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let mut values = [T::default(); N];
+        for val in values.iter_mut() {
+            *val = T::deserialize_uncompressed(&mut reader)?;
+        }
+        Ok(values)
+    }
+
+    #[inline]
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let mut values = [T::default(); N];
+        for val in values.iter_mut() {
+            *val = T::deserialize_unchecked(&mut reader)?;
+        }
+        Ok(values)
+    }
+}
 
 impl<T: CanonicalSerialize> CanonicalSerialize for Vec<T> {
     #[inline]

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -942,17 +942,17 @@ mod test {
             &self,
             mut writer: W,
         ) -> Result<(), SerializationError> {
-            (&[100u8, 200u8]).serialize_uncompressed(&mut writer)
+            [100u8, 200u8].serialize_uncompressed(&mut writer)
         }
 
         #[inline]
         fn uncompressed_size(&self) -> usize {
-            (&[100u8, 200u8]).uncompressed_size()
+            [100u8, 200u8].uncompressed_size()
         }
 
         #[inline]
         fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-            (&[100u8, 200u8]).serialize_unchecked(&mut writer)
+            [100u8, 200u8].serialize_unchecked(&mut writer)
         }
     }
 
@@ -966,16 +966,16 @@ mod test {
 
         #[inline]
         fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-            let result = Vec::<u8>::deserialize_uncompressed(&mut reader)?;
-            assert_eq!(result.as_slice(), &[100u8, 200u8]);
+            let result = <[u8; 2]>::deserialize_uncompressed(&mut reader)?;
+            assert_eq!(result, [100u8, 200u8]);
 
             Ok(Dummy)
         }
 
         #[inline]
         fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-            let result = Vec::<u8>::deserialize_unchecked(&mut reader)?;
-            assert_eq!(result.as_slice(), &[100u8, 200u8]);
+            let result = <[u8; 2]>::deserialize_unchecked(&mut reader)?;
+            assert_eq!(result, [100u8, 200u8]);
 
             Ok(Dummy)
         }

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -219,86 +219,6 @@ impl_uint!(u16);
 impl_uint!(u32);
 impl_uint!(u64);
 
-// Macro for implementing serialize for arrays up to size 32.
-macro_rules! impl_arrays {
-    ($($count:tt)+) => {
-        $(
-            impl<T: CanonicalSerialize> CanonicalSerialize for [T; $count] {
-                #[inline]
-                fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-                    for item in self.iter() {
-                        item.serialize(&mut writer)?;
-                    }
-                    Ok(())
-                }
-
-                #[inline]
-                fn serialized_size(&self) -> usize {
-                    self.iter().map(|item| item.serialized_size()).sum::<usize>()
-                }
-
-                #[inline]
-                fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-                    for item in self.iter() {
-                        item.serialize_uncompressed(&mut writer)?;
-                    }
-                    Ok(())
-                }
-
-                #[inline]
-                fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
-                    for item in self.iter() {
-                        item.serialize_unchecked(&mut writer)?;
-                    }
-                    Ok(())
-                }
-
-                #[inline]
-                fn uncompressed_size(&self) -> usize {
-                    self
-                        .iter()
-                        .map(|item| item.uncompressed_size())
-                        .sum::<usize>()
-                }
-            }
-
-            impl<T: CanonicalDeserialize + Copy + Default> CanonicalDeserialize for [T; $count] {
-                #[inline]
-                fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-                    let mut values = [T::default(); $count];
-                    for val in values.iter_mut() {
-                        *val = T::deserialize(&mut reader)?;
-                    }
-                    Ok(values)
-                }
-
-                #[inline]
-                fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-                    let mut values = [T::default(); $count];
-                    for val in values.iter_mut() {
-                        *val = T::deserialize_uncompressed(&mut reader)?;
-                    }
-                    Ok(values)
-                }
-
-                #[inline]
-                fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-                    let mut values = [T::default(); $count];
-                    for val in values.iter_mut() {
-                        *val = T::deserialize_unchecked(&mut reader)?;
-                    }
-                    Ok(values)
-                }
-            }
-        )+
-    };
-}
-
-impl_arrays!(01 02 03 04 05 06 07 08 09 10
-             11 12 13 14 15 16 17 18 19 20
-             21 22 23 24 25 26 27 28 29 30
-             31 32);
-
 // Serialize usize with 8 bytes
 impl CanonicalSerialize for usize {
     #[inline]
@@ -392,6 +312,86 @@ impl<T: CanonicalSerialize> CanonicalSerialize for [T] {
             .sum::<usize>()
     }
 }
+
+// Macro for implementing serialize for arrays up to size 32.
+macro_rules! impl_arrays {
+    ($($count:tt)+) => {
+        $(
+            impl<T: CanonicalSerialize> CanonicalSerialize for [T; $count] {
+                #[inline]
+                fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+                    for item in self.iter() {
+                        item.serialize(&mut writer)?;
+                    }
+                    Ok(())
+                }
+
+                #[inline]
+                fn serialized_size(&self) -> usize {
+                    self.iter().map(|item| item.serialized_size()).sum::<usize>()
+                }
+
+                #[inline]
+                fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+                    for item in self.iter() {
+                        item.serialize_uncompressed(&mut writer)?;
+                    }
+                    Ok(())
+                }
+
+                #[inline]
+                fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+                    for item in self.iter() {
+                        item.serialize_unchecked(&mut writer)?;
+                    }
+                    Ok(())
+                }
+
+                #[inline]
+                fn uncompressed_size(&self) -> usize {
+                    self
+                        .iter()
+                        .map(|item| item.uncompressed_size())
+                        .sum::<usize>()
+                }
+            }
+
+            impl<T: CanonicalDeserialize + Copy + Default> CanonicalDeserialize for [T; $count] {
+                #[inline]
+                fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+                    let mut values = [T::default(); $count];
+                    for val in values.iter_mut() {
+                        *val = T::deserialize(&mut reader)?;
+                    }
+                    Ok(values)
+                }
+
+                #[inline]
+                fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+                    let mut values = [T::default(); $count];
+                    for val in values.iter_mut() {
+                        *val = T::deserialize_uncompressed(&mut reader)?;
+                    }
+                    Ok(values)
+                }
+
+                #[inline]
+                fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+                    let mut values = [T::default(); $count];
+                    for val in values.iter_mut() {
+                        *val = T::deserialize_unchecked(&mut reader)?;
+                    }
+                    Ok(values)
+                }
+            }
+        )+
+    };
+}
+
+impl_arrays!(01 02 03 04 05 06 07 08 09 10
+             11 12 13 14 15 16 17 18 19 20
+             21 22 23 24 25 26 27 28 29 30
+             31 32);
 
 impl<T: CanonicalSerialize> CanonicalSerialize for Vec<T> {
     #[inline]

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -1065,6 +1065,13 @@ mod test {
     }
 
     #[test]
+    fn test_array() {
+        test_serialize([1u64, 2, 3, 4, 5]);
+        test_serialize([1u8; 33]);
+    }
+
+
+    #[test]
     fn test_vec() {
         test_serialize(vec![1u64, 2, 3, 4, 5]);
         test_serialize(Vec::<u64>::new());

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -45,8 +45,8 @@ pub trait CanonicalSerializeWithFlags: CanonicalSerialize {
 /// The serialization format must be 'length-extension' safe.
 /// e.g. if T implements Canonical Serialize and Deserialize,
 /// then for all strings `x, y`, if `a = T::deserialize(Reader(x))` and `a` is
-/// not an error, then it must be the case that `a = T::deserialize(Reader(x ||
-/// y))`, and that both readers read the same number of bytes.
+/// not an error, then it must be the case that `a = T::deserialize(Reader(x || y))`,
+/// and that both readers read the same number of bytes.
 ///
 /// This trait can be derived if all fields of a struct implement
 /// `CanonicalSerialize` and the `derive` feature is enabled.
@@ -77,8 +77,8 @@ pub trait CanonicalSerialize {
     /// Particular examples of interest:
     /// `bool` - 1 byte encoding
     /// uints - Direct encoding
-    /// Length prefixing (for any container implemented by default) - 8 byte
-    /// encoding Elliptic curves - compressed point encoding
+    /// Length prefixing (for any container implemented by default) - 8 byte encoding
+    /// Elliptic curves - compressed point encoding
     fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError>;
 
     fn serialized_size(&self) -> usize;
@@ -755,8 +755,7 @@ impl CanonicalDeserialize for bool {
     }
 }
 
-// Serialize BTreeMap as `len(map) || key 1 || value 1 || ... || key n || value
-// n`
+// Serialize BTreeMap as `len(map) || key 1 || value 1 || ... || key n || value n`
 impl<K, V> CanonicalSerialize for BTreeMap<K, V>
 where
     K: CanonicalSerialize,

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -324,7 +324,9 @@ impl<T: CanonicalSerialize, const N: usize> CanonicalSerialize for [T; N] {
 
     #[inline]
     fn serialized_size(&self) -> usize {
-        self.iter().map(|item| item.serialized_size()).sum::<usize>()
+        self.iter()
+            .map(|item| item.serialized_size())
+            .sum::<usize>()
     }
 
     #[inline]
@@ -345,8 +347,7 @@ impl<T: CanonicalSerialize, const N: usize> CanonicalSerialize for [T; N] {
 
     #[inline]
     fn uncompressed_size(&self) -> usize {
-        self
-            .iter()
+        self.iter()
             .map(|item| item.uncompressed_size())
             .sum::<usize>()
     }
@@ -1069,7 +1070,6 @@ mod test {
         test_serialize([1u64, 2, 3, 4, 5]);
         test_serialize([1u8; 33]);
     }
-
 
     #[test]
     fn test_vec() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR impls `CanonicalSerialize` and `CanonicalDeserialize` for arrays of up to size 32. This is useful for deriving these traits on structs which contain arrays.

I put `Default` and `Copy` bounds on `CanonicalDeserialize` in order to initialize the initial empty array. We could get rid of these bounds and use an `Option<T>`, but I believe this necessitates heap allocation in order to unwrap the `Option<T>` for the final result which I thought best to avoid. Let me know what y'all think is best.

I'll complete the other TODOs once I get some form of approval from maintainers to move forward (not sure who to ask for review 😁 )

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code (NA)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
