### PR TITLE
Change default `BigInt` `Display` impl to decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [\#386](https://github.com/arkworks-rs/algebra/pull/386) (`ark-ff`) Remove `PrimeField::GENERATOR`, since it already exists on `FftField`.
 - [\#393](https://github.com/arkworks-rs/algebra/pull/393) (`ark-ec`, `ark-ff`) Rename `FpXParams` to `FpXConfig` and `FpXParamsWrapper` to `FpXConfigWrapper`.
 - [\#396](https://github.com/arkworks-rs/algebra/pull/396) (`ark-ec`) Remove `mul_bits` feature, and remove default implementations of `mul` and `mul_by_cofactor_to_projective`.
+- [\#408](https://github.com/arkworks-rs/algebra/pull/408) (`ark-ff`) Change the output of `Display` formatting for BigInt & Fp from hex to decimal.
 
 ### Features
 

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -8,7 +8,7 @@ use ark_ff_macros::unroll_for_loops;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{
     convert::TryFrom,
-    fmt::{Debug, Display},
+    fmt::{Debug, Display, UpperHex},
     io::{Read, Result as IoResult, Write},
     rand::{
         distributions::{Distribution, Standard},
@@ -513,10 +513,19 @@ impl<const N: usize> FromBytes for BigInt<N> {
     }
 }
 
-impl<const N: usize> Display for BigInt<N> {
+impl<const N: usize> UpperHex for BigInt<N> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         for i in self.0.iter().rev() {
             write!(f, "{:016X}", *i)?;
+        }
+        Ok(())
+    }
+}
+
+impl<const N: usize> Display for BigInt<N> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        for i in self.0.iter().rev() {
+            write!(f, "{}", *i)?;
         }
         Ok(())
     }

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -11,6 +11,7 @@ use ark_std::{
     marker::PhantomData,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     str::FromStr,
+    string::ToString,
     One, Zero,
 };
 
@@ -722,12 +723,13 @@ impl<P: FpConfig<N>, const N: usize> FromStr for Fp<P, N> {
     }
 }
 
-/// Outputs a string containing the value of `self`, chunked up into
-/// 64-bit limbs.
+/// Outputs a string containing the value of `self`,
+/// represented as a decimal without leading zeroes.
 impl<P: FpConfig<N>, const N: usize> Display for Fp<P, N> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, stringify!(Fp "({})"), self.into_bigint())
+        let string = self.into_bigint().to_string();
+        write!(f, "{}", string.trim_start_matches('0'))
     }
 }
 

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -232,6 +232,10 @@ pub fn from_str_test<F: PrimeField>() {
             let b = F::from(n);
 
             assert_eq!(a, b);
+            let c = F::from_str(&ark_std::format!("{}", a))
+                .map_err(|_| ())
+                .unwrap();
+            assert_eq!(a, c);
         }
     }
 
@@ -239,6 +243,7 @@ pub fn from_str_test<F: PrimeField>() {
     assert!(F::from_str("0").map_err(|_| ()).unwrap().is_zero());
     assert!(F::from_str("00").is_err());
     assert!(F::from_str("00000000000").is_err());
+    assert!(F::from_str("000000000007").is_err());
 }
 
 pub fn field_test<F: Field>(a: F, b: F) {


### PR DESCRIPTION
## Description

The output of `format!("{}", some_bigint));` is now a decimal string without leading zeroes.
As a consequence, the Display for Fq follows the same format.
This supersedes https://github.com/arkworks-rs/algebra/pull/322 @hdevalence.

`Display` should be used for a human-friendly (?decimal) representation, and we should use the specialised `UpperHex` for its...well, hex, representation.

closes: #322

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
