### PR TITLE
impl `CanonicalSerialize/Deserialize` for `BigUint`

### DIFF
--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.56"
 ark-serialize-derive = { version = "^0.3.0", path = "../serialize-derive", optional = true }
 ark-std = { version = "^0.3.0", default-features = false }
 digest = { version = "0.10", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 sha2 = { version = "0.10", default-features = false}

--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -7,6 +7,7 @@ use ark_std::{
     string::String,
     vec::Vec,
 };
+use num_bigint::BigUint;
 
 use crate::*;
 
@@ -144,6 +145,50 @@ impl CanonicalDeserialize for usize {
         let mut bytes = [0u8; core::mem::size_of::<u64>()];
         reader.read_exact(&mut bytes)?;
         Ok(<u64>::from_le_bytes(bytes) as usize)
+    }
+}
+
+impl CanonicalSerialize for BigUint {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.to_bytes_le().serialize_with_mode(writer, compress)
+    }
+
+    #[inline]
+    fn serialized_size(&self, compress: Compress) -> usize {
+        self.to_bytes_le().serialized_size(compress)
+    }
+}
+
+impl CanonicalDeserialize for BigUint {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        Ok(BigUint::from_bytes_le(&Vec::<u8>::deserialize_with_mode(
+            reader, compress, validate,
+        )?))
+    }
+}
+
+impl Valid for BigUint {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+
+    #[inline]
+    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self>) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        Ok(())
     }
 }
 

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -472,11 +472,15 @@ mod test {
         expected.extend_from_slice(&biguint.to_bytes_le());
 
         let mut bytes = Vec::new();
-        biguint.serialize_with_mode(&mut bytes, Compress::Yes).unwrap();
+        biguint
+            .serialize_with_mode(&mut bytes, Compress::Yes)
+            .unwrap();
         assert_eq!(bytes, expected);
 
         let mut bytes = Vec::new();
-        biguint.serialize_with_mode(&mut bytes, Compress::No).unwrap();
+        biguint
+            .serialize_with_mode(&mut bytes, Compress::No)
+            .unwrap();
         assert_eq!(bytes, expected);
     }
 }

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -465,6 +465,18 @@ mod test {
 
     #[test]
     fn test_biguint() {
-        test_serialize(BigUint::from(123456u64));
+        let biguint = BigUint::from(123456u64);
+        test_serialize(biguint.clone());
+
+        let mut expected = (biguint.to_bytes_le().len() as u64).to_le_bytes().to_vec();
+        expected.extend_from_slice(&biguint.to_bytes_le());
+
+        let mut bytes = Vec::new();
+        biguint.serialize_with_mode(&mut bytes, Compress::Yes).unwrap();
+        assert_eq!(bytes, expected);
+
+        let mut bytes = Vec::new();
+        biguint.serialize_with_mode(&mut bytes, Compress::No).unwrap();
+        assert_eq!(bytes, expected);
     }
 }

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -232,6 +232,7 @@ mod test {
         vec,
         vec::Vec,
     };
+    use num_bigint::BigUint;
 
     #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
     struct Dummy;
@@ -460,5 +461,10 @@ mod test {
     fn test_sha3() {
         test_hash::<_, sha3::Sha3_256>(Dummy);
         test_hash::<_, sha3::Sha3_512>(Dummy);
+    }
+
+    #[test]
+    fn test_biguint() {
+        test_serialize(BigUint::from(123456u64));
     }
 }


### PR DESCRIPTION
## Description

This PR adds the canonical serialization and deserialization for BigUint. A limitation is that it would only support a specific version of num-bigint.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
