### PR TITLE
Fix a corner case for ate pairing in BLS12 and BW6 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - [\#366](https://github.com/arkworks-rs/algebra/pull/366) (`ark-ff`) Fix `norm()` for cubic extension field towers.
 - [\#394](https://github.com/arkworks-rs/algebra/pull/394) (`ark-ff`, `ark-serialize`) Remove `EmptyFlags` construction checks.
 - [\#442](https://github.com/arkworks-rs/algebra/pull/442) (`ark-ff`) Fix deserialization for modulo with 64 shaving bits.
+- [\#460](https://github.com/arkworks-rs/algebra/pull/460) (`ark-ec`) Fix a corner case for ate pairing in BLS12 and BW6 models.
 
 ## v0.3.0
 

--- a/ec/src/models/bls12/mod.rs
+++ b/ec/src/models/bls12/mod.rs
@@ -114,7 +114,7 @@ impl<P: Bls12Parameters> PairingEngine for Bls12<P> {
             }
         }
         let mut f = Self::Fqk::one();
-        for i in BitIteratorBE::new(P::X).skip(1) {
+        for i in BitIteratorBE::without_leading_zeros(P::X).skip(1) {
             f.square_in_place();
             for (p, ref mut coeffs) in &mut pairs {
                 Self::ell(&mut f, coeffs.next().unwrap(), &p.0);
@@ -161,7 +161,7 @@ impl<P: Bls12Parameters> PairingEngine for Bls12<P> {
          -> Fp12<<P as Bls12Parameters>::Fp12Config> {
             let coeffs = coeffs.as_slice();
             let mut j = 0;
-            for i in BitIteratorBE::new(P::X).skip(1) {
+            for i in BitIteratorBE::without_leading_zeros(P::X).skip(1) {
                 f.square_in_place();
                 Self::ell(&mut f, &coeffs[j], &p.0);
                 j += 1;

--- a/ec/src/models/bw6/mod.rs
+++ b/ec/src/models/bw6/mod.rs
@@ -242,7 +242,7 @@ impl<P: BW6Parameters> PairingEngine for BW6<P> {
         // f_{u+1,Q}(P)
         let mut f_1 = Self::Fqk::one();
 
-        for i in BitIteratorBE::new(P::ATE_LOOP_COUNT_1).skip(1) {
+        for i in BitIteratorBE::without_leading_zeros(P::ATE_LOOP_COUNT_1).skip(1) {
             f_1.square_in_place();
 
             for (p, ref mut coeffs) in &mut pairs_1 {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR changes the BLS12 and BW6 model's treatment of the ate pairing count. Otherwise, for certain input, it may fail.

closes: #459 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
