### PR TITLE
Rename `relabel_inplace` to `relabel_in_place`

### DIFF
--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -47,7 +47,7 @@ impl<F: Field> DenseMultilinearExtension<F> {
             evaluations,
         }
     }
-    /// Relabel the point inplace by switching `k` scalars from position `a` to
+    /// Relabel the point in place by switching `k` scalars from position `a` to
     /// position `b`, and from position `b` to position `a` in vector.
     ///
     /// This function turns `P(x_1,...,x_a,...,x_{a+k - 1},...,x_b,...,x_{b+k - 1},...,x_n)`

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -52,7 +52,7 @@ impl<F: Field> DenseMultilinearExtension<F> {
     ///
     /// This function turns `P(x_1,...,x_a,...,x_{a+k - 1},...,x_b,...,x_{b+k - 1},...,x_n)`
     /// to `P(x_1,...,x_b,...,x_{b+k - 1},...,x_a,...,x_{a+k - 1},...,x_n)`
-    pub fn relabel_inplace(&mut self, mut a: usize, mut b: usize, k: usize) {
+    pub fn relabel_in_place(&mut self, mut a: usize, mut b: usize, k: usize) {
         // enforce order of a and b
         if a > b {
             ark_std::mem::swap(&mut a, &mut b);
@@ -103,7 +103,7 @@ impl<F: Field> MultilinearExtension<F> for DenseMultilinearExtension<F> {
 
     fn relabel(&self, a: usize, b: usize, k: usize) -> Self {
         let mut copied = self.clone();
-        copied.relabel_inplace(a, b, k);
+        copied.relabel_in_place(a, b, k);
         copied
     }
 
@@ -311,29 +311,29 @@ mod tests {
 
             let expected = poly.evaluate(&point);
 
-            poly.relabel_inplace(2, 2, 1); // should have no effect
+            poly.relabel_in_place(2, 2, 1); // should have no effect
             assert_eq!(expected, poly.evaluate(&point));
 
-            poly.relabel_inplace(3, 4, 1); // should switch 3 and 4
+            poly.relabel_in_place(3, 4, 1); // should switch 3 and 4
             point.swap(3, 4);
             assert_eq!(expected, poly.evaluate(&point));
 
-            poly.relabel_inplace(7, 5, 1);
+            poly.relabel_in_place(7, 5, 1);
             point.swap(7, 5);
             assert_eq!(expected, poly.evaluate(&point));
 
-            poly.relabel_inplace(2, 5, 3);
+            poly.relabel_in_place(2, 5, 3);
             point.swap(2, 5);
             point.swap(3, 6);
             point.swap(4, 7);
             assert_eq!(expected, poly.evaluate(&point));
 
-            poly.relabel_inplace(7, 0, 2);
+            poly.relabel_in_place(7, 0, 2);
             point.swap(0, 7);
             point.swap(1, 8);
             assert_eq!(expected, poly.evaluate(&point));
 
-            poly.relabel_inplace(0, 9, 1);
+            poly.relabel_in_place(0, 9, 1);
             point.swap(0, 9);
             assert_eq!(expected, poly.evaluate(&point));
         }


### PR DESCRIPTION
## Description

When working on another project (Anemoi hash), I was trying to decide between using `inplace` or `in_place` in method names, and when I checked our use in arkworks-rs, I found that we have been using `in_place` except for one place.

This PR modifies that outlier to use `in_place` as well.

This is a very small PR. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Updated relevant documentation in the code
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
