### PR TITLE
Fix group test templates: some tests aren't executed

### DIFF
--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -3,6 +3,7 @@
 macro_rules! __test_group {
     ($group: ty) => {
         type ScalarField = <$group as Group>::ScalarField;
+        #[test]
         fn test_add_properties() {
             let mut rng = &mut ark_std::test_rng();
             let zero = <$group>::zero();

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -178,6 +178,7 @@ macro_rules! __test_group {
         }
     };
     ($group:ty; curve) => {
+        $crate::__test_group!($group);
         $crate::__test_group!($group; msm);
         type Affine = <$group as CurveGroup>::Affine;
         type Config = <$group as CurveGroup>::Config;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Tests under the `($group: ty)` macro rule weren't being executed.
See e.g. [this job](https://github.com/arkworks-rs/algebra/actions/runs/3229765822/jobs/5287430415)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
