### PR TITLE
Avoid the need of `ark-serialize-derive` for BigInt

### DIFF
--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.59"
 ark-ff-asm = { version = "^0.3.0", path = "../ff-asm" }
 ark-ff-macros = { version = "^0.3.0", path = "../ff-macros" }
 ark-std = { version = "^0.3.0", default-features = false }
-ark-serialize = { version = "^0.3.0", path = "../serialize", features = ["derive"], default-features = false }
+ark-serialize = { version = "^0.3.0", path = "../serialize", default-features = false }
 derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
 paste = "1.0"

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.59"
 ark-ff-asm = { version = "^0.3.0", path = "../ff-asm" }
 ark-ff-macros = { version = "^0.3.0", path = "../ff-macros" }
 ark-std = { version = "^0.3.0", default-features = false }
-ark-serialize = { version = "^0.3.0", path = "../serialize", default-features = false }
+ark-serialize = { version = "^0.3.0", path = "../serialize", features = ["derive"], default-features = false }
 derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
 paste = "1.0"

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -653,6 +653,7 @@ mod tests;
 /// This defines a `BigInteger`, a smart wrapper around a
 /// sequence of `u64` limbs, least-significant limb first.
 // TODO: get rid of this trait once we can use associated constants in const generics.
+// TODO: and remove the `ark-serialize/derive` feature in the Cargo.toml
 pub trait BigInteger:
     CanonicalSerialize
     + CanonicalDeserialize

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -653,7 +653,6 @@ mod tests;
 /// This defines a `BigInteger`, a smart wrapper around a
 /// sequence of `u64` limbs, least-significant limb first.
 // TODO: get rid of this trait once we can use associated constants in const generics.
-// TODO: and remove the `ark-serialize/derive` feature in the Cargo.toml
 pub trait BigInteger:
     CanonicalSerialize
     + CanonicalDeserialize


### PR DESCRIPTION
## Description

For some reasons we suddenly see the following error when ark-ff is being used in the downstream.

```
error: cannot find derive macro `CanonicalSerialize` in this scope
  --> /Users/cusgadmin/.cargo/git/checkouts/algebra-7e23afa68841b66e/423018f/ff/src/biginteger/mod.rs:24:55
   |
24 |     Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize, CanonicalSerialize, CanonicalDeserialize,
   |                                                       ^^^^^^^^^^^^^^^^^^
   |
note: `CanonicalSerialize` is imported here, but it is only a trait, without a derive macro
  --> /Users/cusgadmin/.cargo/git/checkouts/algebra-7e23afa68841b66e/423018f/ff/src/biginteger/mod.rs:7:43
   |
7  | use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
   |                                           ^^^^^^^^^^^^^^^^^^
```

```
error[E0277]: the trait bound `biginteger::BigInt<N>: CanonicalDeserialize` is not satisfied
   --> /Users/cusgadmin/.cargo/git/checkouts/algebra-7e23afa68841b66e/423018f/ff/src/biginteger/mod.rs:256:22
    |
256 | impl<const N: usize> BigInteger for BigInt<N> {
    |                      ^^^^^^^^^^ the trait `CanonicalDeserialize` is not implemented for `biginteger::BigInt<N>`
    |
    = help: the following other types implement trait `CanonicalDeserialize`:
              ()
              (A, B)
              (A, B, C)
              (A, B, C, D)
              (A,)
              BTreeMap<K, V>
              BTreeSet<V>
              Cow<'a, T>
            and 14 others
note: required by a bound in `biginteger::BigInteger`
   --> /Users/cusgadmin/.cargo/git/checkouts/algebra-7e23afa68841b66e/423018f/ff/src/biginteger/mod.rs:661:7
    |
659 | pub trait BigInteger:
    |           ---------- required by a bound in this
660 |     CanonicalSerialize
661 |     + CanonicalDeserialize
    |       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `biginteger::BigInteger`
```

To fix this issue, we can either let `ark-ff` always invoke `ark-serialize-derive`, or try to avoid derivation, by writing our own.

This PR does the latter, feeling that we do want to avoid invoking `ark-serialize-derive`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`