### PR TITLE
Fix prime order field sum of products test for k * 64 + 1 bits field

### DIFF
--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -392,7 +392,14 @@ macro_rules! __test_field {
             let mut a_max = <$field>::ZERO.into_bigint();
             for (i, limb) in a_max.as_mut().iter_mut().enumerate() {
                 if i == <$field as PrimeField>::BigInt::NUM_LIMBS - 1 {
-                    *limb = u64::MAX >> (64 - ((<$field>::MODULUS_BIT_SIZE - 1) % 64));
+                    let mod_num_bits_mod_64 =
+                        64 * <$field as PrimeField>::BigInt::NUM_LIMBS
+                        - (<$field as PrimeField>::MODULUS_BIT_SIZE as usize);
+                    if mod_num_bits_mod_64 == 63 {
+                        *limb = 0u64;
+                    } else {
+                        *limb = u64::MAX >> (mod_num_bits_mod_64 + 1);
+                    }
                 } else {
                     *limb = u64::MAX;
                 }


### PR DESCRIPTION
## Description

This is a re-opening of #538.

This PR fixes the prime order field's sum of products test when the field modulus is k * 64 + 1 bits. 

The overflowing error is because the code tries to do ">> 64". We solve this issue by doing " = 0" when we need to shift 64 bits here.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
