### PR TITLE
refactor: rename UV/MVPolynomial to DenseUV/MVPolynomial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [\#393](https://github.com/arkworks-rs/algebra/pull/393) (`ark-ec`, `ark-ff`) Rename `FpXParams` to `FpXConfig` and `FpXParamsWrapper` to `FpXConfigWrapper`.
 - [\#396](https://github.com/arkworks-rs/algebra/pull/396) (`ark-ec`) Remove `mul_bits` feature, and remove default implementations of `mul` and `mul_by_cofactor_to_projective`.
 - [\#408](https://github.com/arkworks-rs/algebra/pull/408) (`ark-ff`) Change the output of `Display` formatting for BigInt & Fp from hex to decimal.
+- [\#412](https://github.com/arkworks-rs/algebra/pull/412) (`ark-poly`) rename UV/MVPolynomial to DenseUV/MVPolynomial
 
 ### Features
 

--- a/ec/src/hashing/curve_maps/wb/mod.rs
+++ b/ec/src/hashing/curve_maps/wb/mod.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 
 use crate::{models::SWModelParameters, ModelParameters};
 use ark_ff::batch_inversion;
-use ark_poly::{univariate::DensePolynomial, Polynomial, UVPolynomial};
+use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Polynomial};
 
 use crate::{
     hashing::{map_to_curve_hasher::MapToCurve, HashToCurveError},

--- a/poly-benches/benches/dense_uv_polynomial.rs
+++ b/poly-benches/benches/dense_uv_polynomial.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 use ark_ff::{FftField, Field};
 use ark_poly::{
     polynomial::univariate::{DensePolynomial, SparsePolynomial},
-    EvaluationDomain, GeneralEvaluationDomain, Polynomial, UVPolynomial,
+    DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial,
 };
 use ark_poly_benches::size_range;
 use ark_std::rand::Rng;

--- a/poly-benches/benches/fft.rs
+++ b/poly-benches/benches/fft.rs
@@ -2,7 +2,7 @@ extern crate criterion;
 
 use ark_ff::FftField;
 use ark_poly::{
-    polynomial::{univariate::DensePolynomial, UVPolynomial},
+    polynomial::{univariate::DensePolynomial, DenseUVPolynomial},
     EvaluationDomain, MixedRadixEvaluationDomain, Radix2EvaluationDomain,
 };
 use ark_poly_benches::size_range;

--- a/poly/README.md
+++ b/poly/README.md
@@ -16,21 +16,21 @@ The `polynomial` module provides the following traits for defining polynomials i
 Requires implementors to support common operations on polynomials,
 such as `Add`, `Sub`, `Zero`, evaluation at a point, degree, etc,
 and defines methods to serialize to and from the coefficient representation of the polynomial.
-- [`UVPolynomial`](./src/polynomial/mod.rs#L43) :
+- [`DenseUVPolynomial`](./src/polynomial/mod.rs#L43) :
 Specifies that a `Polynomial` is actually a *univariate* polynomial.
-- [`MVPolynomial`](./src/polynomial/mod.rs#L59):
+- [`DenseMVPolynomial`](./src/polynomial/mod.rs#L59):
 Specifies that a `Polynomial` is actually a *multivariate* polynomial.
 
 This crate also provides the following data structures that implement these traits:
 
 - [`univariate/DensePolynomial`](./src/polynomial/univariate/dense.rs#L22):
 Represents degree `d` univariate polynomials via a list of `d + 1` coefficients.
-This struct implements the [`UVPolynomial`](./src/polynomial/mod.rs#L43) trait.
+This struct implements the [`DenseUVPolynomial`](./src/polynomial/mod.rs#L43) trait.
 - [`univariate/SparsePolynomial`](./src/polynomial/univariate/sparse.rs#L15):
 Represents degree `d` univariate polynomials via a list containing all non-zero monomials.
 This should only be used when most coefficients of the polynomial are zero.
 This struct implements the [`Polynomial`](./src/polynomial/mod.rs#L16) trait
-(but *not* the `UVPolynomial` trait).
+(but *not* the `DenseUVPolynomial` trait).
 - [`multivariate/SparsePolynomial`](./src/polynomial/multivariate/sparse.rs#L21):
 Represents multivariate polynomials via a list containing all non-zero monomials.
 

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -239,7 +239,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
 mod tests {
     use crate::{
         domain::Vec,
-        polynomial::{univariate::*, Polynomial, UVPolynomial},
+        polynomial::{univariate::*, DenseUVPolynomial, Polynomial},
         EvaluationDomain, Radix2EvaluationDomain,
     };
     use ark_ff::{FftField, Field, One, UniformRand, Zero};

--- a/poly/src/evaluations/univariate/mod.rs
+++ b/poly/src/evaluations/univariate/mod.rs
@@ -1,6 +1,8 @@
 //! A univariate polynomial represented in evaluations form.
 
-use crate::{univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain, UVPolynomial};
+use crate::{
+    univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain,
+};
 use ark_ff::{batch_inversion, FftField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -35,7 +35,7 @@ pub use evaluations::{
     },
     univariate::Evaluations,
 };
-pub use polynomial::{multivariate, univariate, MVPolynomial, Polynomial, UVPolynomial};
+pub use polynomial::{multivariate, univariate, DenseMVPolynomial, DenseUVPolynomial, Polynomial};
 
 #[cfg(test)]
 mod test;

--- a/poly/src/polynomial/mod.rs
+++ b/poly/src/polynomial/mod.rs
@@ -40,7 +40,7 @@ pub trait Polynomial<F: Field>:
 }
 
 /// Describes the interface for univariate polynomials
-pub trait UVPolynomial<F: Field>: Polynomial<F, Point = F> {
+pub trait DenseUVPolynomial<F: Field>: Polynomial<F, Point = F> {
     /// Constructs a new polynomial from a list of coefficients.
     fn from_coefficients_slice(coeffs: &[F]) -> Self;
 
@@ -56,7 +56,7 @@ pub trait UVPolynomial<F: Field>: Polynomial<F, Point = F> {
 }
 
 /// Describes the interface for multivariate polynomials
-pub trait MVPolynomial<F: Field>: Polynomial<F> {
+pub trait DenseMVPolynomial<F: Field>: Polynomial<F> {
     /// The type of the terms of `self`
     type Term: multivariate::Term;
 

--- a/poly/src/polynomial/multivariate/sparse.rs
+++ b/poly/src/polynomial/multivariate/sparse.rs
@@ -1,7 +1,7 @@
 //! A sparse multivariate polynomial represented in coefficient form.
 use crate::{
     multivariate::{SparseTerm, Term},
-    MVPolynomial, Polynomial,
+    DenseMVPolynomial, Polynomial,
 };
 use ark_ff::{Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
@@ -58,7 +58,7 @@ impl<F: Field> Polynomial<F> for SparsePolynomial<F, SparseTerm> {
     }
 }
 
-impl<F: Field> MVPolynomial<F> for SparsePolynomial<F, SparseTerm> {
+impl<F: Field> DenseMVPolynomial<F> for SparsePolynomial<F, SparseTerm> {
     /// Returns the number of variables in `self`
     fn num_vars(&self) -> usize {
         self.num_vars

--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -1,7 +1,7 @@
 //! A dense univariate polynomial represented in coefficient form.
 use crate::{
     univariate::{DenseOrSparsePolynomial, SparsePolynomial},
-    EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial, UVPolynomial,
+    DenseUVPolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial,
 };
 use ark_ff::{FftField, Field, Zero};
 use ark_serialize::*;
@@ -94,7 +94,7 @@ impl<F: Field> DensePolynomial<F> {
     }
 }
 
-impl<F: Field> UVPolynomial<F> for DensePolynomial<F> {
+impl<F: Field> DenseUVPolynomial<F> for DensePolynomial<F> {
     /// Constructs a new polynomial from a list of coefficients.
     fn from_coefficients_slice(coeffs: &[F]) -> Self {
         Self::from_coefficients_vec(coeffs.to_vec())

--- a/poly/src/polynomial/univariate/mod.rs
+++ b/poly/src/polynomial/univariate/mod.rs
@@ -1,6 +1,6 @@
 //! Work with sparse and dense polynomials.
 
-use crate::{EvaluationDomain, Evaluations, Polynomial, UVPolynomial};
+use crate::{DenseUVPolynomial, EvaluationDomain, Evaluations, Polynomial};
 use ark_ff::{FftField, Field, Zero};
 use ark_std::{borrow::Cow, convert::TryInto, vec::Vec};
 use DenseOrSparsePolynomial::*;

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -2,7 +2,7 @@
 use crate::{
     polynomial::Polynomial,
     univariate::{DenseOrSparsePolynomial, DensePolynomial},
-    EvaluationDomain, Evaluations, UVPolynomial,
+    DenseUVPolynomial, EvaluationDomain, Evaluations,
 };
 use ark_ff::{FftField, Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};


### PR DESCRIPTION
Fixes #170

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue
- [ ] Wrote unit tests (rename)
- [x] Updated relevant documentation in the code:
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer