### PR TITLE
Fix DensePolynomial add assign bug

### DIFF
--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -353,8 +353,8 @@ impl<'a, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> {
                 .for_each(|(a, b)| {
                     *a += b;
                 });
-            self.truncate_leading_zeros();
         }
+        self.truncate_leading_zeros();
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Add assign doesn't perform truncate_leading zeros if self.degree() >= other.degree(). This is problematic in the case self.degree() == other.degree() since you can end up with a polynomial that has a leading zero coefficient. This leading zero coefficient will lead to a panic https://github.com/arkworks-rs/algebra/blob/master/poly/src/polynomial/univariate/dense.rs#L35

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
