### PR TITLE
Build docs correctly on docs.rs

### DIFF
--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -38,3 +38,6 @@ hex = "0.4"
 default = []
 std = [ "ark-std/std", "ark-ff/std", "ark-serialize/std" ]
 parallel = [ "std", "rayon", "ark-std/parallel" ]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "./doc/katex-header.html"]

--- a/ec/doc/katex-header.html
+++ b/ec/doc/katex-header.html
@@ -1,0 +1,1 @@
+../../doc/katex-header.html

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -49,4 +49,4 @@ asm = []
 
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--html-in-header", "../doc/katex-header.html"]
+rustdoc-args = ["--html-in-header", "./doc/katex-header.html"]

--- a/ff/doc/katex-header.html
+++ b/ff/doc/katex-header.html
@@ -1,0 +1,1 @@
+../../doc/katex-header.html


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The `ark-ff` docs currently cannot be built on docs.rs. The problem is that it refers to a file that is outside the crate. This commit fixes the problem.

`ark-ec` is also using LaTeX in its documentation, hence include the KaTeX header there as well.

closes: #587.

I don't know how to try this out, so it's a best effort that hopefully works.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
