### PR TITLE
Add a type `BaseField` to the `Pairing` trait and implement for models

### DIFF
--- a/ec/src/models/bls12/mod.rs
+++ b/ec/src/models/bls12/mod.rs
@@ -88,6 +88,7 @@ impl<P: Bls12Parameters> Bls12<P> {
 }
 
 impl<P: Bls12Parameters> Pairing for Bls12<P> {
+    type BaseField = <P::G1Parameters as CurveConfig>::BaseField;
     type ScalarField = <P::G1Parameters as CurveConfig>::ScalarField;
     type G1 = G1Projective<P>;
     type G1Affine = G1Affine<P>;

--- a/ec/src/models/bn/mod.rs
+++ b/ec/src/models/bn/mod.rs
@@ -91,6 +91,7 @@ impl<P: BnParameters> Bn<P> {
 }
 
 impl<P: BnParameters> Pairing for Bn<P> {
+    type BaseField = <P::G1Parameters as CurveConfig>::BaseField;
     type ScalarField = <P::G1Parameters as CurveConfig>::ScalarField;
     type G1 = G1Projective<P>;
     type G1Affine = G1Affine<P>;

--- a/ec/src/models/bw6/mod.rs
+++ b/ec/src/models/bw6/mod.rs
@@ -211,6 +211,7 @@ impl<P: BW6Parameters> BW6<P> {
 }
 
 impl<P: BW6Parameters> Pairing for BW6<P> {
+    type BaseField = <P::G1Parameters as CurveConfig>::BaseField;
     type ScalarField = <P::G1Parameters as CurveConfig>::ScalarField;
     type G1 = G1Projective<P>;
     type G1Affine = G1Affine<P>;

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -197,6 +197,7 @@ impl<P: MNT4Parameters> MNT4<P> {
 }
 
 impl<P: MNT4Parameters> Pairing for MNT4<P> {
+    type BaseField = <P::G1Parameters as CurveConfig>::BaseField;
     type ScalarField = <P::G1Parameters as CurveConfig>::ScalarField;
     type G1 = G1Projective<P>;
     type G1Affine = G1Affine<P>;

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -203,6 +203,7 @@ impl<P: MNT6Parameters> MNT6<P> {
 }
 
 impl<P: MNT6Parameters> Pairing for MNT6<P> {
+    type BaseField = <P::G1Parameters as CurveConfig>::BaseField;
     type ScalarField = <P::G1Parameters as CurveConfig>::ScalarField;
     type G1 = G1Projective<P>;
     type G1Affine = G1Affine<P>;

--- a/ec/src/pairing.rs
+++ b/ec/src/pairing.rs
@@ -21,6 +21,9 @@ use crate::{AffineRepr, CurveGroup, Group, VariableBaseMSM};
 /// Collection of types (mainly fields and curves) that together describe
 /// how to compute a pairing over a pairing-friendly curve.
 pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
+    /// This is the base field of the G1/G2 groups.
+    type BaseField: PrimeField;
+
     /// This is the scalar field of the G1/G2 groups.
     type ScalarField: PrimeField;
 

--- a/ec/src/pairing.rs
+++ b/ec/src/pairing.rs
@@ -21,7 +21,7 @@ use crate::{AffineRepr, CurveGroup, Group, VariableBaseMSM};
 /// Collection of types (mainly fields and curves) that together describe
 /// how to compute a pairing over a pairing-friendly curve.
 pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
-    /// This is the base field of the G1/G2 groups.
+    /// This is the base field of the G1 group and base prime field of G2.
     type BaseField: PrimeField;
 
     /// This is the scalar field of the G1/G2 groups.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
As per title. As an alternative, we could write:
`type BaseField = P::Fp;`,
but I think the current version proposed in this PR is more aligned with the rest of the `Pairing` trait.

closes: #502

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
