### PR TITLE
Fix deserialization for modulo with 64 shaving bits 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 - [\#350](https://github.com/arkworks-rs/algebra/pull/350) (`ark-serialize`) Fix issues with hygiene whenever a non-standard `Result` type is in scope.
 - [\#358](https://github.com/arkworks-rs/algebra/pull/358) (`ark-ff`) Fix the bug for `QuadExtField::sqrt` when `c1 = 0 && c0.legendre.is_qnr()`
 - [\#366](https://github.com/arkworks-rs/algebra/pull/366) (`ark-ff`) Fix `norm()` for cubic extension field towers.
+- [\#394](https://github.com/arkworks-rs/algebra/pull/394) (`ark-ff`, `ark-serialize`) Remove `EmptyFlags` construction checks.
+- [\#442](https://github.com/arkworks-rs/algebra/pull/442) (`ark-ff`) Fix deserialization for modulo with 64 shaving bits.
 
 ## v0.3.0
 

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -228,7 +228,8 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
             result_bytes.copy_from_u8_slice(bytes);
             // This mask retains everything in the last limb
             // that is below `P::MODULUS_BIT_SIZE`.
-            let last_limb_mask = (u64::MAX.checked_shr(shave_bits).unwrap_or(0)).to_le_bytes();
+            let last_limb_mask =
+                (u64::MAX.checked_shr(shave_bits as u32).unwrap_or(0)).to_le_bytes();
             let mut last_bytes_mask = [0u8; 9];
             last_bytes_mask[..8].copy_from_slice(&last_limb_mask);
 

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -240,7 +240,7 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
             let flag_location = output_byte_size - 1;
 
             // At which byte is the flag located in the last limb?
-            let flag_location_in_last_limb = flag_location - (8 * (N - 1));
+            let flag_location_in_last_limb = flag_location.checked_sub(8 * ($limbs - 1)).unwrap_or(0);
 
             // Take all but the last 9 bytes.
             let last_bytes = result_bytes.last_n_plus_1_bytes_mut();

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -228,7 +228,7 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
             result_bytes.copy_from_u8_slice(bytes);
             // This mask retains everything in the last limb
             // that is below `P::MODULUS_BIT_SIZE`.
-            let last_limb_mask = (u64::MAX >> shave_bits).to_le_bytes();
+            let last_limb_mask = (u64::MAX.checked_shr(shave_bits).unwrap_or(0)).to_le_bytes();
             let mut last_bytes_mask = [0u8; 9];
             last_bytes_mask[..8].copy_from_slice(&last_limb_mask);
 

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -240,7 +240,7 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
             let flag_location = output_byte_size - 1;
 
             // At which byte is the flag located in the last limb?
-            let flag_location_in_last_limb = flag_location.checked_sub(8 * ($limbs - 1)).unwrap_or(0);
+            let flag_location_in_last_limb = flag_location.checked_sub(8 * (N - 1)).unwrap_or(0);
 
             // Take all but the last 9 bytes.
             let last_bytes = result_bytes.last_n_plus_1_bytes_mut();


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In an application, I need to instantiate a field in which the modulus is 256 bits. In arkworks-rs, this field must use Fp320 instead of Fp256, and therefore the number of shaving bits is 64 bits.

However, this can cause an issue during deserialization. 

This PR fixes this issue.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
