### PR TITLE
Avoid unwrapping if inverse doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 - (`ark-poly`) Reduce the number of field multiplications performed by `SparseMultilinearExtension::evaluate` and `DenseMultilinearExtension::evaluate`
+- [\#610](https://github.com/arkworks-rs/algebra/pull/610) (`ark-ec`) Fix panic in `final_exponentiation` step for MNT4/6 curves if inverse does not exist.
 
 ### Breaking changes
 

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -60,7 +60,7 @@ pub trait MNT4Config: 'static + Sized {
 
     fn final_exponentiation(f: MillerLoopOutput<MNT4<Self>>) -> Option<PairingOutput<MNT4<Self>>> {
         let value = f.0;
-        let value_inv = value.inverse().unwrap();
+        let value_inv = value.inverse()?;
         let value_to_first_chunk =
             MNT4::<Self>::final_exponentiation_first_chunk(&value, &value_inv);
         let value_inv_to_first_chunk =

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -61,7 +61,7 @@ pub trait MNT6Config: 'static + Sized {
 
     fn final_exponentiation(f: MillerLoopOutput<MNT6<Self>>) -> Option<PairingOutput<MNT6<Self>>> {
         let value = f.0;
-        let value_inv = value.inverse().unwrap();
+        let value_inv = value.inverse()?;
         let value_to_first_chunk =
             MNT6::<Self>::final_exponentiation_first_chunk(&value, &value_inv);
         let value_inv_to_first_chunk =


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The `final_exponentiation` step for the MNT4/6 curves involved unwrapping an inverse operation,
which can cause ZKP related operations (e.g., verification) to panic.
Instead, it now early returns with None, should the inverse not exist.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code – does not affect any documentation
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
