### PR TITLE
Set correct minimum supported Rust version

### DIFF
--- a/bench-templates/Cargo.toml
+++ b/bench-templates/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+rust-version = "1.63"
 
 ################################# Dependencies ################################
 

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [dependencies]
 ark-std = { version = "0.4.0", default-features = false }

--- a/ff-asm/Cargo.toml
+++ b/ff-asm/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 quote = "1.0.0"

--- a/ff-macros/Cargo.toml
+++ b/ff-macros/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 quote = "1.0.0"

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "build.rs", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.63"
 
 [dependencies]
 ark-ff-asm = { version = "0.4.0", path = "../ff-asm" }

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.63"
 
 [dependencies]
 ark-ff = { version = "0.4.0", path = "../ff", default-features = false }

--- a/serialize-derive/Cargo.toml
+++ b/serialize-derive/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 ################################# Dependencies ################################
 

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 
 [dependencies]
 ark-serialize-derive = { version = "0.4.0", path = "../serialize-derive", optional = true }

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 
 [dependencies]
 ark-std = { version = "0.4.0", default-features = false }

--- a/test-templates/Cargo.toml
+++ b/test-templates/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 
 [dependencies]
 ark-std = { version = "0.4.0", default-features = false }


### PR DESCRIPTION
## Description

The minimum supported Rust version (MSRV) isn't correct in all crates, this commit fixes it.

To find the minumum version [cargo msrv](https://crates.io/crates/cargo-msrv) was used. Here are the results:

 - `ark-ff``: 1.63 due to dependency on `ark-serialize`
 - `ark-ff-asm`: 1.60 due to `ahash` 0.8.0
 - `arf-ff-macros`: 1.60 due to `ahash` 0.8.0
 - `ark-poly`: 1.63 due to dependency on `ark-serialize`
 - `ark-serialize`: 1.63 due to the use of [`core::array::from_fn`](https://doc.rust-lang.org/core/array/fn.from_fn.html)
 - `ark-serialize-derive`: 1.60 due to `ahash` 0.8.0
 - `ark-test-curves`: 1.63 due to depndency on `ark-ec`
 - `ark-algebra-test-templates`: 1.63 due to dependency on `ark-serialize`

In order to verify that now the set versions are at least the minimum, you can run:

    find . -mindepth 2 -name Cargo.toml|parallel 'echo {} && cd `dirname {}` && cargo msrv verify'

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
