### PR TITLE
Add #[must_use] for `normalize_batch`

### DIFF
--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -149,6 +149,7 @@ pub trait CurveGroup:
     type FullGroup;
 
     /// Normalizes a slice of group elements into affine.
+    #[must_use]
     fn normalize_batch(v: &[Self]) -> Vec<Self::Affine>;
 
     /// Converts `self` into the affine representation.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Since 0.4.0, we use `normalize_batch` instead of `batch_normalize`. However, these two methods are different, in that the previous one, `batch_normalize`, does mutation, but the new one just returns a vector.

This PR adds `#[must_use]` to prevent misuse.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
