### PR TITLE
Rename BigInteger::add_nocarry and sub_noborrow and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
     - Rename `Fp*Parameters` to `Fp*Config`.
     - Add `From<u32>`, `From<u16>`, and `From<u8>` `impl`s for `BigInt<N>`.
     - Remove `FftConfig`; move its contents to `FftField`.
+- [\#383](https://github.com/arkworks-rs/algebra/pull/383) (arc-ff) Rename `BigInteger::add_nocarry` to `add_with_carry` and `sub_noborrow` to `sub_with_borrow`.
+
 
 ### Features
 

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -85,7 +85,7 @@ macro_rules! const_modulo {
             remainder = remainder.const_mul2();
             remainder.0[0] |= $a.get_bit(i as usize) as u64;
             if remainder.const_geq($divisor) {
-                let (r, borrow) = remainder.const_sub_noborrow($divisor);
+                let (r, borrow) = remainder.const_sub_with_borrow($divisor);
                 remainder = r;
                 assert!(!borrow);
             }
@@ -183,7 +183,7 @@ impl<const N: usize> BigInt<N> {
 
     #[inline]
     #[ark_ff_asm::unroll_for_loops]
-    pub(crate) const fn const_sub_noborrow(mut self, other: &Self) -> (Self, bool) {
+    pub(crate) const fn const_sub_with_borrow(mut self, other: &Self) -> (Self, bool) {
         let mut borrow = 0;
 
         const_for!((i in 0..N) {

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -701,7 +701,8 @@ pub trait BigInteger:
     /// Number of 64-bit limbs representing `Self`.
     const NUM_LIMBS: usize;
 
-    /// Mutably add another bigint representation to this one, returning the carry bit.
+    /// Add another [`BigInteger`] to `self`. This method stores the result in `self`,
+    /// and returns a carry bit.
     /// # Example
     ///
     /// ```
@@ -721,7 +722,8 @@ pub trait BigInteger:
     /// ```
     fn add_with_carry(&mut self, other: &Self) -> bool;
 
-    /// Mutably subtract another bigint representation from this one, returning
+    /// Subtract another [`BigInteger`] from this one. This method stores the result in
+    /// `self`, and returns a borrow.
     /// the borrow bit.
     /// # Example
     ///

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -708,14 +708,15 @@ pub trait BigInteger:
     /// use ark_ff::{biginteger::BigInteger64 as B, BigInteger as _};
     ///
     /// // Basic
-    /// let (mut one, mut two_add) = (B::from(1u64), B::from(2u64));
-    /// two_add.add_with_carry(&one);
-    /// assert_eq!(two_add, B::from(3u64));
+    /// let (mut one, mut x) = (B::from(1u64), B::from(2u64));
+    /// let carry = x.add_with_carry(&one);
+    /// assert_eq!(x, B::from(3u64));
+    /// assert_eq!(carry, false);
     ///
     /// // Edge-Case
-    /// let mut max_one = B::from(u64::MAX);
-    /// let carry = max_one.add_with_carry(&one);
-    /// assert_eq!(max_one, B::from(0u64));
+    /// let mut x = B::from(u64::MAX);
+    /// let carry = x.add_with_carry(&one);
+    /// assert_eq!(x, B::from(0u64));
     /// assert_eq!(carry, true)
     /// ```
     fn add_with_carry(&mut self, other: &Self) -> bool;
@@ -728,14 +729,15 @@ pub trait BigInteger:
     /// use ark_ff::{biginteger::BigInteger64 as B, BigInteger as _};
     ///
     /// // Basic
-    /// let (mut one, mut two, mut three_sub) = (B::from(1u64), B::from(2u64), B::from(3u64));
-    /// three_sub.sub_with_borrow(&two);
-    /// assert_eq!(three_sub, one);
+    /// let (mut one_sub, two, mut three_sub) = (B::from(1u64), B::from(2u64), B::from(3u64));
+    /// let borrow = three_sub.sub_with_borrow(&two);
+    /// assert_eq!(three_sub, one_sub);
+    /// assert_eq!(borrow, false);
     ///
     /// // Edge-Case
-    /// let borrow = one.sub_with_borrow(&two);
+    /// let borrow = one_sub.sub_with_borrow(&two);
+    /// assert_eq!(one_sub, B::from(u64::MAX));
     /// assert_eq!(borrow, true);
-    /// assert_eq!(one, B::from(u64::MAX));
     /// ```
     fn sub_with_borrow(&mut self, other: &Self) -> bool;
 

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -14,24 +14,24 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
 
     // a + 0 = a
     let mut a0_add = a.clone();
-    a0_add.add_nocarry(&zero);
+    a0_add.add_with_carry(&zero);
     assert_eq!(a0_add, a);
 
     // a - 0 = a
     let mut a0_sub = a.clone();
-    a0_sub.sub_noborrow(&zero);
+    a0_sub.sub_with_borrow(&zero);
     assert_eq!(a0_sub, a);
 
     // a - a = 0
     let mut aa_sub = a.clone();
-    aa_sub.sub_noborrow(&a);
+    aa_sub.sub_with_borrow(&a);
     assert_eq!(aa_sub, zero);
 
     // a + b = b + a
     let mut ab_add = a.clone();
-    ab_add.add_nocarry(&b);
+    ab_add.add_with_carry(&b);
     let mut ba_add = b.clone();
-    ba_add.add_nocarry(&a);
+    ba_add.add_with_carry(&a);
     assert_eq!(ab_add, ba_add);
 }
 

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -37,6 +37,18 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
     let ba_carry = ba_add.add_with_carry(&a);
     assert_eq!(ab_add, ba_add);
     assert_eq!(ab_carry, ba_carry);
+
+    // a * 1 = a
+    let mut a_mul1 = a.clone();
+    a_mul1.muln(0);
+    assert_eq!(a_mul1, a);
+
+    // a * 2 = a + a
+    let mut a_mul2 = a.clone();
+    a_mul2.mul2();
+    let mut a_plus_a = a.clone();
+    a_plus_a.add_with_carry(&a); // Won't assert anything about carry bit.
+    assert_eq!(a_mul2, a_plus_a);
 }
 
 // Test correctness of BigInteger's bit values

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -14,25 +14,29 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
 
     // a + 0 = a
     let mut a0_add = a.clone();
-    a0_add.add_with_carry(&zero);
+    let carry = a0_add.add_with_carry(&zero);
     assert_eq!(a0_add, a);
+    assert_eq!(carry, false);
 
     // a - 0 = a
     let mut a0_sub = a.clone();
-    a0_sub.sub_with_borrow(&zero);
+    let borrow = a0_sub.sub_with_borrow(&zero);
     assert_eq!(a0_sub, a);
+    assert_eq!(borrow, false);
 
     // a - a = 0
     let mut aa_sub = a.clone();
-    aa_sub.sub_with_borrow(&a);
+    let borrow = aa_sub.sub_with_borrow(&a);
     assert_eq!(aa_sub, zero);
+    assert_eq!(borrow, false);
 
     // a + b = b + a
     let mut ab_add = a.clone();
-    ab_add.add_with_carry(&b);
+    let ab_carry = ab_add.add_with_carry(&b);
     let mut ba_add = b.clone();
-    ba_add.add_with_carry(&a);
+    let ba_carry = ba_add.add_with_carry(&a);
     assert_eq!(ab_add, ba_add);
+    assert_eq!(ab_carry, ba_carry);
 }
 
 // Test correctness of BigInteger's bit values

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -198,7 +198,7 @@ impl<P: FpConfig<N>, const N: usize> Fp<P, N> {
     #[inline]
     fn subtract_modulus(&mut self) {
         if !self.is_less_than_modulus() {
-            self.0.sub_noborrow(&Self::MODULUS);
+            self.0.sub_with_borrow(&Self::MODULUS);
         }
     }
 
@@ -733,7 +733,7 @@ impl<P: FpConfig<N>, const N: usize> Neg for Fp<P, N> {
     fn neg(self) -> Self {
         if !self.is_zero() {
             let mut tmp = P::MODULUS;
-            tmp.sub_noborrow(&self.0);
+            tmp.sub_with_borrow(&self.0);
             Fp::new(tmp)
         } else {
             self

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -432,7 +432,7 @@ where
         // This is cheaper than `P::BaseField::one().double().inverse()`
         let mut two_inv = P::BasePrimeField::MODULUS;
 
-        two_inv.add_nocarry(&1u64.into());
+        two_inv.add_with_carry(&1u64.into());
         two_inv.div2();
 
         let two_inv = P::BasePrimeField::from(two_inv);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Rename `BigInteger::add_nocarry` to `add_with_carry` and `sub_noborrow` to `sub_with_borrow`.
- Add assertions for the carry and borrow bits for biginteger addition and subtraction, as well as simple multiplication tests.
- Run fmt.

I did not rename the functions in arithmetic.rs, because those functions seem to actually ignore the carry and borrow bits.

closes: #335, #336

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
