### PR TITLE
Use 2-NAF for representing `ATE_LOOP_COUNT` in MNT Miller loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
     - Bound `AffineCurve` by
         - `Mul<ScalarField, Output = ProjectiveCurve>`
         - `for<'a> Mul<&'a ScalarField, Output = ProjectiveCurve>`
+- [\#445](https://github.com/arkworks-rs/algebra/pull/445) (`ark-ec`) Change the `ATE_LOOP_COUNT` in MNT4/6 curves to use 2-NAF.
 - [\#446](https://github.com/arkworks-rs/algebra/pull/446) (`ark-ff`) Add `CyclotomicMultSubgroup` trait and impl for extension fields
 
 ### Features
@@ -84,6 +85,7 @@
 - [\#339](https://github.com/arkworks-rs/algebra/pull/339) (`ark-ff`) Remove duplicated code from `test_field` module and replace its usage with `ark-test-curves` crate.
 - [\#352](https://github.com/arkworks-rs/algebra/pull/352) (`ark-ff`) Update `QuadExtField::sqrt` for better performance.
 - [\#357](https://github.com/arkworks-rs/algebra/pull/357) (`ark-poly`) Speedup division by vanishing polynomials for dense polynomials.
+- [\#445](https://github.com/arkworks-rs/algebra/pull/445) (`ark-ec`) Use 2-NAF for ate pairing in MNT4/6 curves.
 
 ### Bugfixes
 

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -57,7 +57,6 @@ impl<P: MNT4Parameters> From<G2Affine<P>> for G2Prepared<P> {
 
         let neg_g2 = g2.neg();
         for bit in P::ATE_LOOP_COUNT_2.iter().skip(1) {
-            // print!("{}", bit);
             let (r2, coeff) = MNT4::<P>::doubling_step_for_flipped_miller_loop(&r);
             g2p.double_coefficients.push(coeff);
             r = r2;

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -56,7 +56,7 @@ impl<P: MNT4Parameters> From<G2Affine<P>> for G2Prepared<P> {
         };
 
         let neg_g2 = g2.neg();
-        for bit in P::ATE_LOOP_COUNT_2.iter().skip(1) {
+        for bit in P::ATE_LOOP_COUNT.iter().skip(1) {
             let (r2, coeff) = MNT4::<P>::doubling_step_for_flipped_miller_loop(&r);
             g2p.double_coefficients.push(coeff);
             r = r2;

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -74,7 +74,7 @@ impl<P: MNT4Parameters> From<G2Affine<P>> for G2Prepared<P> {
                     );
                 },
                 0 => continue,
-                _ => unimplemented!(),
+                _ => unreachable!(),
             }
             g2p.addition_coefficients.push(add_coeff);
             r = r_temp;

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -1,4 +1,4 @@
-use core::ops::Neg;
+use ark_std::ops::Neg;
 
 use crate::{
     mnt4::MNT4Parameters,
@@ -73,7 +73,8 @@ impl<P: MNT4Parameters> From<G2Affine<P>> for G2Prepared<P> {
                         &neg_g2.x, &neg_g2.y, &r,
                     );
                 },
-                _ => continue,
+                0 => continue,
+                _ => unimplemented!()
             }
             g2p.addition_coefficients.push(add_coeff);
             r = r_temp;

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -74,7 +74,7 @@ impl<P: MNT4Parameters> From<G2Affine<P>> for G2Prepared<P> {
                     );
                 },
                 0 => continue,
-                _ => unimplemented!()
+                _ => unimplemented!(),
             }
             g2p.addition_coefficients.push(add_coeff);
             r = r_temp;

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -36,47 +36,38 @@ impl<P: MNT4Parameters> Default for G2Prepared<P> {
 }
 
 impl<P: MNT4Parameters> From<G2Affine<P>> for G2Prepared<P> {
-    fn from(g2: G2Affine<P>) -> Self {
+    fn from(g: G2Affine<P>) -> Self {
         let twist_inv = P::TWIST.inverse().unwrap();
 
-        let mut g2p = G2Prepared {
-            x: g2.x,
-            y: g2.y,
-            x_over_twist: g2.x * &twist_inv,
-            y_over_twist: g2.y * &twist_inv,
+        let mut g_prep = G2Prepared {
+            x: g.x,
+            y: g.y,
+            x_over_twist: g.x * &twist_inv,
+            y_over_twist: g.y * &twist_inv,
             double_coefficients: vec![],
             addition_coefficients: vec![],
         };
 
         let mut r = G2ProjectiveExtended {
-            x: g2.x,
-            y: g2.y,
+            x: g.x,
+            y: g.y,
             z: <Fp2<P::Fp2Config>>::one(),
             t: <Fp2<P::Fp2Config>>::one(),
         };
 
-        let neg_g2 = g2.neg();
+        let neg_g = g.neg();
         for bit in P::ATE_LOOP_COUNT.iter().skip(1) {
-            let (r2, coeff) = MNT4::<P>::doubling_step_for_flipped_miller_loop(&r);
-            g2p.double_coefficients.push(coeff);
+            let (r2, coeff) = MNT4::<P>::doubling_for_flipped_miller_loop(&r);
+            g_prep.double_coefficients.push(coeff);
             r = r2;
 
-            let add_coeff;
-            let r_temp;
-            match bit {
-                1 => {
-                    (r_temp, add_coeff) =
-                        MNT4::<P>::mixed_addition_step_for_flipped_miller_loop(&g2.x, &g2.y, &r);
-                },
-                -1 => {
-                    (r_temp, add_coeff) = MNT4::<P>::mixed_addition_step_for_flipped_miller_loop(
-                        &neg_g2.x, &neg_g2.y, &r,
-                    );
-                },
+            let (r_temp, add_coeff) = match bit {
+                1 => MNT4::<P>::mixed_addition_for_flipped_miller_loop(&g.x, &g.y, &r),
+                -1 => MNT4::<P>::mixed_addition_for_flipped_miller_loop(&neg_g.x, &neg_g.y, &r),
                 0 => continue,
                 _ => unreachable!(),
-            }
-            g2p.addition_coefficients.push(add_coeff);
+            };
+            g_prep.addition_coefficients.push(add_coeff);
             r = r_temp;
         }
 
@@ -88,15 +79,15 @@ impl<P: MNT4Parameters> From<G2Affine<P>> for G2Prepared<P> {
             let minus_r_affine_x = r.x * &rz2_inv;
             let minus_r_affine_y = -r.y * &rz3_inv;
 
-            let add_result = MNT4::<P>::mixed_addition_step_for_flipped_miller_loop(
+            let add_result = MNT4::<P>::mixed_addition_for_flipped_miller_loop(
                 &minus_r_affine_x,
                 &minus_r_affine_y,
                 &r,
             );
-            g2p.addition_coefficients.push(add_result.1);
+            g_prep.addition_coefficients.push(add_result.1);
         }
 
-        g2p
+        g_prep
     }
 }
 

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -46,7 +46,7 @@ pub trait MNT4Parameters: 'static {
 pub struct MNT4<P: MNT4Parameters>(PhantomData<fn() -> P>);
 
 impl<P: MNT4Parameters> MNT4<P> {
-    fn doubling_step_for_flipped_miller_loop(
+    fn doubling_for_flipped_miller_loop(
         r: &G2ProjectiveExtended<P>,
     ) -> (G2ProjectiveExtended<P>, AteDoubleCoefficients<P>) {
         let a = r.t.square();
@@ -75,7 +75,7 @@ impl<P: MNT4Parameters> MNT4<P> {
         (r2, coeff)
     }
 
-    fn mixed_addition_step_for_flipped_miller_loop(
+    fn mixed_addition_for_flipped_miller_loop(
         x: &Fp2<P::Fp2Config>,
         y: &Fp2<P::Fp2Config>,
         r: &G2ProjectiveExtended<P>,
@@ -121,28 +121,27 @@ impl<P: MNT4Parameters> MNT4<P> {
             f = f.square() * &g_rr_at_p;
 
             // Compute l_{R,Q}(P) if bit == 1, and l_{R,-Q}(P) if bit == -1
-            let g_rq_at_p;
-            if *bit == 1 {
+            let g_rq_at_p = if *bit == 1 {
                 let ac = &q.addition_coefficients[add_idx];
                 add_idx += 1;
 
-                g_rq_at_p = Fp4::new(
+                Fp4::new(
                     ac.c_rz * &p.y_twist,
                     -(q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
-                );
+                )
             } else if *bit == -1 {
                 let ac = &q.addition_coefficients[add_idx];
                 add_idx += 1;
 
-                g_rq_at_p = Fp4::new(
+                Fp4::new(
                     ac.c_rz * &p.y_twist,
                     -(y_over_twist_neg * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
-                );
+                )
             } else if *bit == 0 {
                 continue;
             } else {
                 unreachable!();
-            }
+            };
             f *= &g_rq_at_p;
         }
 

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -25,7 +25,7 @@ pub type GT<P> = Fp4<P>;
 pub trait MNT4Parameters: 'static {
     const TWIST: Fp2<Self::Fp2Config>;
     const TWIST_COEFF_A: Fp2<Self::Fp2Config>;
-    const ATE_LOOP_COUNT_2: &'static [u64];
+    const ATE_LOOP_COUNT_2: &'static [i8];
     const ATE_IS_LOOP_COUNT_NEG: bool;
     const FINAL_EXPONENT_LAST_CHUNK_1: <Self::Fp as PrimeField>::BigInt;
     const FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG: bool;

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -110,7 +110,7 @@ impl<P: MNT4Parameters> MNT4<P> {
 
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
-
+        let y_over_twist_neg = -q.y_over_twist;
         for (bit, dc) in P::ATE_LOOP_COUNT_2
             .iter()
             .skip(1)
@@ -123,22 +123,28 @@ impl<P: MNT4Parameters> MNT4<P> {
 
             f = f.square() * &g_rr_at_p;
 
-            if bit.abs() == 1 {
+            // Compute l_{R,Q}(P) if bit == 1, and l_{R,-Q}(P) if bit == -1
+            let g_rq_at_p;
+            if *bit == 1 {
                 let ac = &q.addition_coefficients[add_idx];
                 add_idx += 1;
 
-                // Compute l_{R,Q}(P) if bit == 1, and l_{R,-Q}(P) if bit == -1
-                let y_over_twist = if *bit == 1 {
-                    q.y_over_twist
-                } else {
-                    -q.y_over_twist
-                };
-                let g_rq_at_p = Fp4::new(
+                g_rq_at_p = Fp4::new(
                     ac.c_rz * &p.y_twist,
-                    -(y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
+                    -(q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
                 );
-                f *= &g_rq_at_p;
+            } else if *bit == -1 {
+                let ac = &q.addition_coefficients[add_idx];
+                add_idx += 1;
+
+                g_rq_at_p = Fp4::new(
+                    ac.c_rz * &p.y_twist,
+                    -(y_over_twist_neg * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
+                );
+            } else {
+                continue;
             }
+            f *= &g_rq_at_p;
         }
 
         if P::ATE_IS_LOOP_COUNT_NEG {

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -25,7 +25,7 @@ pub type GT<P> = Fp4<P>;
 pub trait MNT4Parameters: 'static {
     const TWIST: Fp2<Self::Fp2Config>;
     const TWIST_COEFF_A: Fp2<Self::Fp2Config>;
-    const ATE_LOOP_COUNT_2: &'static [i8];
+    const ATE_LOOP_COUNT: &'static [i8];
     const ATE_IS_LOOP_COUNT_NEG: bool;
     const FINAL_EXPONENT_LAST_CHUNK_1: <Self::Fp as PrimeField>::BigInt;
     const FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG: bool;
@@ -111,7 +111,7 @@ impl<P: MNT4Parameters> MNT4<P> {
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
         let y_over_twist_neg = -q.y_over_twist;
-        for (bit, dc) in P::ATE_LOOP_COUNT_2
+        for (bit, dc) in P::ATE_LOOP_COUNT
             .iter()
             .skip(1)
             .zip(&q.double_coefficients)

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 use ark_ff::{
     fp2::{Fp2, Fp2Config},
     fp4::{Fp4, Fp4Config},
-    BitIteratorBE, CyclotomicMultSubgroup, Field, PrimeField,
+    CyclotomicMultSubgroup, Field, PrimeField,
 };
 use num_traits::{One, Zero};
 
@@ -111,11 +111,7 @@ impl<P: MNT4Parameters> MNT4<P> {
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
         let y_over_twist_neg = -q.y_over_twist;
-        for (bit, dc) in P::ATE_LOOP_COUNT
-            .iter()
-            .skip(1)
-            .zip(&q.double_coefficients)
-        {
+        for (bit, dc) in P::ATE_LOOP_COUNT.iter().skip(1).zip(&q.double_coefficients) {
             let g_rr_at_p = Fp4::new(
                 -dc.c_4c - &(dc.c_j * &p.x_twist) + &dc.c_l,
                 dc.c_h * &p.y_twist,

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 use ark_ff::{
     fp2::{Fp2, Fp2Config},
     fp4::{Fp4, Fp4Config},
-    BitIteratorBE, Field, PrimeField,
+    Field, PrimeField,
 };
 use num_traits::{One, Zero};
 

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -111,6 +111,7 @@ impl<P: MNT4Parameters> MNT4<P> {
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
         let y_over_twist_neg = -q.y_over_twist;
+        assert_eq!(P::ATE_LOOP_COUNT.len() - 1, q.double_coefficients.len());
         for (bit, dc) in P::ATE_LOOP_COUNT.iter().skip(1).zip(&q.double_coefficients) {
             let g_rr_at_p = Fp4::new(
                 -dc.c_4c - &(dc.c_j * &p.x_twist) + &dc.c_l,
@@ -137,8 +138,10 @@ impl<P: MNT4Parameters> MNT4<P> {
                     ac.c_rz * &p.y_twist,
                     -(y_over_twist_neg * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
                 );
-            } else {
+            } else if *bit == 0 {
                 continue;
+            } else {
+                unimplemented!();
             }
             f *= &g_rq_at_p;
         }

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -141,7 +141,7 @@ impl<P: MNT4Parameters> MNT4<P> {
             } else if *bit == 0 {
                 continue;
             } else {
-                unimplemented!();
+                unreachable!();
             }
             f *= &g_rq_at_p;
         }

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -73,7 +73,8 @@ impl<P: MNT6Parameters> From<G2Affine<P>> for G2Prepared<P> {
                         &neg_g2.x, &neg_g2.y, &r,
                     );
                 },
-                _ => continue,
+                0 => continue,
+                _ => unimplemented!()
             }
             g2p.addition_coefficients.push(add_coeff);
             r = r_temp;

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -36,47 +36,38 @@ impl<P: MNT6Parameters> Default for G2Prepared<P> {
 }
 
 impl<P: MNT6Parameters> From<G2Affine<P>> for G2Prepared<P> {
-    fn from(g2: G2Affine<P>) -> Self {
+    fn from(g: G2Affine<P>) -> Self {
         let twist_inv = P::TWIST.inverse().unwrap();
 
-        let mut g2p = G2Prepared {
-            x: g2.x,
-            y: g2.y,
-            x_over_twist: g2.x * &twist_inv,
-            y_over_twist: g2.y * &twist_inv,
+        let mut g_prep = G2Prepared {
+            x: g.x,
+            y: g.y,
+            x_over_twist: g.x * &twist_inv,
+            y_over_twist: g.y * &twist_inv,
             double_coefficients: vec![],
             addition_coefficients: vec![],
         };
 
         let mut r = G2ProjectiveExtended {
-            x: g2.x,
-            y: g2.y,
+            x: g.x,
+            y: g.y,
             z: <Fp3<P::Fp3Config>>::one(),
             t: <Fp3<P::Fp3Config>>::one(),
         };
 
-        let neg_g2 = g2.neg();
+        let neg_g = g.neg();
         for bit in P::ATE_LOOP_COUNT.iter().skip(1) {
-            let (r2, coeff) = MNT6::<P>::doubling_step_for_flipped_miller_loop(&r);
-            g2p.double_coefficients.push(coeff);
+            let (r2, coeff) = MNT6::<P>::doubling_for_flipped_miller_loop(&r);
+            g_prep.double_coefficients.push(coeff);
             r = r2;
 
-            let add_coeff;
-            let r_temp;
-            match bit {
-                1 => {
-                    (r_temp, add_coeff) =
-                        MNT6::<P>::mixed_addition_step_for_flipped_miller_loop(&g2.x, &g2.y, &r);
-                },
-                -1 => {
-                    (r_temp, add_coeff) = MNT6::<P>::mixed_addition_step_for_flipped_miller_loop(
-                        &neg_g2.x, &neg_g2.y, &r,
-                    );
-                },
+            let (r_temp, add_coeff) = match bit {
+                1 => MNT6::<P>::mixed_addition_for_flipper_miller_loop(&g.x, &g.y, &r),
+                -1 => MNT6::<P>::mixed_addition_for_flipper_miller_loop(&neg_g.x, &neg_g.y, &r),
                 0 => continue,
                 _ => unreachable!(),
-            }
-            g2p.addition_coefficients.push(add_coeff);
+            };
+            g_prep.addition_coefficients.push(add_coeff);
             r = r_temp;
         }
 
@@ -85,18 +76,15 @@ impl<P: MNT6Parameters> From<G2Affine<P>> for G2Prepared<P> {
             let rz2_inv = rz_inv.square();
             let rz3_inv = rz_inv * &rz2_inv;
 
-            let minus_r_affine_x = r.x * &rz2_inv;
-            let minus_r_affine_y = -r.y * &rz3_inv;
+            let minus_r_x = r.x * &rz2_inv;
+            let minus_r_y = -r.y * &rz3_inv;
 
-            let add_result = MNT6::<P>::mixed_addition_step_for_flipped_miller_loop(
-                &minus_r_affine_x,
-                &minus_r_affine_y,
-                &r,
-            );
-            g2p.addition_coefficients.push(add_result.1);
+            let add_result =
+                MNT6::<P>::mixed_addition_for_flipper_miller_loop(&minus_r_x, &minus_r_y, &r);
+            g_prep.addition_coefficients.push(add_result.1);
         }
 
-        g2p
+        g_prep
     }
 }
 

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -57,7 +57,6 @@ impl<P: MNT6Parameters> From<G2Affine<P>> for G2Prepared<P> {
 
         let neg_g2 = g2.neg();
         for bit in P::ATE_LOOP_COUNT_2.iter().skip(1) {
-            // print!("{}", bit);
             let (r2, coeff) = MNT6::<P>::doubling_step_for_flipped_miller_loop(&r);
             g2p.double_coefficients.push(coeff);
             r = r2;

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -74,7 +74,7 @@ impl<P: MNT6Parameters> From<G2Affine<P>> for G2Prepared<P> {
                     );
                 },
                 0 => continue,
-                _ => unimplemented!()
+                _ => unimplemented!(),
             }
             g2p.addition_coefficients.push(add_coeff);
             r = r_temp;

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -56,7 +56,7 @@ impl<P: MNT6Parameters> From<G2Affine<P>> for G2Prepared<P> {
         };
 
         let neg_g2 = g2.neg();
-        for bit in P::ATE_LOOP_COUNT_2.iter().skip(1) {
+        for bit in P::ATE_LOOP_COUNT.iter().skip(1) {
             let (r2, coeff) = MNT6::<P>::doubling_step_for_flipped_miller_loop(&r);
             g2p.double_coefficients.push(coeff);
             r = r2;

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -74,7 +74,7 @@ impl<P: MNT6Parameters> From<G2Affine<P>> for G2Prepared<P> {
                     );
                 },
                 0 => continue,
-                _ => unimplemented!(),
+                _ => unreachable!(),
             }
             g2p.addition_coefficients.push(add_coeff);
             r = r_temp;

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -142,7 +142,7 @@ impl<P: MNT6Parameters> MNT6<P> {
             } else if *bit == 0 {
                 continue;
             } else {
-                unimplemented!();
+                unreachable!();
             }
             f *= &g_rq_at_p;
         }

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -125,26 +125,21 @@ impl<P: MNT6Parameters> MNT6<P> {
 
             f = f.square() * &g_rr_at_p;
 
-            match *bit {
-                1 => {
-                    let ac = &q.addition_coefficients[add_idx];
-                    add_idx += 1;
-                    let g_rq_at_p = Fp6::new(
-                        ac.c_rz * &p.y_twist,
-                        -(q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
-                    );
-                    f *= &g_rq_at_p;
-                },
-                -1 => {
-                    let ac = &q.addition_coefficients[add_idx];
-                    add_idx += 1;
-                    let g_rq_at_p = Fp6::new(
-                        ac.c_rz * &p.y_twist,
-                        -(-q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
-                    );
-                    f *= &g_rq_at_p;
-                },
-                _ => continue,
+            if bit.abs() == 1 {
+                let ac = &q.addition_coefficients[add_idx];
+                add_idx += 1;
+
+                // Compute l_{R,Q}(P) if bit == 1, and l_{R,-Q}(P) if bit == -1
+                let y_over_twist = if *bit == 1 {
+                    q.y_over_twist
+                } else {
+                    -q.y_over_twist
+                };
+                let g_rq_at_p = Fp6::new(
+                    ac.c_rz * &p.y_twist,
+                    -(y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
+                );
+                f *= &g_rq_at_p;
             }
         }
 

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -26,6 +26,7 @@ pub trait MNT6Parameters: 'static {
     const TWIST: Fp3<Self::Fp3Config>;
     const TWIST_COEFF_A: Fp3<Self::Fp3Config>;
     const ATE_LOOP_COUNT: &'static [u64];
+    const ATE_LOOP_COUNT_2: &'static [i8];
     const ATE_IS_LOOP_COUNT_NEG: bool;
     const FINAL_EXPONENT_LAST_CHUNK_1: <Self::Fp as PrimeField>::BigInt;
     const FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG: bool;

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -114,7 +114,8 @@ impl<P: MNT6Parameters> MNT6<P> {
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
         for ((ind, bit), dc) in P::ATE_LOOP_COUNT_2
-            .iter().enumerate()
+            .iter()
+            .enumerate()
             .skip(1)
             .zip(&q.double_coefficients)
         {
@@ -125,15 +126,26 @@ impl<P: MNT6Parameters> MNT6<P> {
 
             f = f.square() * &g_rr_at_p;
 
-            if *bit != 0 {
-                let ac = &q.addition_coefficients[add_idx];
-                add_idx += 1;
-
-                let g_rq_at_p = Fp6::new(
-                    ac.c_rz * &p.y_twist,
-                    -(q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
-                );
-                f *= &g_rq_at_p;
+            match *bit {
+                1 => {
+                    let ac = &q.addition_coefficients[add_idx];
+                    add_idx += 1;
+                    let g_rq_at_p = Fp6::new(
+                        ac.c_rz * &p.y_twist,
+                        -(q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
+                    );
+                    f *= &g_rq_at_p;
+                },
+                -1 => {
+                    let ac = &q.addition_coefficients[add_idx];
+                    add_idx += 1;
+                    let g_rq_at_p = Fp6::new(
+                        ac.c_rz * &p.y_twist,
+                        -(-q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
+                    );
+                    f *= &g_rq_at_p;
+                },
+                _ => continue,
             }
         }
 

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 use ark_ff::{
     fp3::{Fp3, Fp3Config},
     fp6_2over3::{Fp6, Fp6Config},
-    BitIteratorBE, Field, PrimeField,
+    Field, PrimeField,
 };
 use num_traits::{One, Zero};
 
@@ -113,7 +113,8 @@ impl<P: MNT6Parameters> MNT6<P> {
 
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
-        for (bit, dc) in BitIteratorBE::without_leading_zeros(P::ATE_LOOP_COUNT)
+        for ((ind, bit), dc) in P::ATE_LOOP_COUNT_2
+            .iter().enumerate()
             .skip(1)
             .zip(&q.double_coefficients)
         {
@@ -124,7 +125,7 @@ impl<P: MNT6Parameters> MNT6<P> {
 
             f = f.square() * &g_rr_at_p;
 
-            if bit {
+            if *bit != 0 {
                 let ac = &q.addition_coefficients[add_idx];
                 add_idx += 1;
 

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -25,7 +25,6 @@ pub type GT<P> = Fp6<P>;
 pub trait MNT6Parameters: 'static {
     const TWIST: Fp3<Self::Fp3Config>;
     const TWIST_COEFF_A: Fp3<Self::Fp3Config>;
-    const ATE_LOOP_COUNT: &'static [u64];
     const ATE_LOOP_COUNT_2: &'static [i8];
     const ATE_IS_LOOP_COUNT_NEG: bool;
     const FINAL_EXPONENT_LAST_CHUNK_1: <Self::Fp as PrimeField>::BigInt;

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -113,9 +113,8 @@ impl<P: MNT6Parameters> MNT6<P> {
 
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
-        for ((ind, bit), dc) in P::ATE_LOOP_COUNT_2
+        for (bit, dc) in P::ATE_LOOP_COUNT_2
             .iter()
-            .enumerate()
             .skip(1)
             .zip(&q.double_coefficients)
         {

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -25,7 +25,7 @@ pub type GT<P> = Fp6<P>;
 pub trait MNT6Parameters: 'static {
     const TWIST: Fp3<Self::Fp3Config>;
     const TWIST_COEFF_A: Fp3<Self::Fp3Config>;
-    const ATE_LOOP_COUNT_2: &'static [i8];
+    const ATE_LOOP_COUNT: &'static [i8];
     const ATE_IS_LOOP_COUNT_NEG: bool;
     const FINAL_EXPONENT_LAST_CHUNK_1: <Self::Fp as PrimeField>::BigInt;
     const FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG: bool;
@@ -113,7 +113,7 @@ impl<P: MNT6Parameters> MNT6<P> {
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
         let y_over_twist_neg = -q.y_over_twist;
-        for (bit, dc) in P::ATE_LOOP_COUNT_2
+        for (bit, dc) in P::ATE_LOOP_COUNT
             .iter()
             .skip(1)
             .zip(&q.double_coefficients)

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -113,6 +113,7 @@ impl<P: MNT6Parameters> MNT6<P> {
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
         let y_over_twist_neg = -q.y_over_twist;
+        assert_eq!(P::ATE_LOOP_COUNT.len() - 1, q.double_coefficients.len());
         for (bit, dc) in P::ATE_LOOP_COUNT.iter().skip(1).zip(&q.double_coefficients) {
             let g_rr_at_p = Fp6::new(
                 dc.c_l - &dc.c_4c - &(dc.c_j * &p.x_twist),
@@ -138,8 +139,10 @@ impl<P: MNT6Parameters> MNT6<P> {
                     ac.c_rz * &p.y_twist,
                     -(y_over_twist_neg * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
                 );
-            } else {
+            } else if *bit == 0 {
                 continue;
+            } else {
+                unimplemented!();
             }
             f *= &g_rq_at_p;
         }

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 use ark_ff::{
     fp3::{Fp3, Fp3Config},
     fp6_2over3::{Fp6, Fp6Config},
-    BitIteratorBE, CyclotomicMultSubgroup, Field, PrimeField,
+    CyclotomicMultSubgroup, Field, PrimeField,
 };
 use num_traits::{One, Zero};
 
@@ -113,11 +113,7 @@ impl<P: MNT6Parameters> MNT6<P> {
         // code below gets executed for all bits (EXCEPT the MSB itself) of
         // mnt6_param_p (skipping leading zeros) in MSB to LSB order
         let y_over_twist_neg = -q.y_over_twist;
-        for (bit, dc) in P::ATE_LOOP_COUNT
-            .iter()
-            .skip(1)
-            .zip(&q.double_coefficients)
-        {
+        for (bit, dc) in P::ATE_LOOP_COUNT.iter().skip(1).zip(&q.double_coefficients) {
             let g_rr_at_p = Fp6::new(
                 dc.c_l - &dc.c_4c - &(dc.c_j * &p.x_twist),
                 dc.c_h * &p.y_twist,

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -46,7 +46,7 @@ pub trait MNT6Parameters: 'static {
 pub struct MNT6<P: MNT6Parameters>(PhantomData<fn() -> P>);
 
 impl<P: MNT6Parameters> MNT6<P> {
-    fn doubling_step_for_flipped_miller_loop(
+    fn doubling_for_flipped_miller_loop(
         r: &G2ProjectiveExtended<P>,
     ) -> (G2ProjectiveExtended<P>, AteDoubleCoefficients<P>) {
         let a = r.t.square();
@@ -76,7 +76,7 @@ impl<P: MNT6Parameters> MNT6<P> {
         (r2, coeff)
     }
 
-    fn mixed_addition_step_for_flipped_miller_loop(
+    fn mixed_addition_for_flipper_miller_loop(
         x: &Fp3<P::Fp3Config>,
         y: &Fp3<P::Fp3Config>,
         r: &G2ProjectiveExtended<P>,
@@ -123,27 +123,26 @@ impl<P: MNT6Parameters> MNT6<P> {
             f = f.square() * &g_rr_at_p;
 
             // Compute l_{R,Q}(P) if bit == 1, and l_{R,-Q}(P) if bit == -1
-            let g_rq_at_p;
-            if *bit == 1 {
+            let g_rq_at_p = if *bit == 1 {
                 let ac = &q.addition_coefficients[add_idx];
                 add_idx += 1;
 
-                g_rq_at_p = Fp6::new(
+                Fp6::new(
                     ac.c_rz * &p.y_twist,
                     -(q.y_over_twist * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
-                );
+                )
             } else if *bit == -1 {
                 let ac = &q.addition_coefficients[add_idx];
                 add_idx += 1;
-                g_rq_at_p = Fp6::new(
+                Fp6::new(
                     ac.c_rz * &p.y_twist,
                     -(y_over_twist_neg * &ac.c_rz + &(l1_coeff * &ac.c_l1)),
-                );
+                )
             } else if *bit == 0 {
                 continue;
             } else {
                 unreachable!();
-            }
+            };
             f *= &g_rq_at_p;
         }
 


### PR DESCRIPTION
## Description

closes: #19

Benchmarks (over 100 runs):

**MNT6_753:**
- 123 instead of 174 additions
- binary repr: `test mnt6_753::miller_loop            ... bench:   9,326,999 ns/iter (+/- 481,194)`
- 2-NAF:  `test mnt6_753::miller_loop            ... bench:   8,622,133 ns/iter (+/- 546,760)`

**MNT2_298:**
- 48 instead of 70 additions
- binary repr: `test mnt6_298::miller_loop            ... bench:     892,824 ns/iter (+/- 71,584)`
- 2-naf:	`test mnt6_298::miller_loop            ... bench:     819,195 ns/iter (+/- 80,998)`
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
