### PR TITLE
Unify model configs

### DIFF
--- a/ec/src/models/bn/mod.rs
+++ b/ec/src/models/bn/mod.rs
@@ -23,7 +23,7 @@ pub enum TwistType {
     D,
 }
 
-pub trait BnConfig: 'static {
+pub trait BnConfig: 'static + Sized {
     /// The absolute value of the BN curve parameter `X`
     /// (as in `q = 36 X^4 + 36 X^3 + 24 X^2 + 6 X + 1`).
     const X: &'static [u64];
@@ -46,6 +46,124 @@ pub trait BnConfig: 'static {
         BaseField = Fp2<Self::Fp2Config>,
         ScalarField = <Self::G1Config as CurveConfig>::ScalarField,
     >;
+
+    fn multi_miller_loop(
+        a: impl IntoIterator<Item = impl Into<G1Prepared<Self>>>,
+        b: impl IntoIterator<Item = impl Into<G2Prepared<Self>>>,
+    ) -> MillerLoopOutput<Bn<Self>> {
+        let mut pairs = a
+            .into_iter()
+            .zip_eq(b)
+            .filter_map(|(p, q)| {
+                let (p, q) = (p.into(), q.into());
+                match !p.is_zero() && !q.is_zero() {
+                    true => Some((p, q.ell_coeffs.into_iter())),
+                    false => None,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut f = cfg_chunks_mut!(pairs, 4)
+            .map(|pairs| {
+                let mut f = <Bn<Self> as Pairing>::TargetField::one();
+                for i in (1..Self::ATE_LOOP_COUNT.len()).rev() {
+                    if i != Self::ATE_LOOP_COUNT.len() - 1 {
+                        f.square_in_place();
+                    }
+
+                    for (p, coeffs) in pairs.iter_mut() {
+                        Bn::<Self>::ell(&mut f, &coeffs.next().unwrap(), &p.0);
+                    }
+
+                    let bit = Self::ATE_LOOP_COUNT[i - 1];
+                    if bit == 1 || bit == -1 {
+                        for (p, coeffs) in pairs.iter_mut() {
+                            Bn::<Self>::ell(&mut f, &coeffs.next().unwrap(), &p.0);
+                        }
+                    }
+                }
+                f
+            })
+            .product::<<Bn<Self> as Pairing>::TargetField>();
+
+        if Self::X_IS_NEGATIVE {
+            f.cyclotomic_inverse_in_place();
+        }
+
+        for (p, coeffs) in &mut pairs {
+            Bn::<Self>::ell(&mut f, &coeffs.next().unwrap(), &p.0);
+        }
+
+        for (p, coeffs) in &mut pairs {
+            Bn::<Self>::ell(&mut f, &coeffs.next().unwrap(), &p.0);
+        }
+
+        MillerLoopOutput(f)
+    }
+
+    #[allow(clippy::let_and_return)]
+    fn final_exponentiation(f: MillerLoopOutput<Bn<Self>>) -> Option<PairingOutput<Bn<Self>>> {
+        // Easy part: result = elt^((q^6-1)*(q^2+1)).
+        // Follows, e.g., Beuchat et al page 9, by computing result as follows:
+        //   elt^((q^6-1)*(q^2+1)) = (conj(elt) * elt^(-1))^(q^2+1)
+        let f = f.0;
+
+        // f1 = r.cyclotomic_inverse_in_place() = f^(p^6)
+        let mut f1 = f;
+        f1.cyclotomic_inverse_in_place();
+
+        f.inverse().map(|mut f2| {
+            // f2 = f^(-1);
+            // r = f^(p^6 - 1)
+            let mut r = f1 * &f2;
+
+            // f2 = f^(p^6 - 1)
+            f2 = r;
+            // r = f^((p^6 - 1)(p^2))
+            r.frobenius_map_in_place(2);
+
+            // r = f^((p^6 - 1)(p^2) + (p^6 - 1))
+            // r = f^((p^6 - 1)(p^2 + 1))
+            r *= &f2;
+
+            // Hard part follows Laura Fuentes-Castaneda et al. "Faster hashing to G2"
+            // by computing:
+            //
+            // result = elt^(q^3 * (12*z^3 + 6z^2 + 4z - 1) +
+            //               q^2 * (12*z^3 + 6z^2 + 6z) +
+            //               q   * (12*z^3 + 6z^2 + 4z) +
+            //               1   * (12*z^3 + 12z^2 + 6z + 1))
+            // which equals
+            //
+            // result = elt^( 2z * ( 6z^2 + 3z + 1 ) * (q^4 - q^2 + 1)/r ).
+
+            let y0 = Bn::<Self>::exp_by_neg_x(r);
+            let y1 = y0.cyclotomic_square();
+            let y2 = y1.cyclotomic_square();
+            let mut y3 = y2 * &y1;
+            let y4 = Bn::<Self>::exp_by_neg_x(y3);
+            let y5 = y4.cyclotomic_square();
+            let mut y6 = Bn::<Self>::exp_by_neg_x(y5);
+            y3.cyclotomic_inverse_in_place();
+            y6.cyclotomic_inverse_in_place();
+            let y7 = y6 * &y4;
+            let mut y8 = y7 * &y3;
+            let y9 = y8 * &y1;
+            let y10 = y8 * &y4;
+            let y11 = y10 * &r;
+            let mut y12 = y9;
+            y12.frobenius_map_in_place(1);
+            let y13 = y12 * &y11;
+            y8.frobenius_map_in_place(2);
+            let y14 = y8 * &y13;
+            r.cyclotomic_inverse_in_place();
+            let mut y15 = r * &y9;
+            y15.frobenius_map_in_place(3);
+            let y16 = y15 * &y14;
+
+            PairingOutput(y16)
+        })
+    }
 }
 
 pub mod g1;
@@ -105,117 +223,10 @@ impl<P: BnConfig> Pairing for Bn<P> {
         a: impl IntoIterator<Item = impl Into<Self::G1Prepared>>,
         b: impl IntoIterator<Item = impl Into<Self::G2Prepared>>,
     ) -> MillerLoopOutput<Self> {
-        let mut pairs = a
-            .into_iter()
-            .zip_eq(b)
-            .filter_map(|(p, q)| {
-                let (p, q) = (p.into(), q.into());
-                match !p.is_zero() && !q.is_zero() {
-                    true => Some((p, q.ell_coeffs.into_iter())),
-                    false => None,
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let mut f = cfg_chunks_mut!(pairs, 4)
-            .map(|pairs| {
-                let mut f = Self::TargetField::one();
-                for i in (1..P::ATE_LOOP_COUNT.len()).rev() {
-                    if i != P::ATE_LOOP_COUNT.len() - 1 {
-                        f.square_in_place();
-                    }
-
-                    for (p, coeffs) in pairs.iter_mut() {
-                        Self::ell(&mut f, &coeffs.next().unwrap(), &p.0);
-                    }
-
-                    let bit = P::ATE_LOOP_COUNT[i - 1];
-                    if bit == 1 || bit == -1 {
-                        for (p, coeffs) in pairs.iter_mut() {
-                            Self::ell(&mut f, &coeffs.next().unwrap(), &p.0);
-                        }
-                    }
-                }
-                f
-            })
-            .product::<Self::TargetField>();
-
-        if P::X_IS_NEGATIVE {
-            f.cyclotomic_inverse_in_place();
-        }
-
-        for (p, coeffs) in &mut pairs {
-            Self::ell(&mut f, &coeffs.next().unwrap(), &p.0);
-        }
-
-        for (p, coeffs) in &mut pairs {
-            Self::ell(&mut f, &coeffs.next().unwrap(), &p.0);
-        }
-
-        MillerLoopOutput(f)
+        P::multi_miller_loop(a, b)
     }
 
-    #[allow(clippy::let_and_return)]
     fn final_exponentiation(f: MillerLoopOutput<Self>) -> Option<PairingOutput<Self>> {
-        // Easy part: result = elt^((q^6-1)*(q^2+1)).
-        // Follows, e.g., Beuchat et al page 9, by computing result as follows:
-        //   elt^((q^6-1)*(q^2+1)) = (conj(elt) * elt^(-1))^(q^2+1)
-        let f = f.0;
-
-        // f1 = r.cyclotomic_inverse_in_place() = f^(p^6)
-        let mut f1 = f;
-        f1.cyclotomic_inverse_in_place();
-
-        f.inverse().map(|mut f2| {
-            // f2 = f^(-1);
-            // r = f^(p^6 - 1)
-            let mut r = f1 * &f2;
-
-            // f2 = f^(p^6 - 1)
-            f2 = r;
-            // r = f^((p^6 - 1)(p^2))
-            r.frobenius_map_in_place(2);
-
-            // r = f^((p^6 - 1)(p^2) + (p^6 - 1))
-            // r = f^((p^6 - 1)(p^2 + 1))
-            r *= &f2;
-
-            // Hard part follows Laura Fuentes-Castaneda et al. "Faster hashing to G2"
-            // by computing:
-            //
-            // result = elt^(q^3 * (12*z^3 + 6z^2 + 4z - 1) +
-            //               q^2 * (12*z^3 + 6z^2 + 6z) +
-            //               q   * (12*z^3 + 6z^2 + 4z) +
-            //               1   * (12*z^3 + 12z^2 + 6z + 1))
-            // which equals
-            //
-            // result = elt^( 2z * ( 6z^2 + 3z + 1 ) * (q^4 - q^2 + 1)/r ).
-
-            let y0 = Self::exp_by_neg_x(r);
-            let y1 = y0.cyclotomic_square();
-            let y2 = y1.cyclotomic_square();
-            let mut y3 = y2 * &y1;
-            let y4 = Self::exp_by_neg_x(y3);
-            let y5 = y4.cyclotomic_square();
-            let mut y6 = Self::exp_by_neg_x(y5);
-            y3.cyclotomic_inverse_in_place();
-            y6.cyclotomic_inverse_in_place();
-            let y7 = y6 * &y4;
-            let mut y8 = y7 * &y3;
-            let y9 = y8 * &y1;
-            let y10 = y8 * &y4;
-            let y11 = y10 * &r;
-            let mut y12 = y9;
-            y12.frobenius_map_in_place(1);
-            let y13 = y12 * &y11;
-            y8.frobenius_map_in_place(2);
-            let y14 = y8 * &y13;
-            r.cyclotomic_inverse_in_place();
-            let mut y15 = r * &y9;
-            y15.frobenius_map_in_place(3);
-            let y16 = y15 * &y14;
-
-            PairingOutput(y16)
-        })
+        P::final_exponentiation(f)
     }
 }

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -821,8 +821,7 @@ impl<T: MontConfig<N>, const N: usize> Fp<MontBackend<T, N>, N> {
 
 #[cfg(test)]
 mod test {
-    use ark_std::str::FromStr;
-    use ark_std::vec::Vec;
+    use ark_std::{str::FromStr, vec::Vec};
     use ark_test_curves::secp256k1::Fr;
     use num_bigint::{BigInt, BigUint, Sign};
 

--- a/test-templates/src/h2c/mod.rs
+++ b/test-templates/src/h2c/mod.rs
@@ -29,8 +29,7 @@ macro_rules! test_h2c {
                 fs::{read_dir, File},
                 io::BufReader,
             };
-            use $crate::decode;
-            use $crate::Sha256;
+            use $crate::{decode, Sha256};
 
             use $crate::json::SuiteVector;
             #[test]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Since BLS12 and BW6 already had `final_exponentiation` and `multi_miller_loop` as part of the `{BLS12/BW6}Config`, this PR adds it the same methods for `BnConfig`, `MNT4Config` and `MNT6Config`, for consistency.

+ some cargo fmt

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
