### PR TITLE
Add `sum_of_products`

### DIFF
--- a/ec/src/models/short_weierstrass.rs
+++ b/ec/src/models/short_weierstrass.rs
@@ -584,7 +584,7 @@ impl<P: SWCurveConfig> ProjectiveCurve for Projective<P> {
             self.z.double_in_place();
 
             // X3 = F-2*D
-            self.x = f - &d - &d;
+            self.x = f - &d.double();
 
             // Y3 = E*(D-X3)-8*C
             self.y = (d - &self.x) * &e - &*c.double_in_place().double_in_place().double_in_place();
@@ -663,7 +663,7 @@ impl<P: SWCurveConfig> ProjectiveCurve for Projective<P> {
                     i.double_in_place().double_in_place();
 
                     // J = H*I
-                    let mut j = h * &i;
+                    let j = h * &i;
 
                     // r = 2*(S2-Y1)
                     let r = (s2 - &self.y).double();
@@ -674,15 +674,13 @@ impl<P: SWCurveConfig> ProjectiveCurve for Projective<P> {
                     // X3 = r^2 - J - 2*V
                     self.x = r.square();
                     self.x -= &j;
-                    self.x -= &v;
-                    self.x -= &v;
+                    self.x -= &v.double();
 
                     // Y3 = r*(V-X3)-2*Y1*J
-                    j *= &self.y; // J = 2*Y1*J
-                    j.double_in_place();
-                    self.y = v - &self.x;
-                    self.y *= &r;
-                    self.y -= &j;
+                    self.y = P::BaseField::sum_of_products(
+                        &[r, -self.y.double()],
+                        &[(v - &self.x), j]
+                    );
 
                     // Z3 = (Z1+H)^2-Z1Z1-HH
                     self.z += &h;
@@ -779,7 +777,10 @@ impl<'a, P: SWCurveConfig> AddAssign<&'a Self> for Projective<P> {
             self.x = r.square() - &j - &(v.double());
 
             // Y3 = r*(V - X3) - 2*S1*J
-            self.y = r * &(v - &self.x) - &*(s1 * &j).double_in_place();
+            self.y = P::BaseField::sum_of_products(
+                &[r, -s1.double()],
+                &[(v - &self.x), j]
+            );
 
             // Z3 = ((Z1+Z2)^2 - Z1Z1 - Z2Z2)*H
             self.z = ((self.z + &other.z).square() - &z1z1 - &z2z2) * &h;

--- a/ec/src/models/short_weierstrass.rs
+++ b/ec/src/models/short_weierstrass.rs
@@ -677,10 +677,8 @@ impl<P: SWCurveConfig> ProjectiveCurve for Projective<P> {
                     self.x -= &v.double();
 
                     // Y3 = r*(V-X3)-2*Y1*J
-                    self.y = P::BaseField::sum_of_products(
-                        &[r, -self.y.double()],
-                        &[(v - &self.x), j]
-                    );
+                    self.y =
+                        P::BaseField::sum_of_products(&[r, -self.y.double()], &[(v - &self.x), j]);
 
                     // Z3 = (Z1+H)^2-Z1Z1-HH
                     self.z += &h;
@@ -777,10 +775,7 @@ impl<'a, P: SWCurveConfig> AddAssign<&'a Self> for Projective<P> {
             self.x = r.square() - &j - &(v.double());
 
             // Y3 = r*(V - X3) - 2*S1*J
-            self.y = P::BaseField::sum_of_products(
-                &[r, -s1.double()],
-                &[(v - &self.x), j]
-            );
+            self.y = P::BaseField::sum_of_products(&[r, -s1.double()], &[(v - &self.x), j]);
 
             // Z3 = ((Z1+Z2)^2 - Z1Z1 - Z2Z2)*H
             self.z = ((self.z + &other.z).square() - &z1z1 - &z2z2) * &h;

--- a/ec/src/models/short_weierstrass.rs
+++ b/ec/src/models/short_weierstrass.rs
@@ -607,7 +607,7 @@ impl<P: SWCurveConfig> ProjectiveCurve for Projective<P> {
             let s = ((self.x + &yy).square() - &xx - &yyyy).double();
 
             // M = 3*XX+a*ZZ^2
-            let m = xx + &xx + &xx + &P::mul_by_a(&zz.square());
+            let m = xx + xx.double() + P::mul_by_a(&zz.square());
 
             // T = M^2-2*S
             let t = m.square() - &s.double();

--- a/ff/src/biginteger/arithmetic.rs
+++ b/ff/src/biginteger/arithmetic.rs
@@ -15,21 +15,6 @@ pub(crate) fn adc(a: u64, b: u64, carry: &mut u64) -> u64 {
     adc!(a, b, &mut *carry)
 }
 
-macro_rules! mac_with_carry {
-    ($a:expr, $b:expr, $c:expr, &mut $carry:expr$(,)?) => {{
-        let tmp = ($a as u128) + ($b as u128 * $c as u128) + ($carry as u128);
-        $carry = (tmp >> 64) as u64;
-        tmp as u64
-    }};
-}
-
-/// Calculate a + (b * c) + carry, returning the least significant digit
-/// and setting carry to the most significant digit.
-#[inline(always)]
-pub(crate) fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
-    mac_with_carry!(a, b, c, &mut *carry)
-}
-
 #[macro_export]
 macro_rules! sbb {
     ($a:expr, $b:expr, &mut $borrow:expr$(,)?) => {{
@@ -64,6 +49,21 @@ pub(crate) fn mac_discard(a: u64, b: u64, c: u64, carry: &mut u64) {
     let tmp = (u128::from(a)) + u128::from(b) * u128::from(c);
 
     *carry = (tmp >> 64) as u64;
+}
+
+macro_rules! mac_with_carry {
+    ($a:expr, $b:expr, $c:expr, &mut $carry:expr$(,)?) => {{
+        let tmp = ($a as u128) + ($b as u128 * $c as u128) + ($carry as u128);
+        $carry = (tmp >> 64) as u64;
+        tmp as u64
+    }};
+}
+
+/// Calculate a + (b * c) + carry, returning the least significant digit
+/// and setting carry to the most significant digit.
+#[inline(always)]
+pub(crate) fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
+    mac_with_carry!(a, b, c, &mut *carry)
 }
 
 /// Compute the NAF (non-adjacent form) of num

--- a/ff/src/biginteger/arithmetic.rs
+++ b/ff/src/biginteger/arithmetic.rs
@@ -12,7 +12,16 @@ macro_rules! adc {
 /// carry value.
 #[inline(always)]
 pub(crate) fn adc(a: u64, b: u64, carry: &mut u64) -> u64 {
-    adc!(a, b, &mut *carry)
+    let tmp = a as u128 + b as u128 + *carry as u128;
+    *carry = (tmp >> 64) as u64;
+    tmp as u64
+}
+
+/// Calculate a + b + carry, returning the sum
+#[inline(always)]
+pub(crate) fn adc_no_carry(a: u64, b: u64, carry: &mut u64) -> u64 {
+    let tmp = a as u128 + b as u128 + *carry as u128;
+    tmp as u64
 }
 
 #[macro_export]
@@ -35,10 +44,8 @@ pub(crate) fn sbb(a: u64, b: u64, borrow: &mut u64) -> u64 {
 /// `carry` to the upper 64 bits.
 #[inline(always)]
 pub(crate) fn mac(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
-    let tmp = (u128::from(a)) + u128::from(b) * u128::from(c);
-
+    let tmp = (a as u128) + (b as u128 * c as u128);
     *carry = (tmp >> 64) as u64;
-
     tmp as u64
 }
 
@@ -46,8 +53,7 @@ pub(crate) fn mac(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
 /// `carry` to the upper 64 bits.
 #[inline(always)]
 pub(crate) fn mac_discard(a: u64, b: u64, c: u64, carry: &mut u64) {
-    let tmp = (u128::from(a)) + u128::from(b) * u128::from(c);
-
+    let tmp = (a as u128) + (b as u128 * c as u128);
     *carry = (tmp >> 64) as u64;
 }
 
@@ -59,11 +65,21 @@ macro_rules! mac_with_carry {
     }};
 }
 
+macro_rules! mac {
+    ($a:expr, $b:expr, $c:expr, &mut $carry:expr$(,)?) => {{
+        let tmp = ($a as u128) + ($b as u128 * $c as u128);
+        $carry = (tmp >> 64) as u64;
+        tmp as u64
+    }};
+}
+
 /// Calculate a + (b * c) + carry, returning the least significant digit
 /// and setting carry to the most significant digit.
 #[inline(always)]
 pub(crate) fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
-    mac_with_carry!(a, b, c, &mut *carry)
+    let tmp = (a as u128) + (b as u128 * c as u128) + (*carry as u128);
+    *carry = (tmp >> 64) as u64;
+    tmp as u64
 }
 
 /// Compute the NAF (non-adjacent form) of num

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -232,19 +232,10 @@ pub trait Field:
     /// Returns `sum([a_i * b_i])`.
     #[inline]
     fn sum_of_products(a: &[Self], b: &[Self]) -> Self {
-        #[cfg(not(feature = "parallel"))]
-        {
-            a.iter()
-                .zip(b)
-                .fold(Self::zero(), |acc, (a, b)| acc + *a * b)
-        }
-        #[cfg(feature = "parallel")]
-        {
-            cfg_iter!(a)
-                .zip(b)
-                .fold(|| Self::zero(), |acc, (a, b)| acc + *a * b)
-                .sum()
-        }
+        cfg_iter!(a)
+            .zip(b)
+            .map(|(a, b)| *a * b)
+            .sum()
     }
 
     /// Exponentiates this element by a power of the base prime modulus via

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -229,6 +229,19 @@ pub trait Field:
     /// `self` to `self.inverse().unwrap()`.
     fn inverse_in_place(&mut self) -> Option<&mut Self>;
 
+    /// Returns `sum([a_i * b_i])`.
+    #[inline]
+    fn sum_of_products(a: &[Self], b: &[Self]) -> Self {
+        #[cfg(not(feature = "parallel"))]
+        {
+            a.iter().zip(b).fold(Self::zero(), |acc, (a, b)| acc + *a * b)
+        }
+        #[cfg(feature = "parallel")]
+        {
+            cfg_iter!(a).zip(b).fold(|| Self::zero(), |acc, (a, b)| acc + *a * b).sum()
+        }
+    }
+
     /// Exponentiates this element by a power of the base prime modulus via
     /// the Frobenius automorphism.
     fn frobenius_map(&mut self, power: usize);

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -232,10 +232,7 @@ pub trait Field:
     /// Returns `sum([a_i * b_i])`.
     #[inline]
     fn sum_of_products(a: &[Self], b: &[Self]) -> Self {
-        cfg_iter!(a)
-            .zip(b)
-            .map(|(a, b)| *a * b)
-            .sum()
+        cfg_iter!(a).zip(b).map(|(a, b)| *a * b).sum()
     }
 
     /// Exponentiates this element by a power of the base prime modulus via

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -234,11 +234,16 @@ pub trait Field:
     fn sum_of_products(a: &[Self], b: &[Self]) -> Self {
         #[cfg(not(feature = "parallel"))]
         {
-            a.iter().zip(b).fold(Self::zero(), |acc, (a, b)| acc + *a * b)
+            a.iter()
+                .zip(b)
+                .fold(Self::zero(), |acc, (a, b)| acc + *a * b)
         }
         #[cfg(feature = "parallel")]
         {
-            cfg_iter!(a).zip(b).fold(|| Self::zero(), |acc, (a, b)| acc + *a * b).sum()
+            cfg_iter!(a)
+                .zip(b)
+                .fold(|| Self::zero(), |acc, (a, b)| acc + *a * b)
+                .sum()
         }
     }
 

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -76,6 +76,9 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
     /// Set a *= b.
     fn mul_assign(a: &mut Fp<Self, N>, b: &Fp<Self, N>);
 
+    /// Compute the inner product `<a, b>`.
+    fn sum_of_products(a: &[Fp<Self, N>], b: &[Fp<Self, N>]) -> Fp<Self, N>;
+
     /// Set a *= b.
     fn square_in_place(a: &mut Fp<Self, N>);
 
@@ -215,6 +218,11 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
     #[inline]
     fn characteristic() -> &'static [u64] {
         P::MODULUS.as_ref()
+    }
+
+    #[inline]
+    fn sum_of_products(a: &[Self], b: &[Self]) -> Self {
+        P::sum_of_products(a, b)
     }
 
     #[inline]

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -312,7 +312,7 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
         b: &[Fp<MontBackend<Self, N>, N>],
     ) -> Fp<MontBackend<Self, N>, N> {
         assert_eq!(a.len(), b.len());
-        // Adapted from zkcrypto/bls12_381.
+        // Adapted from https://github.com/zkcrypto/bls12_381/pull/84 by @str4d.
 
         // For a single `a x b` multiplication, operand scanning (schoolbook) takes each
         // limb of `a` in turn, and multiplies it by all of the limbs of `b` to compute

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -335,37 +335,45 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
         } else {
             let chunk_size = 2 * (N * 64 - modulus_size) - 1;
             // chunk_size is at least 1, since MODULUS_BIT_SIZE is at most N * 64 - 1.
-            a.chunks(chunk_size).zip(b.chunks(chunk_size)).map(|(a, b)| {
-                // Algorithm 2, line 2
-                let result = (0..N).fold(BigInt::zero(), |mut result, j| {
-                    // Algorithm 2, line 3
-                    let (temp, end) = 
-                    a.iter()
-                        .zip(b)
-                        .fold((result, 0), |(mut temp, mut end), (Fp(a, _), Fp(b, _))| {
-                            let mut carry = 0;
-                            temp.0[0] = fa::mac(temp.0[0], a.0[j], b.0[0], &mut carry);
-                            for k in 1..N {
-                                temp.0[k] = fa::mac_with_carry(temp.0[k], a.0[j], b.0[k], &mut carry);
-                            }
-                            end = fa::adc_no_carry(end, 0, &mut carry);
-                            (temp, end)
-                        });
-                    
-                    let k = temp.0[0].wrapping_mul(Self::INV);
-                    let mut carry = 0;
-                    fa::mac_discard(temp.0[0], k, Self::MODULUS.0[0], &mut carry);
-                    for i in 1..N {
-                        result.0[i - 1] = fa::mac_with_carry(temp.0[i], k, Self::MODULUS.0[i], &mut carry);
-                    }
-                    result.0[N - 1] = fa::adc_no_carry(end, 0, &mut carry);
+            a.chunks(chunk_size)
+                .zip(b.chunks(chunk_size))
+                .map(|(a, b)| {
+                    // Algorithm 2, line 2
+                    let result = (0..N).fold(BigInt::zero(), |mut result, j| {
+                        // Algorithm 2, line 3
+                        let (temp, end) = a.iter().zip(b).fold(
+                            (result, 0),
+                            |(mut temp, mut end), (Fp(a, _), Fp(b, _))| {
+                                let mut carry = 0;
+                                temp.0[0] = fa::mac(temp.0[0], a.0[j], b.0[0], &mut carry);
+                                for k in 1..N {
+                                    temp.0[k] =
+                                        fa::mac_with_carry(temp.0[k], a.0[j], b.0[k], &mut carry);
+                                }
+                                end = fa::adc_no_carry(end, 0, &mut carry);
+                                (temp, end)
+                            },
+                        );
+
+                        let k = temp.0[0].wrapping_mul(Self::INV);
+                        let mut carry = 0;
+                        fa::mac_discard(temp.0[0], k, Self::MODULUS.0[0], &mut carry);
+                        for i in 1..N {
+                            result.0[i - 1] =
+                                fa::mac_with_carry(temp.0[i], k, Self::MODULUS.0[i], &mut carry);
+                        }
+                        result.0[N - 1] = fa::adc_no_carry(end, 0, &mut carry);
+                        result
+                    });
+                    let mut result = Fp::new_unchecked(result);
+                    result.subtract_modulus();
+                    debug_assert_eq!(
+                        a.iter().zip(b).map(|(a, b)| *a * b).sum::<Fp<_, N>>(),
+                        result
+                    );
                     result
-                });
-                let mut result = Fp::new_unchecked(result);
-                result.subtract_modulus();
-                debug_assert_eq!(a.iter().zip(b).map(|(a, b)| *a * b).sum::<Fp<_, N>>(), result);
-                result
-            }).sum()
+                })
+                .sum()
         }
     }
 }

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -206,12 +206,11 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
         for i in 0..N {
             let k = r[i].wrapping_mul(Self::INV);
             let mut carry = 0;
-            fa::mac_with_carry(r[i], k, Self::MODULUS.0[0], &mut carry);
+            fa::mac_discard(r[i], k, Self::MODULUS.0[0], &mut carry);
             for j in 1..N {
                 r[j + i] = fa::mac_with_carry(r[j + i], k, Self::MODULUS.0[j], &mut carry);
             }
-            r.b1[i] = fa::adc(r.b1[i], carry2, &mut carry);
-            carry2 = carry;
+            r.b1[i] = fa::adc(r.b1[i], carry, &mut carry2);
         }
         (a.0).0.copy_from_slice(&r.b1);
         a.subtract_modulus();
@@ -307,6 +306,7 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
         tmp
     }
 
+    #[unroll_for_loops(12)]
     fn sum_of_products(
         a: &[Fp<MontBackend<Self, N>, N>],
         b: &[Fp<MontBackend<Self, N>, N>],
@@ -329,33 +329,44 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
         //   need to store a single extra limb overall, instead of keeping around all the
         //   intermediate results and eventually having twice as many limbs.
 
-        // Algorithm 2, line 2
-        let result = (0..N).fold(BigInt::zero(), |mut result, j| {
-            // Algorithm 2, line 3
-            let (temp, end) =
-                a.iter()
-                    .zip(b)
-                    .fold((result, 0), |(mut temp, end), (Fp(a, _), Fp(b, _))| {
-                        let mut carry = 0;
-                        temp.0[0] = fa::mac(temp.0[0], a.0[j], b.0[0], &mut carry);
-                        for k in 1..N {
-                            temp.0[k] = fa::mac_with_carry(temp.0[k], a.0[j], b.0[k], &mut carry);
-                        }
-                        (temp, fa::adc(end, 0, &mut carry))
-                    });
-
-            let mut carry = 0;
-            let k = temp.0[0].wrapping_mul(Self::INV);
-            fa::mac_discard(temp.0[0], k, Self::MODULUS.0[0], &mut carry);
-            for i in 1..N {
-                result.0[i - 1] = fa::mac_with_carry(temp.0[i], k, Self::MODULUS.0[i], &mut carry);
-            }
-            result.0[N - 1] = fa::adc(end, 0, &mut carry);
-            result
-        });
-        let mut result = Fp::new(result);
-        result.subtract_modulus();
-        result
+        let modulus_size = Self::MODULUS.const_num_bits() as usize;
+        if modulus_size > 64 * N - 1 {
+            a.iter().zip(b).map(|(a, b)| *a * b).sum()
+        } else {
+            let chunk_size = 2 * (N * 64 - modulus_size) - 1;
+            // chunk_size is at least 1, since MODULUS_BIT_SIZE is at most N * 64 - 1.
+            a.chunks(chunk_size).zip(b.chunks(chunk_size)).map(|(a, b)| {
+                // Algorithm 2, line 2
+                let result = (0..N).fold(BigInt::zero(), |mut result, j| {
+                    // Algorithm 2, line 3
+                    let (temp, end) = 
+                    a.iter()
+                        .zip(b)
+                        .fold((result, 0), |(mut temp, mut end), (Fp(a, _), Fp(b, _))| {
+                            let mut carry = 0;
+                            temp.0[0] = fa::mac(temp.0[0], a.0[j], b.0[0], &mut carry);
+                            for k in 1..N {
+                                temp.0[k] = fa::mac_with_carry(temp.0[k], a.0[j], b.0[k], &mut carry);
+                            }
+                            end = fa::adc_no_carry(end, 0, &mut carry);
+                            (temp, end)
+                        });
+                    
+                    let k = temp.0[0].wrapping_mul(Self::INV);
+                    let mut carry = 0;
+                    fa::mac_discard(temp.0[0], k, Self::MODULUS.0[0], &mut carry);
+                    for i in 1..N {
+                        result.0[i - 1] = fa::mac_with_carry(temp.0[i], k, Self::MODULUS.0[i], &mut carry);
+                    }
+                    result.0[N - 1] = fa::adc_no_carry(end, 0, &mut carry);
+                    result
+                });
+                let mut result = Fp::new_unchecked(result);
+                result.subtract_modulus();
+                debug_assert_eq!(a.iter().zip(b).map(|(a, b)| *a * b).sum::<Fp<_, N>>(), result);
+                result
+            }).sum()
+        }
     }
 }
 
@@ -570,8 +581,8 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
         let mut carry2 = 0;
         crate::const_for!((i in 0..N) {
             let tmp = lo[i].wrapping_mul(T::INV);
-            let mut carry = 0;
-            mac_with_carry!(lo[i], tmp, T::MODULUS.0[0], &mut carry);
+            let mut carry;
+            mac!(lo[i], tmp, T::MODULUS.0[0], &mut carry);
             crate::const_for!((j in 1..N) {
                 let k = i + j;
                 if k >= N {
@@ -580,8 +591,7 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
                     lo[k] = mac_with_carry!(lo[k], tmp, T::MODULUS.0[j], &mut carry);
                 }
             });
-            hi[i] = adc!(hi[i], carry2, &mut carry);
-            carry2 = carry;
+            hi[i] = adc!(hi[i], carry, &mut carry2);
         });
 
         crate::const_for!((i in 0..N) {

--- a/test-curves/src/bls12_381/fr.rs
+++ b/test-curves/src/bls12_381/fr.rs
@@ -5,3 +5,21 @@ use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 #[generator = "7"]
 pub struct FrConfig;
 pub type Fr = Fp256<MontBackend<FrConfig, 4>>;
+
+#[test]
+fn test_inv() {
+    assert_eq!(FrConfig::INV, 0xffff_fffe_ffff_ffff);
+}
+
+#[test]
+fn test_modulus() {
+    assert_eq!(
+        FrConfig::MODULUS.0,
+        [
+            0xffff_ffff_0000_0001,
+            0x53bd_a402_fffe_5bfe,
+            0x3339_d808_09a1_d805,
+            0x73ed_a753_299d_7d48,
+        ]
+    );
+}

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -76,6 +76,16 @@ fn random_multiplication_tests<F: Field, R: Rng>(rng: &mut R) {
     }
 }
 
+fn random_sum_of_products_tests<F: Field, R: Rng>(rng: &mut R) {
+    for _ in 0..ITERATIONS {
+        let a = (0..10).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        let b = (0..10).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        let result_1 = F::sum_of_products(&a, &b);
+        let result_2 = a.into_iter().zip(b).map(|(a, b)| a * b).sum::<F>();
+        assert_eq!(result_1, result_2);
+    }
+}
+
 fn random_inversion_tests<F: Field, R: Rng>(rng: &mut R) {
     assert!(F::zero().inverse().is_none());
 
@@ -162,6 +172,7 @@ fn random_field_tests<F: Field>() {
     random_addition_tests::<F, _>(&mut rng);
     random_subtraction_tests::<F, _>(&mut rng);
     random_multiplication_tests::<F, _>(&mut rng);
+    random_sum_of_products_tests::<F, _>(&mut rng);
     random_inversion_tests::<F, _>(&mut rng);
     random_doubling_tests::<F, _>(&mut rng);
     random_squaring_tests::<F, _>(&mut rng);

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -78,11 +78,45 @@ fn random_multiplication_tests<F: Field, R: Rng>(rng: &mut R) {
 
 fn random_sum_of_products_tests<F: Field, R: Rng>(rng: &mut R) {
     for _ in 0..ITERATIONS {
-        let a = (0..10).map(|_| F::rand(rng)).collect::<Vec<_>>();
-        let b = (0..10).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        for length in 1..100 {
+            let a = (0..length).map(|_| F::rand(rng)).collect::<Vec<_>>();
+            let b = (0..length).map(|_| F::rand(rng)).collect::<Vec<_>>();
+            let result_1 = F::sum_of_products(&a, &b);
+            let result_2 = a.into_iter().zip(b).map(|(a, b)| a * b).sum::<F>();
+            assert_eq!(result_1, result_2, "length: {length}");
+        }
+    }
+}
+
+fn edge_case_sum_of_products_tests<F: PrimeField>() {
+    use ark_ff::BigInteger;
+    let mut a_max = F::ZERO.into_bigint();
+    for (i, limb) in a_max.as_mut().iter_mut().enumerate() {
+        if i == F::BigInt::NUM_LIMBS - 1 {
+            *limb = u64::MAX >> (64 - ((F::MODULUS_BIT_SIZE - 1) % 64));
+        } else {
+            *limb = u64::MAX;
+        }
+    }
+    let a_max = F::from_bigint(a_max).unwrap();
+    let b_max = -F::one(); // p - 1.
+    for length in 1..100 {
+        let a = vec![a_max; length];
+        let b = vec![b_max; length];
         let result_1 = F::sum_of_products(&a, &b);
         let result_2 = a.into_iter().zip(b).map(|(a, b)| a * b).sum::<F>();
-        assert_eq!(result_1, result_2);
+        assert_eq!(result_1, result_2, "length: {length}");
+    }
+    let two_inv = F::from(2u64).inverse().unwrap();
+    let neg_one = -F::one();
+    let a_max = neg_one * two_inv - F::one();
+    let b_max = neg_one * two_inv - F::one();
+    for length in 1..100 {
+        let a = vec![a_max; length];
+        let b = vec![b_max; length];
+        let result_1 = F::sum_of_products(&a, &b);
+        let result_2 = a.into_iter().zip(b).map(|(a, b)| a * b).sum::<F>();
+        assert_eq!(result_1, result_2, "length: {length}");
     }
 }
 
@@ -358,6 +392,9 @@ pub fn primefield_test<F: PrimeField>() {
     from_str_test::<F>();
     let one = F::one();
     assert_eq!(F::from(one.into_bigint()), one);
+
+    let mut rng = ark_std::test_rng();
+    edge_case_sum_of_products_tests::<F>();
 
     fft_field_test::<F>();
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adapts https://github.com/zkcrypto/bls12_381/pull/84 to `ark-ff`. Resolves #121.

I believe the code in `bls12_381` has a bug wherein it does not work for any arbitrary number of inputs (additions overflow the allocated space). So I've modified it to chunk up the inputs into smaller batches where we *can* guarantee that we won't have overflow issues.

I've also used the new method in short weierstrass point additions. This shaves off ~20ns for additions:

Old:
```
test bls12_381::g1::add_assign         ... bench:         726 ns/iter (+/- 28)
test bls12_381::g1::add_assign_mixed   ... bench:         546 ns/iter (+/- 13)
```

New:
```
test bls12_381::g1::add_assign         ... bench:         704 ns/iter (+/- 33)
test bls12_381::g1::add_assign_mixed   ... bench:         526 ns/iter (+/- 18)
```
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
