### PR TITLE
`QUADRATIC_NONRESIDUE` is not used

### DIFF
--- a/ff/src/fields/models/fp2.rs
+++ b/ff/src/fields/models/fp2.rs
@@ -12,9 +12,6 @@ pub trait Fp2Config: 'static + Send + Sync + Sized {
     /// `f(X) = X^2 - Self::NONRESIDUE` in Fp\[X\] is irreducible in `Self::Fp`.
     const NONRESIDUE: Self::Fp;
 
-    /// A quadratic nonresidue in Fp2, used for calculating square roots in Fp2.
-    const QUADRATIC_NONRESIDUE: Fp2<Self>;
-
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_FP2_C1: &'static [Self::Fp];
 

--- a/test-curves/src/bls12_381/fq2.rs
+++ b/test-curves/src/bls12_381/fq2.rs
@@ -12,10 +12,6 @@ impl Fp2Config for Fq2Config {
     #[rustfmt::skip]
     const NONRESIDUE: Fq = MontFp!(Fq, "-1");
 
-    /// QUADRATIC_NONRESIDUE = (U + 1)
-    #[rustfmt::skip]
-    const QUADRATIC_NONRESIDUE: Fq2 = QuadExt!(FQ_ONE, FQ_ONE);
-
     /// Coefficients for the Frobenius automorphism.
     #[rustfmt::skip]
     const FROBENIUS_COEFF_FP2_C1: &'static [Fq] = &[


### PR DESCRIPTION
Either the sqrt algorithm was changed or the variable was never used.

## Description

Slightly simplifies the interface for fp2.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
