### PR TITLE
The repository cloned for test_against_curves should be the current working revision, not master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,6 @@ jobs:
       - name: Checkout algebra
         uses: actions/checkout@v2
         with:
-          repository: arkworks-rs/algebra
           path: algebra
 
       - name: Install Rust


### PR DESCRIPTION
Any non-default `repository` config option implies fetching from github master

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

See the example CI jobs that were executed for r1cs: https://github.com/mmagician/r1cs-std/pull/2
- the first commit had the `repository` set in the actions/checkout task: its `test_against_curves` job passed
- the second commit was after a change to master which was an equivalent change that is proposed in this PR, i.e. removing the `repository` config option. The tests failed as expected.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
