### PR TITLE
Allow to overwrite default impl of `msm` in TwistedEdwards form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Pending
 
-- [\#567](https://github.com/arkworks-rs/algebra/pull/567) (`ark-ec`) Allow to overwrite the default implementation of the `msm` function provided by the `VariableBaseMSM` trait by a specialized version in `SWCurveConfig`.
-
 ### Breaking changes
 
 ### Features
@@ -198,6 +196,7 @@
 - [\#357](https://github.com/arkworks-rs/algebra/pull/357) (`ark-poly`) Speedup division by vanishing polynomials for dense polynomials.
 - [\#445](https://github.com/arkworks-rs/algebra/pull/445) (`ark-ec`) Use 2-NAF for ate pairing in MNT4/6 curves.
 - [\#509](https://github.com/arkworks-rs/algebra/pull/509) (`ark-ff`, `ark-ff-macros`) Support prime fields with (64 * k)-bit modulus.
+- [\#567](https://github.com/arkworks-rs/algebra/pull/567) (`ark-ec`) Allow to overwrite the default implementation of the `msm` function for TwistedEdwards form provided by the `VariableBaseMSM` trait by a specialized version in `TECurveConfig`.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- [\#567](https://github.com/arkworks-rs/algebra/pull/567) (`ark-ec`) Allow to overwrite the default implementation of the `msm` function provided by the `VariableBaseMSM` trait by a specialized version in `SWCurveConfig`.
+
 ### Breaking changes
 
 ### Features

--- a/ec/src/models/twisted_edwards/group.rs
+++ b/ec/src/models/twisted_edwards/group.rs
@@ -488,4 +488,8 @@ impl<P: TECurveConfig> ScalarMul for Projective<P> {
     }
 }
 
-impl<P: TECurveConfig> VariableBaseMSM for Projective<P> {}
+impl<P: TECurveConfig> VariableBaseMSM for Projective<P> {
+    fn msm(bases: &[Self::MulBase], bigints: &[Self::ScalarField]) -> Result<Self, usize> {
+        P::msm(bases, bigints)
+    }
+}

--- a/ec/src/models/twisted_edwards/mod.rs
+++ b/ec/src/models/twisted_edwards/mod.rs
@@ -4,7 +4,7 @@ use ark_serialize::{
 };
 use ark_std::io::{Read, Write};
 
-use crate::{AffineRepr, Group};
+use crate::{scalar_mul::variable_base::VariableBaseMSM, AffineRepr, Group};
 use num_traits::Zero;
 
 use ark_ff::fields::Field;
@@ -83,6 +83,16 @@ pub trait TECurveConfig: super::CurveConfig {
         }
 
         res
+    }
+
+    /// Default implementation for multi scalar multiplication
+    fn msm(
+        bases: &[Affine<Self>],
+        scalars: &[Self::ScalarField],
+    ) -> Result<Projective<Self>, usize> {
+        (bases.len() == scalars.len())
+            .then(|| VariableBaseMSM::msm_unchecked(bases, scalars))
+            .ok_or(usize::min(bases.len(), scalars.len()))
     }
 
     /// If uncompressed, serializes both x and y coordinates.


### PR DESCRIPTION
Allow to overwrite default impl of `msm` in TwistedEdwards form

## Description

Completely analogous to PR #528, allow us to also overwrite `msm` in TwistedEdwards form.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
~~- [ ] Wrote unit tests~~
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
