### PR TITLE
Fix test_sw_properties for some cofactor groups

### DIFF
--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -259,16 +259,17 @@ macro_rules! __test_group {
             assert!(generator.is_on_curve());
             assert!(generator.is_in_correct_subgroup_assuming_on_curve());
 
-            let mut x = BaseField::zero();
-            let mut i = 0;
-            loop {
+            for i in 0.. {
+                let x = BaseField::from(i);
                 // y^2 = x^3 + a * x + b
                 let rhs = x * x.square() + x * <Config as SWCurveConfig>::COEFF_A + <Config as SWCurveConfig>::COEFF_B;
 
                 if let Some(y) = rhs.sqrt() {
                     let p = Affine::new_unchecked(x, if y < -y { y } else { -y });
                     if !<<$group as CurveGroup>::Config as CurveConfig>::cofactor_is_one() {
-                        assert!(!p.is_in_correct_subgroup_assuming_on_curve());
+                        if p.is_in_correct_subgroup_assuming_on_curve() {
+                            continue;
+                        }
                     }
 
                     let g1 = p.mul_by_cofactor_to_group();
@@ -278,9 +279,6 @@ macro_rules! __test_group {
                         break;
                     }
                 }
-
-                i += 1;
-                x += BaseField::one();
             }
 
             for _ in 0..ITERATIONS {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The sw_properties test failed for groups with cofactors, for which the first valid point (according to incrementing x) was on the prime order subgroup.
The test assumed that the first point should have been of low order, such that multiplying it with the cofactor put it in the high order group.

This patch simplifies the code, and skips over these points.

This version works for the experimental curves that @Tarinn and I are testing out, one of which has cofactor 2, and triggered this edge case.

Fixes #553

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (this is a unit test that is fixed for future curves)
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
