### PR TITLE
Add `#[must_use]` to `frobenius_map_in_place`

### DIFF
--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -267,6 +267,7 @@ pub trait Field:
 
     /// Returns `self^s`, where `s = Self::BasePrimeField::MODULUS^power`.
     /// This is also called the Frobenius automorphism.
+    #[must_use]
     fn frobenius_map(&self, power: usize) -> Self {
         let mut this = *self;
         this.frobenius_map_in_place(power);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Otherwise downstream users will not get notified if they dont switch to `frobenius_map_in_place`.
As pointed out by user alex.eecs in Discord, and also useful for https://github.com/arkworks-rs/r1cs-std/pull/114.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
