### PR TITLE
Tracking PR for moving generators from `FFTField` to `Field`

### DIFF
--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -141,6 +141,9 @@ pub trait Field:
     /// The multiplicative identity of the field.
     const ONE: Self;
 
+    /// The generator of the multiplicative group of the field
+    const GENERATOR: Self;
+
     /// Returns the characteristic of the field,
     /// in little-endian representation.
     fn characteristic() -> &'static [u64] {
@@ -400,9 +403,6 @@ fn exp_loop<F: CyclotomicMultSubgroup, I: Iterator<Item = i8>>(f: &mut F, e: I) 
 
 /// The interface for fields that are able to be used in FFTs.
 pub trait FftField: Field {
-    /// The generator of the multiplicative group of the field
-    const GENERATOR: Self;
-
     /// Let `N` be the size of the multiplicative group defined by the field.
     /// Then `TWO_ADICITY` is the two-adicity of `N`, i.e. the integer `s`
     /// such that `N = 2^s * t` for some odd integer `t`.

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -47,6 +47,9 @@ pub trait CubicExtConfig: 'static + Send + Sync + Sized {
     /// The cubic non-residue used to construct the extension.
     const NONRESIDUE: Self::BaseField;
 
+    /// The generator of the multiplicative group of the quadratic extension field
+    const GENERATOR: (Self::BaseField, Self::BaseField, Self::BaseField);
+
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff];
     const FROBENIUS_COEFF_C2: &'static [Self::FrobCoeff];
@@ -165,6 +168,8 @@ impl<P: CubicExtConfig> Field for CubicExtField<P> {
     const ZERO: Self = Self::new(P::BaseField::ZERO, P::BaseField::ZERO, P::BaseField::ZERO);
 
     const ONE: Self = Self::new(P::BaseField::ONE, P::BaseField::ZERO, P::BaseField::ZERO);
+
+    const GENERATOR: Self = Self::new(P::GENERATOR.0, P::GENERATOR.1, P::GENERATOR.2);
 
     fn extension_degree() -> u64 {
         3 * P::BaseField::extension_degree()

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -183,6 +183,8 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
     const ZERO: Self = P::ZERO;
     const ONE: Self = P::ONE;
 
+    const GENERATOR: Self = P::GENERATOR;
+
     fn extension_degree() -> u64 {
         1
     }
@@ -336,7 +338,6 @@ impl<P: FpConfig<N>, const N: usize> PrimeField for Fp<P, N> {
 }
 
 impl<P: FpConfig<N>, const N: usize> FftField for Fp<P, N> {
-    const GENERATOR: Self = P::GENERATOR;
     const TWO_ADICITY: u32 = P::TWO_ADICITY;
     const TWO_ADIC_ROOT_OF_UNITY: Self = P::TWO_ADIC_ROOT_OF_UNITY;
     const SMALL_SUBGROUP_BASE: Option<u32> = P::SMALL_SUBGROUP_BASE;

--- a/ff/src/fields/models/fp12_2over3over2.rs
+++ b/ff/src/fields/models/fp12_2over3over2.rs
@@ -22,6 +22,9 @@ pub trait Fp12Config: 'static + Send + Sync + Copy {
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_FP12_C1: &'static [Fp2<Fp2Config<Self>>];
 
+    /// The generator of the multiplicative group of the Fp6 field
+    const GENERATOR: (Fp6<Self::Fp6Config>, Fp6<Self::Fp6Config>);
+
     /// Multiply by quadratic nonresidue v.
     #[inline(always)]
     fn mul_fp6_by_nonresidue(fe: &Fp6<Self::Fp6Config>) -> Fp6<Self::Fp6Config> {
@@ -45,6 +48,8 @@ impl<P: Fp12Config> QuadExtConfig for Fp12ConfigWrapper<P> {
     const NONRESIDUE: Self::BaseField = P::NONRESIDUE;
 
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP12_C1;
+
+    const GENERATOR: (Self::BaseField, Self::BaseField) = P::GENERATOR;
 
     #[inline(always)]
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {

--- a/ff/src/fields/models/fp2.rs
+++ b/ff/src/fields/models/fp2.rs
@@ -17,6 +17,9 @@ pub trait Fp2Config: 'static + Send + Sync + Sized {
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_FP2_C1: &'static [Self::Fp];
 
+    /// The generator of the multiplicative group of the quadratic extension field
+    const GENERATOR: (Self::Fp, Self::Fp);
+
     /// Return `fe * Self::NONRESIDUE`.
     /// Intended for specialization when [`Self::NONRESIDUE`] has a special
     /// structure that can speed up multiplication
@@ -64,6 +67,8 @@ impl<P: Fp2Config> QuadExtConfig for Fp2ConfigWrapper<P> {
     const NONRESIDUE: Self::BaseField = P::NONRESIDUE;
 
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP2_C1;
+
+    const GENERATOR: (Self::BaseField, Self::BaseField) = P::GENERATOR;
 
     #[inline(always)]
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {

--- a/ff/src/fields/models/fp3.rs
+++ b/ff/src/fields/models/fp3.rs
@@ -14,6 +14,9 @@ pub trait Fp3Config: 'static + Send + Sync + Sized {
     const FROBENIUS_COEFF_FP3_C1: &'static [Self::Fp];
     const FROBENIUS_COEFF_FP3_C2: &'static [Self::Fp];
 
+    /// The generator of the multiplicative group of the cubic extension field
+    const GENERATOR: (Self::Fp, Self::Fp, Self::Fp);
+
     /// p^3 - 1 = 2^s * t, where t is odd.
     const TWO_ADICITY: u32;
     const TRACE_MINUS_ONE_DIV_TWO: &'static [u64];
@@ -50,6 +53,8 @@ impl<P: Fp3Config> CubicExtConfig for Fp3ConfigWrapper<P> {
 
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP3_C1;
     const FROBENIUS_COEFF_C2: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP3_C2;
+
+    const GENERATOR: (Self::BaseField, Self::BaseField, Self::BaseField) = P::GENERATOR;
 
     #[inline(always)]
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {

--- a/ff/src/fields/models/fp4.rs
+++ b/ff/src/fields/models/fp4.rs
@@ -19,6 +19,9 @@ pub trait Fp4Config: 'static + Send + Sync {
     /// non_residue^((modulus^i-1)/4) for i=0,1,2,3
     const FROBENIUS_COEFF_FP4_C1: &'static [<Self::Fp2Config as Fp2Config>::Fp];
 
+    /// The generator of the multiplicative group of the Fp4 field
+    const GENERATOR: (Fp2<Self::Fp2Config>, Fp2<Self::Fp2Config>);
+
     #[inline(always)]
     fn mul_fp2_by_nonresidue(fe: &Fp2<Self::Fp2Config>) -> Fp2<Self::Fp2Config> {
         // see [[DESD06, Section 5.1]](https://eprint.iacr.org/2006/471.pdf).
@@ -38,6 +41,8 @@ impl<P: Fp4Config> QuadExtConfig for Fp4ConfigWrapper<P> {
     const NONRESIDUE: Self::BaseField = P::NONRESIDUE;
 
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP4_C1;
+
+    const GENERATOR: (Self::BaseField, Self::BaseField) = P::GENERATOR;
 
     #[inline(always)]
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {

--- a/ff/src/fields/models/fp6_2over3.rs
+++ b/ff/src/fields/models/fp6_2over3.rs
@@ -19,6 +19,9 @@ pub trait Fp6Config: 'static + Send + Sync {
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_FP6_C1: &'static [<Self::Fp3Config as Fp3Config>::Fp];
 
+    /// The generator of the multiplicative group of the Fp6 field
+    const GENERATOR: (Fp3<Self::Fp3Config>, Fp3<Self::Fp3Config>);
+
     #[inline(always)]
     fn mul_fp3_by_nonresidue(fe: &Fp3<Self::Fp3Config>) -> Fp3<Self::Fp3Config> {
         let mut res = *fe;
@@ -42,6 +45,8 @@ impl<P: Fp6Config> QuadExtConfig for Fp6ConfigWrapper<P> {
     const NONRESIDUE: Self::BaseField = P::NONRESIDUE;
 
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP6_C1;
+
+    const GENERATOR: (Self::BaseField, Self::BaseField) = P::GENERATOR;
 
     #[inline(always)]
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {

--- a/ff/src/fields/models/fp6_3over2.rs
+++ b/ff/src/fields/models/fp6_3over2.rs
@@ -14,6 +14,13 @@ pub trait Fp6Config: 'static + Send + Sync + Copy {
     const FROBENIUS_COEFF_FP6_C1: &'static [Fp2<Self::Fp2Config>];
     const FROBENIUS_COEFF_FP6_C2: &'static [Fp2<Self::Fp2Config>];
 
+    /// The generator of the multiplicative group of the Fp6 field
+    const GENERATOR: (
+        Fp2<Self::Fp2Config>,
+        Fp2<Self::Fp2Config>,
+        Fp2<Self::Fp2Config>,
+    );
+
     #[inline(always)]
     fn mul_fp2_by_nonresidue(fe: &Fp2<Self::Fp2Config>) -> Fp2<Self::Fp2Config> {
         Self::NONRESIDUE * fe
@@ -35,6 +42,8 @@ impl<P: Fp6Config> CubicExtConfig for Fp6ConfigWrapper<P> {
 
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP6_C1;
     const FROBENIUS_COEFF_C2: &'static [Self::FrobCoeff] = P::FROBENIUS_COEFF_FP6_C2;
+
+    const GENERATOR: (Self::BaseField, Self::BaseField, Self::BaseField) = P::GENERATOR;
 
     #[inline(always)]
     fn mul_base_field_by_nonresidue(fe: &Self::BaseField) -> Self::BaseField {

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -48,6 +48,9 @@ pub trait QuadExtConfig: 'static + Send + Sync + Sized {
     /// Coefficients for the Frobenius automorphism.
     const FROBENIUS_COEFF_C1: &'static [Self::FrobCoeff];
 
+    /// The generator of the multiplicative group of the quadratic extension field
+    const GENERATOR: (Self::BaseField, Self::BaseField);
+
     /// A specializable method for multiplying an element of the base field by
     /// the quadratic non-residue. This is used in Karatsuba multiplication
     /// and in complex squaring.
@@ -208,6 +211,7 @@ impl<P: QuadExtConfig> Field for QuadExtField<P> {
 
     const ZERO: Self = Self::new(P::BaseField::ZERO, P::BaseField::ZERO);
     const ONE: Self = Self::new(P::BaseField::ONE, P::BaseField::ZERO);
+    const GENERATOR: Self = Self::new(P::GENERATOR.0, P::GENERATOR.1);
 
     fn extension_degree() -> u64 {
         2 * P::BaseField::extension_degree()


### PR DESCRIPTION
## Description

We plan to move generators from `FFTField` to `Field`, which is for #276 and #472.

The current progress of this PR is that we have finished moving, but we need to supply the generators. I am currently factoring q^k-1 both by hand-waving and Sage, first for those curves in `test-curves`.

closes: #276

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
