### PR TITLE
Update ff version on readme for asm

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ RUSTFLAGS="-C target-feature=+bmi2,+adx" cargo +nightly [test/build/bench] --fea
 To enable this in the `Cargo.toml` of your own projects, enable the `asm` feature flag:
 
 ```toml
-ark-ff = { version = "0.1", features = [ "asm" ] }
+ark-ff = { version = "0.3.0", features = [ "asm" ] }
 ```
 
 Note that because inline assembly support in Rust is currently unstable, using this backend requires using the Nightly compiler at the moment.


### PR DESCRIPTION
## Description

```
In the readme there's a tiny advice to add this line to improve the performances of finite field arithmetic:

ark-ff = { version = "0.1", features = [ "asm" ] }
however the current version of ark-ff is 0.3
```

closes: #347

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
