### PR TITLE
use `into_bigint()` in `Debug` for `Fp<P, N>`

### DIFF
--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -156,9 +156,9 @@ impl<P: FpConfig<N>, const N: usize> Fp<P, N> {
     }
 }
 
-impl<P, const N: usize> ark_std::fmt::Debug for Fp<P, N> {
+impl<P: FpConfig<N>, const N: usize> ark_std::fmt::Debug for Fp<P, N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> ark_std::fmt::Result {
-        ark_std::fmt::Debug::fmt(&self.0, f)
+        ark_std::fmt::Debug::fmt(&self.into_bigint(), f)
     }
 }
 


### PR DESCRIPTION
## Description

Implements the `Debug` trait using the `into_bigint()` conversion which performs the Montgomery reduction in case of the Montgomery backend.

closes: #76 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
