### PR TITLE
Change evaluation domain API for cosets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## Pending
 
-- [\#487](https://github.com/arkworks-rs/algebra/pull/487) (`ark-poly`) Refactor `EvaluationDomain` trait for cosets:
-    - Add constructors `new_subgroup` and `new_coset`.
-    - Add convenience method `get_coset`.
-    - Add methods `offset` and `offset_inv`.
-    - Remove method `generator_inv`.
-    - Remove method `divide_by_vanishing_poly_on_coset_in_place`.
-    - Remove coset fft methods: `coset_fft`, `coset_fft_in_place`, `coset_ifft`, `coset_ifft_in_place`.
-
 ### Breaking changes
 
 - [\#300](https://github.com/arkworks-rs/algebra/pull/300) (`ark-ec`) Change the implementation of `Hash` trait of `GroupProjective` to use the affine coordinates.
@@ -134,6 +126,10 @@
     - New serialization format for Twisted Edwards curves:
         - Points with a "positive" x-coordinate are serialized with the sign bit set to zero.
         - Points with a "negative" x-coordinate are serialized with the sign bit set to one.
+- [\#487](https://github.com/arkworks-rs/algebra/pull/487) (`ark-poly`) Refactor `EvaluationDomain` trait for cosets:
+    - Remove method `generator_inv`.
+    - Remove method `divide_by_vanishing_poly_on_coset_in_place`.
+    - Remove coset fft methods: `coset_fft`, `coset_fft_in_place`, `coset_ifft`, `coset_ifft_in_place`.
 
 ### Features
 
@@ -154,6 +150,10 @@
 - [\#446](https://github.com/arkworks-rs/algebra/pull/446) (`ark-ff`) Add `CyclotomicMultSubgroup` trait and impl for extension fields
 - [\#467](https://github.com/arkworks-rs/algebra/pull/467) (`ark-ec`)
     - Move implementation of `serialize_with_mode()`, `deserialize_with_mode()`, and `serialized_size()` into `{SW,TE}CurveConfig` to allow customization.
+- [\#487](https://github.com/arkworks-rs/algebra/pull/487) (`ark-poly`) Refactor `EvaluationDomain` trait for cosets:
+    - Add constructors `new_subgroup` and `new_coset`.
+    - Add convenience method `get_coset`.
+    - Add methods `coset_offset` and `coset_offset_inv`.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,9 +151,9 @@
 - [\#467](https://github.com/arkworks-rs/algebra/pull/467) (`ark-ec`)
     - Move implementation of `serialize_with_mode()`, `deserialize_with_mode()`, and `serialized_size()` into `{SW,TE}CurveConfig` to allow customization.
 - [\#487](https://github.com/arkworks-rs/algebra/pull/487) (`ark-poly`) Refactor `EvaluationDomain` trait for cosets:
-    - Add constructors `new_subgroup` and `new_coset`.
+    - Add constructor `new_coset`.
     - Add convenience method `get_coset`.
-    - Add methods `coset_offset` and `coset_offset_inv`.
+    - Add methods `coset_offset`, `coset_offset_inv` and `coset_offset_pow_size`.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Pending
 
+- [\#487](https://github.com/arkworks-rs/algebra/pull/487) (`ark-poly`) Refactor `EvaluationDomain` trait for cosets:
+    - Add constructors `new_subgroup` and `new_coset`.
+    - Add convenience method `get_coset`.
+    - Add methods `offset` and `offset_inv`.
+    - Remove method `generator_inv`.
+    - Remove method `divide_by_vanishing_poly_on_coset_in_place`.
+    - Remove coset fft methods: `coset_fft`, `coset_fft_in_place`, `coset_ifft`, `coset_ifft_in_place`.
+
 ### Breaking changes
 
 - [\#300](https://github.com/arkworks-rs/algebra/pull/300) (`ark-ec`) Change the implementation of `Hash` trait of `GroupProjective` to use the affine coordinates.

--- a/poly-benches/benches/fft.rs
+++ b/poly-benches/benches/fft.rs
@@ -82,18 +82,20 @@ fn bench_ifft_in_place<F: FftField, D: EvaluationDomain<F>>(b: &mut Bencher, deg
 fn bench_coset_fft_in_place<F: FftField, D: EvaluationDomain<F>>(b: &mut Bencher, degree: &usize) {
     // Per benchmark setup
     let (domain, mut a) = fft_common_setup::<F, D>(*degree);
+    let coset_domain = domain.get_coset(F::GENERATOR).unwrap();
     b.iter(|| {
         // Per benchmark iteration
-        domain.coset_fft_in_place(&mut a);
+        coset_domain.fft_in_place(&mut a);
     });
 }
 
 fn bench_coset_ifft_in_place<F: FftField, D: EvaluationDomain<F>>(b: &mut Bencher, degree: &usize) {
     // Per benchmark setup
     let (domain, mut a) = fft_common_setup::<F, D>(*degree);
+    let coset_domain = domain.get_coset(F::GENERATOR).unwrap();
     b.iter(|| {
         // Per benchmark iteration
-        domain.coset_ifft_in_place(&mut a);
+        coset_domain.ifft_in_place(&mut a);
     });
 }
 

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -121,6 +121,28 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
         None
     }
 
+    fn new_subgroup(subgroup_size: usize) -> Option<Self> {
+        let domain = Radix2EvaluationDomain::new_subgroup(subgroup_size);
+        if let Some(domain) = domain {
+            return Some(GeneralEvaluationDomain::Radix2(domain));
+        }
+
+        if F::SMALL_SUBGROUP_BASE.is_some() {
+            return Some(GeneralEvaluationDomain::MixedRadix(
+                MixedRadixEvaluationDomain::new_subgroup(subgroup_size)?,
+            ));
+        }
+
+        None
+    }
+
+    fn get_coset(&self, offset: F) -> Option<Self> {
+        Some(match self {
+            Self::Radix2(domain) => Self::Radix2(domain.get_coset(offset)?),
+            Self::MixedRadix(domain) => Self::MixedRadix(domain.get_coset(offset)?),
+        })
+    }
+
     fn compute_size_of_domain(num_coeffs: usize) -> Option<usize> {
         let domain_size = Radix2EvaluationDomain::<F>::compute_size_of_domain(num_coeffs);
         if let Some(domain_size) = domain_size {

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -182,8 +182,13 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
     }
 
     #[inline]
-    fn generator_inv(&self) -> F {
-        map!(self, generator_inv)
+    fn offset(&self) -> F {
+        map!(self, offset)
+    }
+
+    #[inline]
+    fn offset_inv(&self) -> F {
+        map!(self, offset_inv)
     }
 
     #[inline]
@@ -194,16 +199,6 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
     #[inline]
     fn ifft_in_place<T: DomainCoeff<F>>(&self, evals: &mut Vec<T>) {
         map!(self, ifft_in_place, evals)
-    }
-
-    #[inline]
-    fn coset_fft_in_place<T: DomainCoeff<F>>(&self, coeffs: &mut Vec<T>) {
-        map!(self, coset_fft_in_place, coeffs)
-    }
-
-    #[inline]
-    fn coset_ifft_in_place<T: DomainCoeff<F>>(&self, evals: &mut Vec<T>) {
-        map!(self, coset_ifft_in_place, evals)
     }
 
     #[inline]

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -182,13 +182,13 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
     }
 
     #[inline]
-    fn offset(&self) -> F {
-        map!(self, offset)
+    fn coset_offset(&self) -> F {
+        map!(self, coset_offset)
     }
 
     #[inline]
-    fn offset_inv(&self) -> F {
-        map!(self, offset_inv)
+    fn coset_offset_inv(&self) -> F {
+        map!(self, coset_offset_inv)
     }
 
     #[inline]
@@ -214,11 +214,6 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
     #[inline]
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F {
         map!(self, evaluate_vanishing_polynomial, tau)
-    }
-
-    /// Returns the `i`-th element of the domain.
-    fn element(&self, i: usize) -> F {
-        map!(self, element, i)
     }
 
     /// Return an iterator over the elements of the domain.

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -121,21 +121,6 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
         None
     }
 
-    fn new_subgroup(subgroup_size: usize) -> Option<Self> {
-        let domain = Radix2EvaluationDomain::new_subgroup(subgroup_size);
-        if let Some(domain) = domain {
-            return Some(GeneralEvaluationDomain::Radix2(domain));
-        }
-
-        if F::SMALL_SUBGROUP_BASE.is_some() {
-            return Some(GeneralEvaluationDomain::MixedRadix(
-                MixedRadixEvaluationDomain::new_subgroup(subgroup_size)?,
-            ));
-        }
-
-        None
-    }
-
     fn get_coset(&self, offset: F) -> Option<Self> {
         Some(match self {
             Self::Radix2(domain) => Self::Radix2(domain.get_coset(offset)?),
@@ -189,6 +174,10 @@ impl<F: FftField> EvaluationDomain<F> for GeneralEvaluationDomain<F> {
     #[inline]
     fn coset_offset_inv(&self) -> F {
         map!(self, coset_offset_inv)
+    }
+
+    fn coset_offset_pow_size(&self) -> F {
+        map!(self, coset_offset_pow_size)
     }
 
     #[inline]

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -41,7 +41,7 @@ pub struct MixedRadixEvaluationDomain<F: FftField> {
     pub offset: F,
     /// Inverse of the offset that specifies the coset.
     pub offset_inv: F,
-    /// Constant coefficient for the vanishing polynomial. 
+    /// Constant coefficient for the vanishing polynomial.
     /// Equals `self.offset^self.size`.
     pub offset_pow_size: F,
 }

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -37,8 +37,6 @@ pub struct MixedRadixEvaluationDomain<F: FftField> {
     pub group_gen: F,
     /// Inverse of the generator of the subgroup.
     pub group_gen_inv: F,
-    /// Multiplicative generator of the finite field.
-    pub generator_inv: F,
     /// Offset that specifies the coset.
     pub offset: F,
     /// Inverse of the offset that specifies the coset.
@@ -99,7 +97,6 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
             size_inv,
             group_gen,
             group_gen_inv: group_gen.inverse()?,
-            generator_inv: F::GENERATOR.inverse()?,
             offset: F::one(),
             offset_inv: F::one(),
         })

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -41,7 +41,8 @@ pub struct MixedRadixEvaluationDomain<F: FftField> {
     pub offset: F,
     /// Inverse of the offset that specifies the coset.
     pub offset_inv: F,
-    /// Constant coefficient for the vanishing polynomial.
+    /// Constant coefficient for the vanishing polynomial. 
+    /// Equals `self.offset^self.size`.
     pub offset_pow_size: F,
 }
 

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -195,7 +195,7 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
     fn evaluate_all_lagrange_coefficients(&self, tau: F) -> Vec<F> {
         // Evaluate all Lagrange polynomials
         let size = self.size();
-        let t_size = tau.pow(&[self.size]);
+        let t_size = tau.pow([self.size]);
         let one = F::one();
         if t_size.is_one() {
             let mut u = vec![F::zero(); size];
@@ -243,7 +243,7 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
     /// For multiplicative subgroups, this polynomial is `z(X) = X^self.size -
     /// 1`.
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F {
-        tau.pow(&[self.size]) - F::one()
+        tau.pow([self.size]) - F::one()
     }
 
     /// Returns the `i`-th element of the domain, where elements are ordered by
@@ -252,7 +252,7 @@ impl<F: FftField> EvaluationDomain<F> for MixedRadixEvaluationDomain<F> {
     fn element(&self, i: usize) -> F {
         // TODO: Consider precomputed exponentiation tables if we need this to be
         // faster.
-        self.group_gen.pow(&[i as u64])
+        self.group_gen.pow([i as u64])
     }
 
     /// Return an iterator over the elements of the domain.
@@ -371,7 +371,7 @@ pub(crate) fn serial_mixed_radix_fft<T: DomainCoeff<F>, F: FftField>(
             }
         }
 
-        let omega_q = omega.pow(&[(n / q) as u64]);
+        let omega_q = omega.pow([(n / q) as u64]);
         let mut qth_roots = Vec::with_capacity(q);
         qth_roots.push(F::one());
         for i in 1..q {
@@ -382,7 +382,7 @@ pub(crate) fn serial_mixed_radix_fft<T: DomainCoeff<F>, F: FftField>(
 
         // Doing the q_adicity passes.
         for _ in 0..q_adicity {
-            let w_m = omega.pow(&[(n / (q * m)) as u64]);
+            let w_m = omega.pow([(n / (q * m)) as u64]);
             let mut k = 0;
             while k < n {
                 let mut w_j = F::one(); // w_j is omega_m ^ j
@@ -423,7 +423,7 @@ pub(crate) fn serial_mixed_radix_fft<T: DomainCoeff<F>, F: FftField>(
 
     for _ in 0..two_adicity {
         // w_m is 2^s-th root of unity now
-        let w_m = omega.pow(&[(n / (2 * m)) as u64]);
+        let w_m = omega.pow([(n / (2 * m)) as u64]);
 
         let mut k = 0;
         while k < n {

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -236,7 +236,11 @@ pub trait EvaluationDomain<F: FftField>:
 
     /// Returns the `i`-th element of the domain.
     fn element(&self, i: usize) -> F {
-        self.coset_offset() * self.group_gen().pow([i as u64])
+        let mut result = self.group_gen().pow([i as u64]);
+        if !self.coset_offset().is_one() {
+            result *= self.coset_offset()
+        }
+        result
     }
 
     /// Return an iterator over the elements of the domain.

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -81,11 +81,11 @@ pub trait EvaluationDomain<F: FftField>:
     /// Return the group inverse of `self.group_gen()`.
     fn group_gen_inv(&self) -> F;
 
-    /// Return the offset that defines this domain.
-    fn offset(&self) -> F;
+    /// Return the group offset that defines this domain.
+    fn coset_offset(&self) -> F;
 
     /// Return the inverse of `self.offset()`.
-    fn offset_inv(&self) -> F;
+    fn coset_offset_inv(&self) -> F;
 
     /// Compute a FFT.
     #[inline]
@@ -168,7 +168,7 @@ pub trait EvaluationDomain<F: FftField>:
         // detect by checking if the vanishing poly is 0.
         let size = self.size();
         let z_h_at_tau = self.evaluate_vanishing_polynomial(tau);
-        let offset = self.offset();
+        let offset = self.coset_offset();
         let group_gen = self.group_gen();
         if z_h_at_tau.is_zero() {
             // In this case, we know that tau = hg^i, for some value i.
@@ -226,7 +226,9 @@ pub trait EvaluationDomain<F: FftField>:
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F;
 
     /// Returns the `i`-th element of the domain.
-    fn element(&self, i: usize) -> F;
+    fn element(&self, i: usize) -> F {
+        self.coset_offset() * self.group_gen().pow([i as u64])
+    }
 
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> Self::Elements;

--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -46,6 +46,17 @@ pub trait EvaluationDomain<F: FftField>:
     /// having `num_coeffs` coefficients.
     fn new(num_coeffs: usize) -> Option<Self>;
 
+    /// Construct a domain
+    fn new_subgroup(subgroup_size: usize) -> Option<Self>;
+
+    /// Construct a coset domain
+    fn new_coset(coset_size: usize, offset: F) -> Option<Self> {
+        Self::new_subgroup(coset_size)?.get_coset(offset)
+    }
+
+    /// Construct a coset domain from a subgroup domain
+    fn get_coset(&self, offset: F) -> Option<Self>;
+
     /// Return the size of a domain that is large enough for evaluations of a
     /// polynomial having `num_coeffs` coefficients.
     fn compute_size_of_domain(num_coeffs: usize) -> Option<usize>;

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -33,6 +33,7 @@ pub struct Radix2EvaluationDomain<F: FftField> {
     /// Inverse of the offset that specifies the coset.
     pub offset_inv: F,
     /// Constant coefficient for the vanishing polynomial.
+    /// Equals `self.offset^self.size`.
     pub offset_pow_size: F,
 }
 

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -169,7 +169,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
         // detect by checking if the vanishing poly is 0.
         let size = self.size();
         // TODO: Make this use the vanishing polynomial
-        let z_h_at_tau = tau.pow(&[self.size]) - F::one();
+        let z_h_at_tau = tau.pow([self.size]) - F::one();
         let domain_offset = F::one();
         if z_h_at_tau.is_zero() {
             // In this case, we know that tau = hg^i, for some value i.
@@ -199,7 +199,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
             use ark_ff::fields::batch_inversion;
 
             // v_0_inv = m * h^(m-1)
-            let v_0_inv = F::from(self.size) * domain_offset.pow(&[self.size - 1]);
+            let v_0_inv = F::from(self.size) * domain_offset.pow([self.size - 1]);
             let mut l_i = z_h_at_tau.inverse().unwrap() * v_0_inv;
             let mut negative_cur_elem = -domain_offset;
             let mut lagrange_coefficients_inverse = vec![F::zero(); size];
@@ -227,7 +227,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
     /// For multiplicative subgroups, this polynomial is `z(X) = X^self.size -
     /// 1`.
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F {
-        tau.pow(&[self.size]) - F::one()
+        tau.pow([self.size]) - F::one()
     }
 
     /// Returns the `i`-th element of the domain, where elements are ordered by
@@ -236,7 +236,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
     fn element(&self, i: usize) -> F {
         // TODO: Consider precomputed exponentiation tables if we need this to be
         // faster.
-        self.group_gen.pow(&[i as u64])
+        self.group_gen.pow([i as u64])
     }
 
     /// Return an iterator over the elements of the domain.
@@ -445,7 +445,7 @@ mod tests {
             let mut m = 1;
             for _i in 1..=log_n {
                 // w_m is 2^i-th root of unity
-                let w_m = omega.pow(&[(n / (2 * m)) as u64]);
+                let w_m = omega.pow([(n / (2 * m)) as u64]);
 
                 let mut k = 0;
                 while k < n {

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -82,7 +82,6 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
             size_inv,
             group_gen,
             group_gen_inv: group_gen.inverse()?,
-            generator_inv: F::GENERATOR.inverse()?,
             offset: F::one(),
             offset_inv: F::one(),
         })

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -32,6 +32,8 @@ pub struct Radix2EvaluationDomain<F: FftField> {
     pub offset: F,
     /// Inverse of the offset that specifies the coset.
     pub offset_inv: F,
+    /// Constant coefficient for the vanishing polynomial.
+    pub offset_pow_size: F,
 }
 
 impl<F: FftField> fmt::Debug for Radix2EvaluationDomain<F> {
@@ -82,6 +84,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
             group_gen_inv: group_gen.inverse()?,
             offset: F::one(),
             offset_inv: F::one(),
+            offset_pow_size: F::one(),
         })
     }
 
@@ -89,6 +92,7 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
         Some(Radix2EvaluationDomain {
             offset,
             offset_inv: offset.inverse()?,
+            offset_pow_size: offset.pow([self.size]),
             ..*self
         })
     }
@@ -128,12 +132,12 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
     }
 
     #[inline]
-    fn offset(&self) -> F {
+    fn coset_offset(&self) -> F {
         self.offset
     }
 
     #[inline]
-    fn offset_inv(&self) -> F {
+    fn coset_offset_inv(&self) -> F {
         self.offset_inv
     }
 
@@ -150,34 +154,24 @@ impl<F: FftField> EvaluationDomain<F> for Radix2EvaluationDomain<F> {
     }
 
     fn vanishing_polynomial(&self) -> crate::univariate::SparsePolynomial<F> {
-        let coeffs = vec![(0, -self.offset.pow([self.size])), (self.size(), F::one())];
+        let coeffs = vec![(0, -self.offset_pow_size), (self.size(), F::one())];
         crate::univariate::SparsePolynomial::from_coefficients_vec(coeffs)
     }
 
     /// This evaluates the vanishing polynomial for this domain at tau.
     /// For multiplicative subgroups, this polynomial is `z(X) = X^self.size -
-    /// 1`.
+    /// offset^self.size`.
     fn evaluate_vanishing_polynomial(&self, tau: F) -> F {
-        tau.pow([self.size]) - self.offset.pow([self.size])
-    }
-
-    /// Returns the `i`-th element of the domain, where elements are ordered by
-    /// their power of the generator which they correspond to.
-    /// e.g. the `i`-th element is g^i
-    fn element(&self, i: usize) -> F {
-        // TODO: Consider precomputed exponentiation tables if we need this to be
-        // faster.
-        self.offset * self.group_gen.pow([i as u64])
+        tau.pow([self.size]) - self.offset_pow_size
     }
 
     /// Return an iterator over the elements of the domain.
     fn elements(&self) -> Elements<F> {
         Elements {
-            cur_elem: F::one(),
+            cur_elem: self.offset,
             cur_pow: 0,
             size: self.size,
             group_gen: self.group_gen,
-            offset: self.offset,
         }
     }
 }

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -468,7 +468,7 @@ mod tests {
                     let mut actual_vec = expected_vec.clone();
 
                     let domain = Radix2EvaluationDomain::new(d).unwrap();
-                    let coset_domain = domain.get_coset(Fr::GENERATOR);
+                    let coset_domain = domain.get_coset(Fr::GENERATOR).unwrap();
 
                     serial_radix2_fft(&mut expected_vec, domain.group_gen, log_d);
                     domain.fft_in_place(&mut actual_vec);

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -191,7 +191,6 @@ pub struct Elements<F: FftField> {
     pub(crate) cur_pow: u64,
     pub(crate) size: u64,
     pub(crate) group_gen: F,
-    pub(crate) offset: F,
 }
 
 impl<F: FftField> Iterator for Elements<F> {
@@ -203,7 +202,7 @@ impl<F: FftField> Iterator for Elements<F> {
             let cur_elem = self.cur_elem;
             self.cur_elem *= &self.group_gen;
             self.cur_pow += 1;
-            Some(self.offset * cur_elem)
+            Some(cur_elem)
         }
     }
 }

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -191,6 +191,7 @@ pub struct Elements<F: FftField> {
     pub(crate) cur_pow: u64,
     pub(crate) size: u64,
     pub(crate) group_gen: F,
+    pub(crate) offset: F,
 }
 
 impl<F: FftField> Iterator for Elements<F> {
@@ -202,7 +203,7 @@ impl<F: FftField> Iterator for Elements<F> {
             let cur_elem = self.cur_elem;
             self.cur_elem *= &self.group_gen;
             self.cur_pow += 1;
-            Some(cur_elem)
+            Some(self.offset * cur_elem)
         }
     }
 }

--- a/poly/src/test.rs
+++ b/poly/src/test.rs
@@ -23,6 +23,7 @@ fn fft_composition() {
             let coeffs = 1 << coeffs;
 
             let domain = D::new(coeffs).unwrap();
+            let coset_domain = domain.get_coset(F::GENERATOR).unwrap();
 
             let mut v = vec![];
             for _ in 0..coeffs {
@@ -40,13 +41,13 @@ fn fft_composition() {
             domain.ifft_in_place(&mut v2);
             assert_eq!(v, v2, "fft(ifft(.)) != iden");
 
-            domain.coset_ifft_in_place(&mut v2);
-            domain.coset_fft_in_place(&mut v2);
-            assert_eq!(v, v2, "coset_fft(coset_ifft(.)) != iden");
+            coset_domain.ifft_in_place(&mut v2);
+            coset_domain.fft_in_place(&mut v2);
+            assert_eq!(v, v2, "fft(ifft(.)) != iden");
 
-            domain.coset_fft_in_place(&mut v2);
-            domain.coset_ifft_in_place(&mut v2);
-            assert_eq!(v, v2, "coset_ifft(coset_fft(.)) != iden");
+            coset_domain.fft_in_place(&mut v2);
+            coset_domain.ifft_in_place(&mut v2);
+            assert_eq!(v, v2, "ifft(fft(.)) != iden");
         }
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #88

---

* Added two constructors `new_subgroup(subgroup_size)` and `new_coset(coset_size, offset)`. I kept the old constructor new(num_coeffs) since it contains logic to choose a subgroup size
* Removed cosetFFT / cosetIFFT methods
* Added get_coset(offset) convenience method 
* Removed `divide_by_vanishing_poly_on_coset_in_place()`. It wasn't clear if this method was appropriate anymore given domains can be coset domains.
* Removed generator_inv() method and added offset() and offset_inv() methods
* Moved `evaluate_all_lagrange_coefficients()` into a default implementation. **Is there any reason not to do the same for the vanishing_polynomial and element methods?**

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
