### PR TITLE
Patch Cargo.toml for new curve tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,14 @@ jobs:
             echo      "ark-ff-asm = { path = 'algebra/ff-asm' }";
             echo      "ark-ec = { path = 'algebra/ec' }";
             echo      "ark-algebra-test-templates = { path = 'algebra/test-templates' }"
+            echo      "ark-bls12-377 = { git = 'https://github.com/arkworks-rs/curves' }"
+            echo      "ark-bls12-381 = { git = 'https://github.com/arkworks-rs/curves' }"
+            echo      "ark-bn254 = { git = 'https://github.com/arkworks-rs/curves' }"
+            echo      "ark-pallas = { git = 'https://github.com/arkworks-rs/curves' }"
+            echo      "ark-bw6-761 = { git = 'https://github.com/arkworks-rs/curves' }"
+            echo      "ark-mnt4-298 = { git = 'https://github.com/arkworks-rs/curves' }"
+            echo      "ark-mnt6-298 = { git = 'https://github.com/arkworks-rs/curves' }"
+            echo      "ark-ed-on-bls12-377 = { git = 'https://github.com/arkworks-rs/curves' }"
           } >> Cargo.toml
 
       - name: Test on ${{ matrix.curve }}

--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -103,7 +103,6 @@ macro_rules! impl_Fp {
             Hash(bound = ""),
             Clone(bound = ""),
             Copy(bound = ""),
-            Debug(bound = ""),
             PartialEq(bound = ""),
             Eq(bound = "")
         )]
@@ -253,6 +252,12 @@ macro_rules! impl_Fp {
                 if !self.is_valid() {
                     self.0.sub_noborrow(&P::MODULUS);
                 }
+            }
+        }
+        
+        impl<P> ark_std::fmt::Debug for $Fp<P> {
+            fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
+                ark_std::fmt::Debug::fmt(&self.0, f)
             }
         }
 

--- a/ff/src/fields/macros.rs
+++ b/ff/src/fields/macros.rs
@@ -254,7 +254,7 @@ macro_rules! impl_Fp {
                 }
             }
         }
-        
+
         impl<P> ark_std::fmt::Debug for $Fp<P> {
             fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
                 ark_std::fmt::Debug::fmt(&self.0, f)


### PR DESCRIPTION
## Description

The recent GitHub actions are falling because it is accessing the 0.3.0 version of curves, while we recently did a refactoring on curve parameters.

This PR is to see if we can convince GitHub actions to use the latest curves.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.

N/A:
- [ ] Wrote unit tests
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Updated relevant documentation in the code