### PR TITLE
Fix tests for Modulus plus one div four

### DIFF
--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -428,14 +428,12 @@ macro_rules! __test_field {
             assert_eq!(BigUint::from(<$field>::MODULUS_MINUS_ONE_DIV_TWO), &modulus_minus_one / 2u32);
             assert_eq!(<$field>::MODULUS_BIT_SIZE as u64, modulus.bits());
             if let Some(SqrtPrecomputation::Case3Mod4 { modulus_plus_one_div_four }) = <$field>::SQRT_PRECOMP {
-                let check = &((&modulus + 1u8) / 4u8).to_u64_digits();
-                if check.len() != modulus_plus_one_div_four.len() {
-                    for &zero in &modulus_plus_one_div_four[modulus_plus_one_div_four.len()..] {
-                        assert_eq!(zero, 0);
-                    }
-                }
-                let modulus_plus_one_div_four = &modulus_plus_one_div_four[..check.len()];
-                assert_eq!(modulus_plus_one_div_four, check);
+                // Handle the case where `(MODULUS + 1) / 4`
+                // has fewer limbs than `MODULUS`.
+                let check = ((&modulus + 1u8) / 4u8).to_u64_digits();
+                let len = check.len()
+                assert_eq!(&modulus_plus_one_div_four[..len], &check);
+                assert!(modulus_plus_one_div_four[len..].iter().all(|l| *l == 0)));
             }
 
             let mut two_adicity = 0;

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -428,7 +428,14 @@ macro_rules! __test_field {
             assert_eq!(BigUint::from(<$field>::MODULUS_MINUS_ONE_DIV_TWO), &modulus_minus_one / 2u32);
             assert_eq!(<$field>::MODULUS_BIT_SIZE as u64, modulus.bits());
             if let Some(SqrtPrecomputation::Case3Mod4 { modulus_plus_one_div_four }) = <$field>::SQRT_PRECOMP {
-                assert_eq!(modulus_plus_one_div_four, &((&modulus + 1u8) / 4u8).to_u64_digits());
+                let check = &((&modulus + 1u8) / 4u8).to_u64_digits();
+                if check.len() != modulus_plus_one_div_four.len() {
+                    for &zero in &modulus_plus_one_div_four[modulus_plus_one_div_four.len()..] {
+                        assert_eq!(zero, 0);
+                    }
+                }
+                let modulus_plus_one_div_four = &modulus_plus_one_div_four[..check.len()];
+                assert_eq!(modulus_plus_one_div_four, check);
             }
 
             let mut two_adicity = 0;

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -431,7 +431,7 @@ macro_rules! __test_field {
                 // Handle the case where `(MODULUS + 1) / 4`
                 // has fewer limbs than `MODULUS`.
                 let check = ((&modulus + 1u8) / 4u8).to_u64_digits();
-                let len = check.len()
+                let len = check.len();
                 assert_eq!(&modulus_plus_one_div_four[..len], &check);
                 assert!(modulus_plus_one_div_four[len..].iter().all(|l| *l == 0));
             }

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -433,7 +433,7 @@ macro_rules! __test_field {
                 let check = ((&modulus + 1u8) / 4u8).to_u64_digits();
                 let len = check.len()
                 assert_eq!(&modulus_plus_one_div_four[..len], &check);
-                assert!(modulus_plus_one_div_four[len..].iter().all(|l| *l == 0)));
+                assert!(modulus_plus_one_div_four[len..].iter().all(|l| *l == 0));
             }
 
             let mut two_adicity = 0;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In the field tests, when (modulus + 1) / 4 is a limb shorter than the modulus, the comparison failed because of trailing zeroes.

This fix is a bit ugly, but works for the curve that I'm implementing. I'm not sure what would be cleaner, suggestions welcome. `BigUint::from()` would've been a lot cleaner, but it takes no `&[u64]`; how is that generally resolved in Arkworks?

What kind of unit test would you want? I intend to submit the curve I mention above when I'm sure I can show nothing-up-my-sleeves. FWIW, the kind of curves that trigger this condition, are curves that are slightly bigger than a nice round n*64 bits in length; e.g. curves that embed existing 256-bit curves.

---

- [x] Targeted PR against correct branch (master)
- [x] ~~Linked to GitHub issue with discussion and accepted design OR have~~ an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
