### PR TITLE
Fix MontFp issue in fields with 64 * k bits

### DIFF
--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -28,7 +28,7 @@ digest = { version = "0.10", default-features = false, features = ["alloc"] }
 itertools = { version = "0.10", default-features = false }
 
 [dev-dependencies]
-ark-test-curves = { version = "^0.3.0", path = "../test-curves", default-features = false, features = [ "bls12_381_curve", "mnt6_753"] }
+ark-test-curves = { version = "^0.3.0", path = "../test-curves", default-features = false, features = [ "bls12_381_curve", "mnt6_753", "secp256k1"] }
 blake2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 sha2 = { version = "0.10", default-features = false }

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -821,19 +821,23 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
 
 #[cfg(test)]
 mod test {
-    use num_bigint::{BigInt, Sign, BigUint};
-    use ark_test_curves::secp256k1::Fr;
     use ark_std::str::FromStr;
-    use ark_std::string::String;
     use ark_std::vec::Vec;
+    use ark_test_curves::secp256k1::Fr;
+    use num_bigint::{BigInt, BigUint, Sign};
 
     #[test]
     fn test_mont_macro_correctness() {
-        let (is_positive, limbs) = str_to_limbs_u64("111192936301596926984056301862066282284536849596023571352007112326586892541694");
+        let (is_positive, limbs) = str_to_limbs_u64(
+            "111192936301596926984056301862066282284536849596023571352007112326586892541694",
+        );
         let t = Fr::from_sign_and_limbs(is_positive, &limbs);
 
         let result: BigUint = t.into();
-        let expected = BigUint::from_str("111192936301596926984056301862066282284536849596023571352007112326586892541694").unwrap();
+        let expected = BigUint::from_str(
+            "111192936301596926984056301862066282284536849596023571352007112326586892541694",
+        )
+        .unwrap();
 
         assert_eq!(result, expected);
     }

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -199,12 +199,14 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
                 }
                 (a.0).0 = r;
             }
+            a.subtract_modulus();
         } else {
             // Alternative implementation
             // Implements CIOS.
-            *a = a.mul_without_cond_subtract(b);
+            let (carry, res) = a.mul_without_cond_subtract(b);
+            *a = res;
+            a.subtract_modulus_with_carry(carry);
         }
-        a.subtract_modulus();
     }
 
     #[inline(always)]
@@ -734,7 +736,7 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
         }
     }
 
-    const fn mul_without_cond_subtract(mut self, other: &Self) -> Self {
+    const fn mul_without_cond_subtract(mut self, other: &Self) -> (bool, Self) {
         let (mut lo, mut hi) = ([0u64; N], [0u64; N]);
         crate::const_for!((i in 0..N) {
             let mut carry = 0;
@@ -768,12 +770,12 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
         crate::const_for!((i in 0..N) {
             (self.0).0[i] = hi[i];
         });
-        self
+        (carry2 != 0, self)
     }
 
-    const fn mul(mut self, other: &Self) -> Self {
-        self = self.mul_without_cond_subtract(other);
-        self.const_subtract_modulus()
+    const fn mul(self, other: &Self) -> Self {
+        let (carry, res) = self.mul_without_cond_subtract(other);
+        res.const_subtract_modulus_with_carry(carry)
     }
 
     const fn const_is_valid(&self) -> bool {
@@ -788,8 +790,8 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
     }
 
     #[inline]
-    const fn const_subtract_modulus(mut self) -> Self {
-        if !self.const_is_valid() {
+    const fn const_subtract_modulus_with_carry(mut self, carry: bool) -> Self {
+        if carry || !self.const_is_valid() {
             self.0 = Self::sub_with_borrow(&self.0, &T::MODULUS);
         }
         self

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -818,3 +818,42 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
         a.const_sub_with_borrow(b).0
     }
 }
+
+#[cfg(test)]
+mod test {
+    use num_bigint::{BigInt, Sign, BigUint};
+    use ark_test_curves::secp256k1::Fr;
+    use ark_std::str::FromStr;
+    use ark_std::string::String;
+    use ark_std::vec::Vec;
+
+    #[test]
+    fn test_mont_macro_correctness() {
+        let (is_positive, limbs) = str_to_limbs_u64("111192936301596926984056301862066282284536849596023571352007112326586892541694");
+        let t = Fr::from_sign_and_limbs(is_positive, &limbs);
+
+        let result: BigUint = t.into();
+        let expected = BigUint::from_str("111192936301596926984056301862066282284536849596023571352007112326586892541694").unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    fn str_to_limbs_u64(num: &str) -> (bool, Vec<u64>) {
+        let (sign, digits) = BigInt::from_str(num)
+            .expect("could not parse to bigint")
+            .to_radix_le(16);
+        let limbs = digits
+            .chunks(16)
+            .map(|chunk| {
+                let mut this = 0u64;
+                for (i, hexit) in chunk.iter().enumerate() {
+                    this += (*hexit as u64) << (4 * i);
+                }
+                this
+            })
+            .collect::<Vec<_>>();
+
+        let sign_is_positive = sign != Sign::Minus;
+        (sign_is_positive, limbs)
+    }
+}

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -205,7 +205,12 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
             // Implements CIOS.
             let (carry, res) = a.mul_without_cond_subtract(b);
             *a = res;
-            a.subtract_modulus_with_carry(carry);
+
+            if Self::MODULUS_HAS_SPARE_BIT {
+                a.subtract_modulus_with_carry(carry);
+            } else {
+                a.subtract_modulus();
+            }
         }
     }
 
@@ -775,7 +780,11 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
 
     const fn mul(self, other: &Self) -> Self {
         let (carry, res) = self.mul_without_cond_subtract(other);
-        res.const_subtract_modulus_with_carry(carry)
+        if T::MODULUS_HAS_SPARE_BIT {
+            res.const_subtract_modulus()
+        } else {
+            res.const_subtract_modulus_with_carry(carry)
+        }
     }
 
     const fn const_is_valid(&self) -> bool {
@@ -787,6 +796,14 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
             }
         });
         false
+    }
+
+    #[inline]
+    const fn const_subtract_modulus(mut self) -> Self {
+        if !self.const_is_valid() {
+            self.0 = Self::sub_with_borrow(&self.0, &T::MODULUS);
+        }
+        self
     }
 
     #[inline]


### PR DESCRIPTION
## Description

Previously, we changed the logic of field multiplication to support 64 * k bits, as in #509 and #532. 

We did not, however, change the one that affects the `MontFp` macro. This was previously not detected because `MontFp` uses a special, dedicated function to perform the computation (since it cannot use Fp because Fp has not yet been constructed), while the rest is using other functions.

This PR fixes so, in that `MontFp` will also call a function that is aware of the 64 * k issue.

closes: #549 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Wrote unit tests

