### PR TITLE
Fix `test_fft` for BLS12-381 domain `2^32 * 3`

### DIFF
--- a/test-curves/src/bls12_381/fr.rs
+++ b/test-curves/src/bls12_381/fr.rs
@@ -3,6 +3,8 @@ use ark_ff::fields::{Fp256, MontBackend, MontConfig};
 #[derive(MontConfig)]
 #[modulus = "52435875175126190479447740508185965837690552500527637822603658699938581184513"]
 #[generator = "7"]
+#[small_subgroup_base = "3"]
+#[small_subgroup_power = "1"]
 pub struct FrConfig;
 pub type Fr = Fp256<MontBackend<FrConfig, 4>>;
 

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -365,17 +365,15 @@ macro_rules! __test_field {
                 (1 << <$field>::TWO_ADICITY) * (small_subgroup_base as u64).pow(small_subgroup_base_adicity);
                 assert_eq!(large_subgroup_root_of_unity.pow([pow]), <$field>::one());
 
-                for i in 0..<$field>::TWO_ADICITY {
-                    for j in 0..small_subgroup_base_adicity {
-                        use core::convert::TryFrom;
-                        let size = usize::try_from(1 << i as usize).unwrap()
-                        * usize::try_from((small_subgroup_base as u64).pow(j)).unwrap();
+                for i in 0..=<$field>::TWO_ADICITY {
+                    for j in 0..=small_subgroup_base_adicity {
+                        let size = (1u64 << i) * (small_subgroup_base as u64).pow(j);
                         let root = <$field>::get_root_of_unity(size as u64).unwrap();
                         assert_eq!(root.pow([size as u64]), <$field>::one());
                     }
                 }
             } else {
-                for i in 0..<$field>::TWO_ADICITY {
+                for i in 0..=<$field>::TWO_ADICITY {
                     let size = 1 << i;
                     let root = <$field>::get_root_of_unity(size).unwrap();
                     assert_eq!(root.pow([size as u64]), <$field>::one());


### PR DESCRIPTION
## Description

In some TurboPlonk implementations, a degree-five gate is being used. So, there are two domains being used.

- one 2^k
- another one 2^k * 2 * 3 (to allow degree-five gates and some hiding degrees)

To allow the algorithm to use a mixed-radix domain (instead of 2^k * 2 * 2 * 2), we want to add the small subgroup base for BLS12-381's Fr. However, the `test_fft` test appears to be insufficient for `2^32` already, not to mention `2^32 * 3`.

Note that this improvement is important in practice because it saves 25% of the MSM when using Lagrange bases.

Also, the `test_fft` only tests `0..ADICITY`, but it should be `0..=ADICITY`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
