### PR TITLE
Introduce an explicit clear-cofactor method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [\#386](https://github.com/arkworks-rs/algebra/pull/386) (`ark-ff-macros`, `ark-ff`) Add a macro to derive `MontConfig`.
 - [\#396](https://github.com/arkworks-rs/algebra/pull/396) (`ark-ec`) Add a default `mul` function to `{TE,SW}ModelParameters` trait definition.
 - [\#397](https://github.com/arkworks-rs/algebra/pull/397) (`ark-ec`) Add `HashMapPippenger` to variable-base MSM.
+- [\#420](https://github.com/arkworks-rs/algebra/pull/420) (`ark-ec`) Add a `clear_cofactor` method to `AffineCurve`.
 
 ### Improvements
 

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -289,6 +289,14 @@ pub trait AffineCurve:
     #[must_use]
     fn mul<S: Into<<Self::ScalarField as PrimeField>::BigInt>>(&self, by: S) -> Self::Projective;
 
+    /// Performs cofactor clearing.
+    /// The default method is simply to multiply by the cofactor.
+    /// For some curve families more efficient methods exist. 
+    #[must_use]
+    fn clear_cofactor(&self) -> Self {
+        self.mul_by_cofactor()
+    }
+
     /// Multiplies this element by the cofactor and output the
     /// resulting projective element.
     #[must_use]

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -291,7 +291,7 @@ pub trait AffineCurve:
 
     /// Performs cofactor clearing.
     /// The default method is simply to multiply by the cofactor.
-    /// For some curve families more efficient methods exist. 
+    /// For some curve families more efficient methods exist.
     #[must_use]
     fn clear_cofactor(&self) -> Self;
 

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -293,9 +293,7 @@ pub trait AffineCurve:
     /// The default method is simply to multiply by the cofactor.
     /// For some curve families more efficient methods exist. 
     #[must_use]
-    fn clear_cofactor(&self) -> Self {
-        self.mul_by_cofactor()
-    }
+    fn clear_cofactor(&self) -> Self;
 
     /// Multiplies this element by the cofactor and output the
     /// resulting projective element.

--- a/ec/src/models/mod.rs
+++ b/ec/src/models/mod.rs
@@ -80,8 +80,7 @@ pub trait SWModelParameters: ModelParameters {
 
     /// Performs cofactor clearing.
     /// The default method is simply to multiply by the cofactor.
-    /// For some curve families though, it is sufficient to multiply
-    /// by a smaller scalar.
+    /// Some curves can implement a more efficient algorithm.
     fn clear_cofactor(
         item: &short_weierstrass_jacobian::GroupAffine<Self>,
     ) -> short_weierstrass_jacobian::GroupAffine<Self> {

--- a/ec/src/models/mod.rs
+++ b/ec/src/models/mod.rs
@@ -1,4 +1,4 @@
-use crate::ProjectiveCurve;
+use crate::{ProjectiveCurve, AffineCurve};
 use ark_ff::{Field, PrimeField, SquareRootField, Zero};
 
 pub mod bls12;
@@ -76,6 +76,16 @@ pub trait SWModelParameters: ModelParameters {
         item: &short_weierstrass_jacobian::GroupAffine<Self>,
     ) -> bool {
         Self::mul_affine(item, Self::ScalarField::characteristic()).is_zero()
+    }
+
+    /// Performs cofactor clearing.
+    /// The default method is simply to multiply by the cofactor.
+    /// For some curve families though, it is sufficient to multiply
+    /// by a smaller scalar.
+    fn clear_cofactor(
+        item: &short_weierstrass_jacobian::GroupAffine<Self>,
+     ) -> short_weierstrass_jacobian::GroupAffine<Self> {
+        item.clear_cofactor()
     }
 
     /// Default implementation of group multiplication for projective

--- a/ec/src/models/mod.rs
+++ b/ec/src/models/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ProjectiveCurve, AffineCurve};
+use crate::{AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, PrimeField, SquareRootField, Zero};
 
 pub mod bls12;
@@ -84,8 +84,8 @@ pub trait SWModelParameters: ModelParameters {
     /// by a smaller scalar.
     fn clear_cofactor(
         item: &short_weierstrass_jacobian::GroupAffine<Self>,
-     ) -> short_weierstrass_jacobian::GroupAffine<Self> {
-        item.clear_cofactor()
+    ) -> short_weierstrass_jacobian::GroupAffine<Self> {
+        item.mul_by_cofactor()
     }
 
     /// Default implementation of group multiplication for projective
@@ -156,6 +156,16 @@ pub trait TEModelParameters: ModelParameters {
         item: &twisted_edwards_extended::GroupAffine<Self>,
     ) -> bool {
         Self::mul_affine(item, Self::ScalarField::characteristic()).is_zero()
+    }
+
+    /// Performs cofactor clearing.
+    /// The default method is simply to multiply by the cofactor.
+    /// For some curve families though, it is sufficient to multiply
+    /// by a smaller scalar.
+    fn clear_cofactor(
+        item: &twisted_edwards_extended::GroupAffine<Self>,
+    ) -> twisted_edwards_extended::GroupAffine<Self> {
+        item.mul_by_cofactor()
     }
 
     /// Default implementation of group multiplication for projective

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -233,6 +233,9 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
         P::mul_affine(self, Self::Parameters::COFACTOR)
     }
 
+    /// Performs cofactor clearing.
+    /// The default method is simply to multiply by the cofactor.
+    /// Some curves can implement a more efficient algorithm.
     #[must_use]
     fn clear_cofactor(&self) -> Self {
         P::clear_cofactor(&self)

--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -232,6 +232,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     fn mul_by_cofactor_to_projective(&self) -> Self::Projective {
         P::mul_affine(self, Self::Parameters::COFACTOR)
     }
+
+    #[must_use]
+    fn clear_cofactor(&self) -> Self {
+        P::clear_cofactor(&self)
+    }
 }
 
 impl<P: Parameters> Neg for GroupAffine<P> {

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -153,6 +153,9 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
         P::mul_affine(self, Self::Parameters::COFACTOR)
     }
 
+    /// Performs cofactor clearing.
+    /// The default method is simply to multiply by the cofactor.
+    /// Some curves can implement a more efficient algorithm.
     #[must_use]
     fn clear_cofactor(&self) -> Self {
         P::clear_cofactor(&self)

--- a/ec/src/models/twisted_edwards_extended.rs
+++ b/ec/src/models/twisted_edwards_extended.rs
@@ -152,6 +152,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     fn mul_by_cofactor_to_projective(&self) -> Self::Projective {
         P::mul_affine(self, Self::Parameters::COFACTOR)
     }
+
+    #[must_use]
+    fn clear_cofactor(&self) -> Self {
+        P::clear_cofactor(&self)
+    }
 }
 
 impl<P: Parameters> Zeroize for GroupAffine<P> {

--- a/test-curves/src/bls12_381/g1.rs
+++ b/test-curves/src/bls12_381/g1.rs
@@ -39,7 +39,6 @@ impl SWModelParameters for Parameters {
     #[inline(always)]
     fn mul_by_a(_: &Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
-
     }
 
     #[inline]

--- a/test-curves/src/bls12_381/g1.rs
+++ b/test-curves/src/bls12_381/g1.rs
@@ -39,6 +39,17 @@ impl SWModelParameters for Parameters {
     #[inline(always)]
     fn mul_by_a(_: &Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
+
+    }
+    #[inline]
+    fn clear_cofactor(p: &G1Affine) -> G1Affine {
+        // Using the effective cofactor, as explained in
+        // Section 5 of https://eprint.iacr.org/2019/403.pdf.
+        //
+        // It is enough to multiply by (x - 1), instead of (x - 1)^2 / 3
+        // sqrt(76329603384216526031706109802092473003*3) = 15132376222941642753
+        let h_eff: &[u64] = &[0xd201000000010001];
+        Parameters::mul_affine(&p, h_eff).into()
     }
 }
 

--- a/test-curves/src/bls12_381/g1.rs
+++ b/test-curves/src/bls12_381/g1.rs
@@ -41,6 +41,7 @@ impl SWModelParameters for Parameters {
         Self::BaseField::zero()
 
     }
+
     #[inline]
     fn clear_cofactor(p: &G1Affine) -> G1Affine {
         // Using the effective cofactor, as explained in

--- a/test-templates/src/curves.rs
+++ b/test-templates/src/curves.rs
@@ -1,7 +1,8 @@
 #![allow(unused)]
 use ark_ec::{
-    twisted_edwards_extended::GroupProjective, wnaf::WnafContext, AffineCurve,
-    MontgomeryModelParameters, ProjectiveCurve, SWModelParameters, TEModelParameters,
+    short_weierstrass_jacobian::GroupAffine, twisted_edwards_extended::GroupProjective,
+    wnaf::WnafContext, AffineCurve, MontgomeryModelParameters, ProjectiveCurve, SWModelParameters,
+    TEModelParameters,
 };
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SWFlags, SerializationError};
@@ -302,6 +303,7 @@ pub fn sw_tests<P: SWModelParameters>() {
     sw_curve_serialization_test::<P>();
     sw_from_random_bytes::<P>();
     sw_affine_sum_test::<P>();
+    sw_cofactor_clearing_test::<P>();
 }
 
 pub fn sw_from_random_bytes<P: SWModelParameters>() {
@@ -433,6 +435,17 @@ pub fn sw_affine_sum_test<P: SWModelParameters>() {
     }
 }
 
+fn sw_cofactor_clearing_test<P: SWModelParameters>() {
+    let mut rng = ark_std::test_rng();
+
+    for _ in 0..ITERATIONS {
+        let a = GroupAffine::<P>::rand(&mut rng);
+        // let a_affine = a.into_affine();
+        let b = a.clear_cofactor();
+        assert!(b.is_in_correct_subgroup_assuming_on_curve());
+    }
+}
+
 pub fn montgomery_conversion_test<P>()
 where
     P: TEModelParameters,
@@ -454,6 +467,7 @@ where
 {
     edwards_curve_serialization_test::<P>();
     edwards_from_random_bytes::<P>();
+    edwards_cofactor_clearing_test::<P>();
 }
 
 pub fn edwards_from_random_bytes<P: TEModelParameters>()
@@ -557,5 +571,15 @@ pub fn edwards_curve_serialization_test<P: TEModelParameters>() {
             let b = GroupAffine::<P>::deserialize_uncompressed(&mut cursor).unwrap();
             assert_eq!(a, b);
         }
+    }
+}
+
+fn edwards_cofactor_clearing_test<P: TEModelParameters>() {
+    let mut rng = ark_std::test_rng();
+
+    for _ in 0..ITERATIONS {
+        let a = GroupProjective::<P>::rand(&mut rng).into_affine();
+        let b = a.clear_cofactor();
+        assert!(b.is_in_correct_subgroup_assuming_on_curve());
     }
 }

--- a/test-templates/src/curves.rs
+++ b/test-templates/src/curves.rs
@@ -440,7 +440,6 @@ fn sw_cofactor_clearing_test<P: SWModelParameters>() {
 
     for _ in 0..ITERATIONS {
         let a = GroupAffine::<P>::rand(&mut rng);
-        // let a_affine = a.into_affine();
         let b = a.clear_cofactor();
         assert!(b.is_in_correct_subgroup_assuming_on_curve());
     }


### PR DESCRIPTION
There are faster ways to clear the cofactor that multiplying by `h`, see e.g. https://eprint.iacr.org/2021/1130.pdf.
In this PR I expose a method `clear_cofactor` on `AffineCurve`, which SW/TE-ModelParameters implement with a default `mul_by_cofactor()` call, but which allows upstream implementers of these traits to override with a more efficient implementation.

As an example, I've added a concrete speedup for bls12-381 G1 (see [companion PR in curves](https://github.com/arkworks-rs/curves/pull/103)) which employs multiplication by a smaller scalar than the cofactor itself.
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

related to https://github.com/arkworks-rs/algebra/issues/308

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
