### PR TITLE
if "greatest" is selected, second coordinate should be picked

### DIFF
--- a/ec/src/models/short_weierstrass/affine.rs
+++ b/ec/src/models/short_weierstrass/affine.rs
@@ -108,11 +108,11 @@ impl<P: SWCurveConfig> Affine<P> {
     /// largest y-coordinate be selected.
     #[allow(dead_code)]
     pub fn get_point_from_x_unchecked(x: P::BaseField, greatest: bool) -> Option<Self> {
-        Self::get_ys_from_x_unchecked(x).map(|(y, neg_y)| {
+        Self::get_ys_from_x_unchecked(x).map(|(smaller, larger)| {
             if greatest {
-                Self::new_unchecked(x, y)
+                Self::new_unchecked(x, larger)
             } else {
-                Self::new_unchecked(x, neg_y)
+                Self::new_unchecked(x, smaller)
             }
         })
     }


### PR DESCRIPTION
## Description

If I'm not mistaken, then according to the docs and code of `get_ys_from_x_unchecked`, the second value should be selected if `greatest` flag is true. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
