### PR TITLE
Add katex support in documentation.

### DIFF
--- a/doc/katex-header.html
+++ b/doc/katex-header.html
@@ -1,0 +1,31 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
+
+<!-- The loading of KaTeX is deferred to speed up page rendering -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js" integrity="sha384-X/XCfMm41VSsqRNQgDerQczD69XqmjOOOwYQvr/uuC+j4OPoNhVgjdGFwhvN02Ja" crossorigin="anonymous"></script>
+
+<!-- To automatically render math in text elements, include the auto-render extension: -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"
+    onload="renderMathInElement(document.body);"></script>
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+renderMathInElement(document.body, {
+    macros: {
+    "\\defeq": ":=",
+    "\\FF": "\\mathbb{F}",
+    "\\GG": "\\mathbb{G}",
+    "\\prover": "\\mathsf{P}",
+    "\\verifier": "\\mathsf{V}",
+    },
+    delimiters: [
+        {left: "$$", right: "$$", display: true},
+        {left: "$", right: "$", display: false},
+    ],
+});
+});
+</script>
+<style>
+.katex { font-size: 1em !important; }
+pre.rust, .docblock code, .docblock-short code { font-size: 0.85em !important; }
+</style>
+

--- a/doc/katex-header.html
+++ b/doc/katex-header.html
@@ -1,4 +1,4 @@
-<!DOCTYPE> <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
+<!DOCTYPE html> <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
 
 <!-- The loading of KaTeX is deferred to speed up page rendering -->
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js" integrity="sha384-X/XCfMm41VSsqRNQgDerQczD69XqmjOOOwYQvr/uuC+j4OPoNhVgjdGFwhvN02Ja" crossorigin="anonymous"></script>

--- a/doc/katex-header.html
+++ b/doc/katex-header.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
+<!DOCTYPE> <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
 
 <!-- The loading of KaTeX is deferred to speed up page rendering -->
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js" integrity="sha384-X/XCfMm41VSsqRNQgDerQczD69XqmjOOOwYQvr/uuC+j4OPoNhVgjdGFwhvN02Ja" crossorigin="anonymous"></script>

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -46,3 +46,7 @@ default = []
 std = [ "ark-std/std", "ark-serialize/std" ]
 parallel = [ "std", "rayon", "ark-std/parallel" ]
 asm = []
+
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "../doc/katex-header.html"]

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -1,3 +1,7 @@
+//! Utilities for a field $\FF$.
+//!
+//!
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
     unused,

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+doc:
+	RUSTDOCFLAGS="--html-in-header doc/katex-header.html" cargo doc --no-deps
+
+.PHONY: doc


### PR DESCRIPTION
This commit adds latex support within rustdoc for arkworks algebra.
In order to add latex code in textmode, use delimiters `$` and `$`.
In order to add latex code in displaymode, use delimiters `$$` and `$$`.
To compile the documentation, use `cargo rustdoc`.

This is achieved via the option `--html-in-header` set via
- the environment variable `RUSTDOCFLAGS`, or
- the variable `build.rustdocflags` of `.cargo/config.toml`
I opted for the latter making it a default compilation flag to use with
rustdoc.

IMPORTANT: for some reason (independent from us) `cargo rustdoc` fails
on rust nightly and this is due to a failure concerning `cfg-if` and
`rand-chacha`. I did not investigate the reason why this happened.

