### PR TITLE
Explicit disambiguation for SW and TE tests + bring back the Montgomery curve test

### DIFF
--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -258,7 +258,7 @@ macro_rules! __test_group {
             let mut i = 0;
             loop {
                 // y^2 = x^3 + a * x + b
-                let rhs = x * x.square() + x * Config::COEFF_A + Config::COEFF_B;
+                let rhs = x * x.square() + x * <Config as SWCurveConfig>::COEFF_A + <Config as SWCurveConfig>::COEFF_B;
 
                 if let Some(y) = rhs.sqrt() {
                     let p = Affine::new_unchecked(x, if y < -y { y } else { -y });

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -338,6 +338,21 @@ macro_rules! __test_group {
                 }
             }
         }
+
+        #[test]
+        fn test_montgomery_conversion_test()
+        {
+            // A = 2 * (a + d) / (a - d)
+            let a = <Config as TECurveConfig>::BaseField::one().double()
+                * &(<Config as TECurveConfig>::COEFF_A + &<Config as TECurveConfig>::COEFF_D)
+                * &(<Config as TECurveConfig>::COEFF_A - &<Config as TECurveConfig>::COEFF_D).inverse().unwrap();
+            // B = 4 / (a - d)
+            let b = <Config as TECurveConfig>::BaseField::one().double().double() *
+                &(<Config as TECurveConfig>::COEFF_A - &<Config as TECurveConfig>::COEFF_D).inverse().unwrap();
+
+            assert_eq!(a, <Config as TECurveConfig>::MontCurveConfig::COEFF_A);
+            assert_eq!(b, <Config as TECurveConfig>::MontCurveConfig::COEFF_B);
+        }
     }
 }
 

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -351,8 +351,8 @@ macro_rules! __test_group {
             let b = <Config as TECurveConfig>::BaseField::one().double().double() *
                 &(<Config as TECurveConfig>::COEFF_A - &<Config as TECurveConfig>::COEFF_D).inverse().unwrap();
 
-            assert_eq!(a, <Config as TECurveConfig>::MontCurveConfig::COEFF_A);
-            assert_eq!(b, <Config as TECurveConfig>::MontCurveConfig::COEFF_B);
+            assert_eq!(a, <Config as MontCurveConfig>::COEFF_A);
+            assert_eq!(b, <Config as MontCurveConfig>::COEFF_B);
         }
     }
 }

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -342,6 +342,7 @@ macro_rules! __test_group {
         #[test]
         fn test_montgomery_conversion_test()
         {
+            use ark_ec::twisted_edwards::MontCurveConfig;
             // A = 2 * (a + d) / (a - d)
             let a = <Config as TECurveConfig>::BaseField::one().double()
                 * &(<Config as TECurveConfig>::COEFF_A + &<Config as TECurveConfig>::COEFF_D)

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -317,7 +317,7 @@ macro_rules! __test_group {
             let one = BaseField::one();
             for _ in 0..ITERATIONS {
                 let f = BaseField::rand(rng);
-                assert_eq!(Config::mul_by_a(f), f * Config::COEFF_A);
+                assert_eq!(<Config as TECurveConfig>::mul_by_a(f), f * <Config as TECurveConfig>::COEFF_A);
             }
             {
                 use ark_ec::models::twisted_edwards::TEFlags;

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -280,8 +280,8 @@ macro_rules! __test_group {
 
             for _ in 0..ITERATIONS {
                 let f = BaseField::rand(rng);
-                assert_eq!(Config::mul_by_a(f), f * Config::COEFF_A);
-                assert_eq!(Config::add_b(f), f + Config::COEFF_B);
+                assert_eq!(<Config as SWCurveConfig>::mul_by_a(f), f * <Config as SWCurveConfig>::COEFF_A);
+                assert_eq!(<Config as SWCurveConfig>::add_b(f), f + <Config as SWCurveConfig>::COEFF_B);
             }
             {
                 use ark_ec::models::short_weierstrass::SWFlags;

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -344,11 +344,11 @@ macro_rules! __test_group {
         {
             use ark_ec::twisted_edwards::MontCurveConfig;
             // A = 2 * (a + d) / (a - d)
-            let a = <Config as TECurveConfig>::BaseField::one().double()
+            let a = <Config as CurveConfig>::BaseField::one().double()
                 * &(<Config as TECurveConfig>::COEFF_A + &<Config as TECurveConfig>::COEFF_D)
                 * &(<Config as TECurveConfig>::COEFF_A - &<Config as TECurveConfig>::COEFF_D).inverse().unwrap();
             // B = 4 / (a - d)
-            let b = <Config as TECurveConfig>::BaseField::one().double().double() *
+            let b = <Config as CurveConfig>::BaseField::one().double().double() *
                 &(<Config as TECurveConfig>::COEFF_A - &<Config as TECurveConfig>::COEFF_D).inverse().unwrap();
 
             assert_eq!(a, <Config as MontCurveConfig>::COEFF_A);


### PR DESCRIPTION
## Description

When working to fix the curve tests in `r1cs_std`, I go back to `curves` to update the tests related to R1CS.
It appears that the test templates may encounter issues for TE curves that have the SW parameters as well as TE curves and its Montgomery curve.

This PR also brings back the Montgomery curve parameter test.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A: 
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`