### PR TITLE
Fix bench templates for MNT4/6 and BW6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
             echo      "ark-ff-macros = { path = 'algebra/ff-macros' }";
             echo      "ark-ff-asm = { path = 'algebra/ff-asm' }";
             echo      "ark-ec = { path = 'algebra/ec' }";
+            echo      "ark-algebra-bench-templates = { path = 'algebra/bench-templates' }"
             echo      "ark-algebra-test-templates = { path = 'algebra/test-templates' }"
             echo      "ark-bls12-377 = { git = 'https://github.com/arkworks-rs/curves' }"
             echo      "ark-bls12-381 = { git = 'https://github.com/arkworks-rs/curves' }"

--- a/bench-templates/src/macros/pairing.rs
+++ b/bench-templates/src/macros/pairing.rs
@@ -17,7 +17,11 @@ macro_rules! pairing_bench {
             ) = g1s
                 .into_iter()
                 .zip(g2s)
-                .map(|(g1, g2)| (g1.into(), g2.into()))
+                .map(|(g1, g2)| {
+                    let g1: <$curve as Pairing>::G1Prepared = g1.into();
+                    let g2: <$curve as Pairing>::G2Prepared = g2.into();
+                    (g1, g2)
+                })
                 .unzip();
             let mut count = 0;
             b.iter(|| {
@@ -48,7 +52,7 @@ macro_rules! pairing_bench {
 
             let mut count = 0;
             b.iter(|| {
-                let tmp = $curve::final_exponentiation(v[count]);
+                let tmp = <$curve as Pairing>::final_exponentiation(v[count]);
                 count = (count + 1) % SAMPLES;
                 tmp
             });
@@ -66,7 +70,7 @@ macro_rules! pairing_bench {
 
             let mut count = 0;
             b.iter(|| {
-                let tmp = $curve::pairing(v1[count], v2[count]);
+                let tmp = <$curve as Pairing>::pairing(v1[count], v2[count]);
                 count = (count + 1) % SAMPLES;
                 tmp
             });

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -163,7 +163,7 @@ impl<P: MNT6Parameters> MNT6<P> {
         f
     }
 
-    pub fn final_exponentiation(value: &Fp6<P::Fp6Config>) -> GT<P::Fp6Config> {
+    fn final_exponentiation(value: &Fp6<P::Fp6Config>) -> GT<P::Fp6Config> {
         let value_inv = value.inverse().unwrap();
         let value_to_first_chunk = Self::final_exponentiation_first_chunk(value, &value_inv);
         let value_inv_to_first_chunk = Self::final_exponentiation_first_chunk(&value_inv, value);

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -163,13 +163,6 @@ impl<P: MNT6Parameters> MNT6<P> {
         f
     }
 
-    fn final_exponentiation(value: &Fp6<P::Fp6Config>) -> GT<P::Fp6Config> {
-        let value_inv = value.inverse().unwrap();
-        let value_to_first_chunk = Self::final_exponentiation_first_chunk(value, &value_inv);
-        let value_inv_to_first_chunk = Self::final_exponentiation_first_chunk(&value_inv, value);
-        Self::final_exponentiation_last_chunk(&value_to_first_chunk, &value_inv_to_first_chunk)
-    }
-
     fn final_exponentiation_first_chunk(
         elt: &Fp6<P::Fp6Config>,
         elt_inv: &Fp6<P::Fp6Config>,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

For MNT4/6 and BW6, we encounter some challenges:

```
error[E0282]: type annotations needed
  --> curve-benches/benches/bw6_761.rs:27:1
   |
27 | pairing_bench!(BW6_761, Fq6);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `A` declared on the associated function `unzip`
   |
   = note: this error originates in the macro `pairing_bench` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider specifying the generic arguments
  --> /Users/cusgadmin/.cargo/git/checkouts/algebra-7e23afa68841b66e/ea6f503/bench-templates/src/macros/pairing.rs:21:23
   |
21 |                 .unzip::<A, ark_ec::bw6::G2Prepared<ark_bw6_761::Parameters>, Vec<ark_ec::bw6::G1Prepared<ark_bw6_761::Parameters>>, Vec<ark_ec::bw6::G2Prepared<ark_bw6_761::Parameters>>>();
   |                       +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```

In addition, it may call a different method of the struct, rather than the one for the implementation of `Pairing`:

```
error[E0308]: mismatched types
   --> curve-benches/benches/mnt6_298.rs:24:1
    |
24  | pairing_bench!(MNT6_298, Fq6);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | |
    | expected reference, found struct `MillerLoopOutput`
    | arguments to this function are incorrect
    |
    = note: expected reference `&QuadExtField<ark_ff::fp6_2over3::Fp6ConfigWrapper<Fq6Config>>`
                  found struct `MillerLoopOutput<MNT6<ark_mnt6_298::Parameters>>`
note: associated function defined here
   --> /Users/cusgadmin/.cargo/git/checkouts/algebra-7e23afa68841b66e/8eb4e7a/ec/src/models/mnt6/mod.rs:166:12
    |
166 |     pub fn final_exponentiation(value: &Fp6<P::Fp6Config>) -> GT<P::Fp6Config> {
    |            ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `pairing_bench` (in Nightly builds, run with -Z macro-backtrace for more info)

```

This PR wants to fix both, by explicitly stating the trait or the type.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
