### PR TITLE
add serde to Field

### DIFF
--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -22,6 +22,7 @@ derivative = { version = "2", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
 paste = "1.0"
 rayon = { version = "1", optional = true }
+serde = { version = "1.0", features = ["derive"] }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 num-bigint = { version = "0.4", default-features = false }
 digest = { version = "0.10", default-features = false, features = ["alloc"] }

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -18,13 +18,74 @@ use ark_std::{
     vec::Vec,
 };
 use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 #[macro_use]
 pub mod arithmetic;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize)]
-pub struct BigInt<const N: usize>(pub [u64; N]);
+mod arrays {
+    use ark_std::vec::Vec;
+    use ark_std::{convert::TryInto, marker::PhantomData};
+
+    use serde::{
+        de::{SeqAccess, Visitor},
+        ser::SerializeTuple,
+        Deserialize, Deserializer, Serialize, Serializer,
+    };
+    pub fn serialize<S: Serializer, T: Serialize, const N: usize>(
+        data: &[T; N],
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut s = ser.serialize_tuple(N)?;
+        for item in data {
+            s.serialize_element(item)?;
+        }
+        s.end()
+    }
+
+    struct ArrayVisitor<T, const N: usize>(PhantomData<T>);
+
+    impl<'de, T, const N: usize> Visitor<'de> for ArrayVisitor<T, N>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = [T; N];
+
+        fn expecting(&self, formatter: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
+            formatter.write_str(&format!("an array of length {}", N))
+        }
+
+        #[inline]
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            // can be optimized using MaybeUninit
+            let mut data = Vec::with_capacity(N);
+            for _ in 0..N {
+                match (seq.next_element())? {
+                    Some(val) => data.push(val),
+                    None => return Err(serde::de::Error::invalid_length(N, &self)),
+                }
+            }
+            match data.try_into() {
+                Ok(arr) => Ok(arr),
+                Err(_) => unreachable!(),
+            }
+        }
+    }
+    pub fn deserialize<'de, D, T, const N: usize>(deserializer: D) -> Result<[T; N], D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>,
+    {
+        deserializer.deserialize_tuple(N, ArrayVisitor::<T, N>(PhantomData))
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Zeroize, Serialize, Deserialize)]
+pub struct BigInt<const N: usize>(#[serde(with = "arrays")] pub [u64; N]);
 
 impl<const N: usize> Default for BigInt<N> {
     fn default() -> Self {

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -12,6 +12,7 @@ use ark_std::{
 
 pub use ark_ff_macros;
 use num_traits::{One, Zero};
+use serde::{de::DeserializeOwned, Serialize};
 use zeroize::Zeroize;
 
 pub mod utils;
@@ -113,6 +114,8 @@ pub trait Field:
     + CanonicalSerializeWithFlags
     + CanonicalDeserialize
     + CanonicalDeserializeWithFlags
+    + Serialize
+    + DeserializeOwned
     + Add<Self, Output = Self>
     + Sub<Self, Output = Self>
     + Mul<Self, Output = Self>

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -12,6 +12,7 @@ use ark_std::{
 };
 
 use num_traits::{One, Zero};
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use ark_std::rand::{
@@ -78,7 +79,7 @@ pub trait CubicExtConfig: 'static + Send + Sync + Sized {
 
 /// An element of a cubic extension field F_p\[X\]/(X^3 - P::NONRESIDUE) is
 /// represented as c0 + c1 * X + c2 * X^2, for c0, c1, c2 in `P::BaseField`.
-#[derive(Derivative)]
+#[derive(Serialize, Deserialize, Derivative)]
 #[derivative(
     Default(bound = "P: CubicExtConfig"),
     Hash(bound = "P: CubicExtConfig"),

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -17,6 +17,7 @@ use ark_std::{
 #[macro_use]
 mod montgomery_backend;
 pub use montgomery_backend::*;
+use serde::{Deserialize, Serialize};
 
 use crate::{BigInt, BigInteger, FftField, Field, LegendreSymbol, PrimeField, SqrtPrecomputation};
 /// A trait that specifies the configuration of a prime field.
@@ -100,7 +101,7 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
 
 /// Represents an element of the prime field F_p, where `p == P::MODULUS`.
 /// This type can represent elements in any field of size at most N * 64 bits.
-#[derive(Derivative)]
+#[derive(Serialize, Deserialize, Derivative)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -12,6 +12,7 @@ use ark_std::{
 };
 
 use num_traits::{One, Zero};
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use ark_std::rand::{
@@ -93,7 +94,7 @@ pub trait QuadExtConfig: 'static + Send + Sync + Sized {
 
 /// An element of a quadratic extension field F_p\[X\]/(X^2 - P::NONRESIDUE) is
 /// represented as c0 + c1 * X, for c0, c1 in `P::BaseField`.
-#[derive(Derivative)]
+#[derive(Serialize, Deserialize, Derivative)]
 #[derivative(
     Default(bound = "P: QuadExtConfig"),
     Hash(bound = "P: QuadExtConfig"),


### PR DESCRIPTION
I presume this is no good, but let's start a discussion o.o 

It is currently really painful to use arkworks in real-world projects because as soon as you want to serialize to disk or to send something over the wire, you can't use serde. Or at least, you have to resort to very verbose tricks (using serde_with, for example) to be able to serialize/deserialize any struct you have that contains `Field`.