### PR TITLE
Allow running BLS12-381 curve test in the field-only mode

### DIFF
--- a/test-curves/src/bls12_381/mod.rs
+++ b/test-curves/src/bls12_381/mod.rs
@@ -20,11 +20,11 @@ pub mod g1_swu_iso;
 pub mod g2;
 #[cfg(feature = "bls12_381_curve")]
 pub mod g2_swu_iso;
-
 #[cfg(feature = "bls12_381_curve")]
 pub use {fq::*, fq12::*, fq2::*, fq6::*, g1::*, g1_swu_iso::*, g2::*, g2_swu_iso::*};
 
 #[cfg(test)]
+#[cfg(feature = "bls12_381_curve")]
 mod tests;
 
 #[cfg(feature = "bls12_381_curve")]

--- a/test-curves/src/bls12_381/mod.rs
+++ b/test-curves/src/bls12_381/mod.rs
@@ -4,13 +4,13 @@ pub use fr::*;
 #[cfg(feature = "bls12_381_curve")]
 use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
 
-#[cfg(feature = "bls12_381_scalar_field")]
+#[cfg(feature = "bls12_381_curve")]
 pub mod fq;
-#[cfg(feature = "bls12_381_scalar_field")]
+#[cfg(feature = "bls12_381_curve")]
 pub mod fq12;
-#[cfg(feature = "bls12_381_scalar_field")]
+#[cfg(feature = "bls12_381_curve")]
 pub mod fq2;
-#[cfg(feature = "bls12_381_scalar_field")]
+#[cfg(feature = "bls12_381_curve")]
 pub mod fq6;
 #[cfg(feature = "bls12_381_curve")]
 pub mod g1;
@@ -20,13 +20,11 @@ pub mod g1_swu_iso;
 pub mod g2;
 #[cfg(feature = "bls12_381_curve")]
 pub mod g2_swu_iso;
-#[cfg(feature = "bls12_381_scalar_field")]
-pub use {fq::*, fq12::*, fq2::*, fq6::*};
+
 #[cfg(feature = "bls12_381_curve")]
-pub use {g1::*, g1_swu_iso::*, g2::*, g2_swu_iso::*};
+pub use {fq::*, fq12::*, fq2::*, fq6::*, g1::*, g1_swu_iso::*, g2::*, g2_swu_iso::*};
 
 #[cfg(test)]
-#[cfg(feature = "bls12_381_scalar_field")]
 mod tests;
 
 #[cfg(feature = "bls12_381_curve")]

--- a/test-curves/src/bls12_381/mod.rs
+++ b/test-curves/src/bls12_381/mod.rs
@@ -1,14 +1,16 @@
 pub mod fr;
-use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
 pub use fr::*;
 
 #[cfg(feature = "bls12_381_curve")]
+use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
+
+#[cfg(feature = "bls12_381_scalar_field")]
 pub mod fq;
-#[cfg(feature = "bls12_381_curve")]
+#[cfg(feature = "bls12_381_scalar_field")]
 pub mod fq12;
-#[cfg(feature = "bls12_381_curve")]
+#[cfg(feature = "bls12_381_scalar_field")]
 pub mod fq2;
-#[cfg(feature = "bls12_381_curve")]
+#[cfg(feature = "bls12_381_scalar_field")]
 pub mod fq6;
 #[cfg(feature = "bls12_381_curve")]
 pub mod g1;
@@ -18,16 +20,22 @@ pub mod g1_swu_iso;
 pub mod g2;
 #[cfg(feature = "bls12_381_curve")]
 pub mod g2_swu_iso;
+#[cfg(feature = "bls12_381_scalar_field")]
+pub use {fq::*, fq12::*, fq2::*, fq6::*};
 #[cfg(feature = "bls12_381_curve")]
-pub use {fq::*, fq12::*, fq2::*, fq6::*, g1::*, g1_swu_iso::*, g2::*, g2_swu_iso::*};
+pub use {g1::*, g1_swu_iso::*, g2::*, g2_swu_iso::*};
 
 #[cfg(test)]
+#[cfg(feature = "bls12_381_scalar_field")]
 mod tests;
 
+#[cfg(feature = "bls12_381_curve")]
 pub type Bls12_381 = Bls12<Parameters>;
 
+#[cfg(feature = "bls12_381_curve")]
 pub struct Parameters;
 
+#[cfg(feature = "bls12_381_curve")]
 impl Bls12Parameters for Parameters {
     const X: &'static [u64] = &[0xd201000000010000];
     const X_IS_NEGATIVE: bool = true;

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -4,10 +4,10 @@ use ark_ec::{
 };
 use ark_ff::{Field, One, UniformRand, Zero};
 
-use crate::bls12_381::{Fq, Fq2, Fq6, FqConfig, Fr, FrConfig};
+use crate::bls12_381::{Fq, FqConfig, Fr, FrConfig};
 
 #[cfg(feature = "bls12_381_curve")]
-use crate::bls12_381::{g1, G1Affine, G1Projective};
+use crate::bls12_381::{g1, Fq2, Fq6, G1Affine, G1Projective};
 #[cfg(feature = "bls12_381_curve")]
 use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
 
@@ -22,7 +22,11 @@ use ark_std::{
     test_rng,
 };
 
+#[cfg(feature = "bls12_381_curve")]
 generate_field_test!(bls12_381; fq2; fq6; mont(6, 4); );
+
+#[cfg(not(feature = "bls12_381_curve"))]
+generate_field_test!(bls12_381; mont(6, 4); );
 
 #[cfg(feature = "bls12_381_curve")]
 generate_g1_test!(bls12_381; curve_tests; sw_tests;);

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -2,7 +2,6 @@ use ark_ec::AffineCurve;
 use ark_ff::{Field, One, UniformRand, Zero};
 
 use crate::bls12_381::{g1, Fq, Fq2, Fq6, FqConfig, Fr, FrConfig, G1Affine, G1Projective};
-
 use ark_algebra_test_templates::{
     curves::*, fields::*, generate_field_test, generate_g1_test, msm::*,
 };

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -4,13 +4,12 @@ use ark_ec::{
 };
 use ark_ff::{Field, One, UniformRand, Zero};
 
-use crate::bls12_381::{Fq, Fq2, Fq6, FqConfig, Fr, FrConfig, G1Affine, G1Projective};
+use crate::bls12_381::{g1, Fq, Fq2, Fq6, FqConfig, Fr, FrConfig, G1Affine, G1Projective};
 use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
 
 use ark_algebra_test_templates::{
     curves::*, fields::*, generate_field_test, generate_g1_test, msm::*,
 };
-
 use ark_std::{
     ops::{AddAssign, MulAssign, SubAssign},
     rand::Rng,

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -4,17 +4,12 @@ use ark_ec::{
 };
 use ark_ff::{Field, One, UniformRand, Zero};
 
-use crate::bls12_381::{Fq, FqConfig, Fr, FrConfig};
-
-#[cfg(feature = "bls12_381_curve")]
-use crate::bls12_381::{g1, Fq2, Fq6, G1Affine, G1Projective};
-#[cfg(feature = "bls12_381_curve")]
+use crate::bls12_381::{Fq, Fq2, Fq6, FqConfig, Fr, FrConfig, G1Affine, G1Projective};
 use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
 
-use ark_algebra_test_templates::{curves::*, fields::*, generate_field_test, msm::*};
-
-#[cfg(feature = "bls12_381_curve")]
-use ark_algebra_test_templates::{curves::*, generate_g1_test, msm::*};
+use ark_algebra_test_templates::{
+    curves::*, fields::*, generate_field_test, generate_g1_test, msm::*,
+};
 
 use ark_std::{
     ops::{AddAssign, MulAssign, SubAssign},
@@ -22,11 +17,5 @@ use ark_std::{
     test_rng,
 };
 
-#[cfg(feature = "bls12_381_curve")]
 generate_field_test!(bls12_381; fq2; fq6; mont(6, 4); );
-
-#[cfg(not(feature = "bls12_381_curve"))]
-generate_field_test!(bls12_381; mont(6, 4); );
-
-#[cfg(feature = "bls12_381_curve")]
 generate_g1_test!(bls12_381; curve_tests; sw_tests;);

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -1,18 +1,13 @@
-#![allow(unused_imports)]
-use ark_ec::{
-    models::short_weierstrass::SWCurveConfig, AffineCurve, PairingEngine, ProjectiveCurve,
-};
+use ark_ec::AffineCurve;
 use ark_ff::{Field, One, UniformRand, Zero};
 
 use crate::bls12_381::{g1, Fq, Fq2, Fq6, FqConfig, Fr, FrConfig, G1Affine, G1Projective};
-use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
 
 use ark_algebra_test_templates::{
     curves::*, fields::*, generate_field_test, generate_g1_test, msm::*,
 };
 use ark_std::{
     ops::{AddAssign, MulAssign, SubAssign},
-    rand::Rng,
     test_rng,
 };
 

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -4,10 +4,18 @@ use ark_ec::{
 };
 use ark_ff::{Field, One, UniformRand, Zero};
 
-use crate::bls12_381::{g1, Fq, Fq2, Fq6, FqConfig, Fr, FrConfig, G1Affine, G1Projective};
-use ark_algebra_test_templates::{
-    curves::*, fields::*, generate_field_test, generate_g1_test, msm::*,
-};
+use crate::bls12_381::{Fq, Fq2, Fq6, FqConfig, Fr, FrConfig};
+
+#[cfg(feature = "bls12_381_curve")]
+use crate::bls12_381::{g1, G1Affine, G1Projective};
+#[cfg(feature = "bls12_381_curve")]
+use ark_ec::bls12::{Bls12, Bls12Parameters, TwistType};
+
+use ark_algebra_test_templates::{curves::*, fields::*, generate_field_test, msm::*};
+
+#[cfg(feature = "bls12_381_curve")]
+use ark_algebra_test_templates::{curves::*, generate_g1_test, msm::*};
+
 use ark_std::{
     ops::{AddAssign, MulAssign, SubAssign},
     rand::Rng,
@@ -15,4 +23,6 @@ use ark_std::{
 };
 
 generate_field_test!(bls12_381; fq2; fq6; mont(6, 4); );
+
+#[cfg(feature = "bls12_381_curve")]
 generate_g1_test!(bls12_381; curve_tests; sw_tests;);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

At this moment, if one does the following, which is the case of ark-snark (!)
```
[dev-dependencies]
ark-test-curves = { version = "^0.3.0", default-features = false, features = [ "bls12_381_scalar_field" ] }
```

It would fail because the conditional compilation for bls12_381_scalar_field is not complete. It would report that several modules are missing. 

This PR fixes so.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`