### PR TITLE
Fix evaluation of dense polynomials over domains smaller than the degree

### DIFF
--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -509,4 +509,55 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn evaluate_over_small_domain() {
+        // Test that polynomial evaluation over a domain, and interpolation returns the
+        // same poly.
+        let mut rng = test_rng();
+        for poly_degree_dim in 1..5 {
+            let poly_degree = (1 << poly_degree_dim) - 1;
+            let sparse_poly = rand_sparse_poly(poly_degree, &mut rng);
+
+            for domain_dim in 0..poly_degree_dim {
+                let domain_size = 1 << domain_dim;
+                let domain = GeneralEvaluationDomain::new(domain_size).unwrap();
+
+                let sparse_evals = sparse_poly.evaluate_over_domain_by_ref(domain);
+
+                // Test that sparse evaluation and dense evaluation agree
+                let dense_poly: DensePolynomial<Fr> = sparse_poly.clone().into();
+                let dense_evals = dense_poly.clone().evaluate_over_domain(domain);
+                assert_eq!(
+                    sparse_evals, dense_evals,
+                    "poly_degree_dim = {}, domain_dim = {}",
+                    poly_degree_dim, domain_dim
+                );
+
+                // Test interpolation works, by checking that interpolated polynomial agrees with the original on the domain
+                let (_q, r) = (dense_poly.clone() + -sparse_evals.interpolate())
+                    .divide_by_vanishing_poly(domain)
+                    .unwrap();
+                assert_eq!(
+                    r,
+                    DensePolynomial::<Fr>::zero(),
+                    "poly_degree_dim = {}, domain_dim = {}",
+                    poly_degree_dim,
+                    domain_dim
+                );
+
+                // Consistency check that the dense polynomials interpolation is correct.
+                let (_q, r) = (dense_poly.clone() + -dense_evals.interpolate())
+                    .divide_by_vanishing_poly(domain)
+                    .unwrap();
+                assert_eq!(
+                    r,
+                    DensePolynomial::<Fr>::zero(),
+                    "poly_degree_dim = {}, domain_dim = {}",
+                    poly_degree_dim,
+                    domain_dim
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Fixes the evaluation of dense polynomials over domains smaller than the polynomial degree.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Currently, the coefficients of dense polynomials are truncated to match the size of the evaluation domain. This causes unexpected / incorrect behavior when larger polynomials are used. This PR resolves the issue by reducing the polynomial mod `X^d` where `d` is the size of the domain, before the FFT is performed.

A new unit test is located in `src/polynomial/univariate/sparse.rs`

It may also be a good idea to throw an error in the FFT routine when the coefficient vector is bigger than the FFT size, so that information is not accidentally discarded.

closes: #520

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ x ] Targeted PR against correct branch (master)
- [ x ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ x ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
