### PR TITLE
Make `short_weierstrass::Affine`'s `infinity` flag conditional

### DIFF
--- a/ec/src/hashing/curve_maps/swu/mod.rs
+++ b/ec/src/hashing/curve_maps/swu/mod.rs
@@ -206,6 +206,9 @@ mod test {
 
         /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
         const GENERATOR: Affine<Self> = Affine::new_unchecked(MontFp!("62"), MontFp!("70"));
+
+        /// We use `bool` because the point (0, 0) could be on the curve.
+        type ZeroIndicator = bool;
     }
 
     impl SWUConfig for TestSWUMapToCurveConfig {

--- a/ec/src/hashing/curve_maps/wb/mod.rs
+++ b/ec/src/hashing/curve_maps/wb/mod.rs
@@ -165,6 +165,9 @@ mod test {
 
         /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
         const GENERATOR: Affine<Self> = Affine::new_unchecked(MontFp!("62"), MontFp!("70"));
+
+        /// We use `()` because the point (0, 0) is not on the curve.
+        type ZeroIndicator = ();
     }
 
     /// Testing WB19 hashing on a small curve
@@ -198,6 +201,9 @@ mod test {
 
         /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
         const GENERATOR: Affine<Self> = Affine::new_unchecked(MontFp!("84"), MontFp!("2"));
+
+        /// We use `bool because the point (0, 0) could be on the curve.
+        type ZeroIndicator = bool;
     }
 
     /// SWU parameters for E_isogenous

--- a/ec/src/models/bn/g1.rs
+++ b/ec/src/models/bn/g1.rs
@@ -44,7 +44,7 @@ impl<'a, P: BnConfig> From<&'a G1Projective<P>> for G1Prepared<P> {
 
 impl<P: BnConfig> G1Prepared<P> {
     pub fn is_zero(&self) -> bool {
-        self.0.infinity
+        self.0.is_zero()
     }
 }
 

--- a/ec/src/models/bn/g2.rs
+++ b/ec/src/models/bn/g2.rs
@@ -103,7 +103,7 @@ impl<P: BnConfig> Default for G2Prepared<P> {
 
 impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
     fn from(q: G2Affine<P>) -> Self {
-        if q.infinity {
+        if q.is_zero() {
             G2Prepared {
                 ell_coeffs: vec![],
                 infinity: true,

--- a/ec/src/models/bw6/g1.rs
+++ b/ec/src/models/bw6/g1.rs
@@ -45,7 +45,7 @@ impl<'a, P: BW6Config> From<&'a G1Projective<P>> for G1Prepared<P> {
 
 impl<P: BW6Config> G1Prepared<P> {
     pub fn is_zero(&self) -> bool {
-        self.0.infinity
+        self.0.is_zero()
     }
 }
 

--- a/ec/src/models/bw6/g2.rs
+++ b/ec/src/models/bw6/g2.rs
@@ -48,7 +48,7 @@ impl<P: BW6Config> Default for G2Prepared<P> {
 
 impl<P: BW6Config> From<G2Affine<P>> for G2Prepared<P> {
     fn from(q: G2Affine<P>) -> Self {
-        if q.infinity {
+        if q.is_zero() {
             return Self {
                 ell_coeffs_1: vec![],
                 ell_coeffs_2: vec![],

--- a/ec/src/models/short_weierstrass/group.rs
+++ b/ec/src/models/short_weierstrass/group.rs
@@ -620,6 +620,7 @@ impl<P: SWCurveConfig> CanonicalDeserialize for Projective<P> {
 impl<M: SWCurveConfig, ConstraintF: Field> ToConstraintField<ConstraintF> for Projective<M>
 where
     M::BaseField: ToConstraintField<ConstraintF>,
+    M::ZeroIndicator: ToConstraintField<ConstraintF>,
 {
     #[inline]
     fn to_field_elements(&self) -> Option<Vec<ConstraintF>> {

--- a/ec/src/models/short_weierstrass/mod.rs
+++ b/ec/src/models/short_weierstrass/mod.rs
@@ -2,7 +2,10 @@ use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, Compress, SerializationError, Valid, Validate,
 };
-use ark_std::io::{Read, Write};
+use ark_std::{
+    hash::Hash,
+    io::{Read, Write},
+};
 
 use ark_ff::fields::Field;
 
@@ -29,6 +32,9 @@ pub trait SWCurveConfig: super::CurveConfig {
     const COEFF_B: Self::BaseField;
     /// Generator of the prime-order subgroup.
     const GENERATOR: Affine<Self>;
+
+    /// A type that is stored in `Affine<Self>` to indicate whether the point is at infinity.
+    type ZeroIndicator: ZeroInd<Self>;
 
     /// Helper method for computing `elem * Self::COEFF_A`.
     ///
@@ -124,7 +130,7 @@ pub trait SWCurveConfig: super::CurveConfig {
         mut writer: W,
         compress: ark_serialize::Compress,
     ) -> Result<(), SerializationError> {
-        let (x, y, flags) = match item.infinity {
+        let (x, y, flags) = match item.is_zero() {
             true => (
                 Self::BaseField::zero(),
                 Self::BaseField::zero(),
@@ -196,5 +202,32 @@ pub trait SWCurveConfig: super::CurveConfig {
             Compress::Yes => zero.serialized_size_with_flags::<SWFlags>(),
             Compress::No => zero.compressed_size() + zero.serialized_size_with_flags::<SWFlags>(),
         }
+    }
+}
+
+pub trait ZeroInd<C: SWCurveConfig>:
+    Hash + Ord + Eq + Copy + Sync + Send + Sized + 'static
+{
+    const IS_ZERO: Self;
+    const IS_NOT_ZERO: Self;
+    fn is_zero(point: &Affine<C>) -> bool;
+    fn zeroize(&mut self) {
+        *self = Self::IS_NOT_ZERO;
+    }
+}
+
+impl<C: SWCurveConfig<ZeroIndicator = bool>> ZeroInd<C> for bool {
+    const IS_ZERO: Self = true;
+    const IS_NOT_ZERO: Self = false;
+    fn is_zero(point: &Affine<C>) -> bool {
+        point.infinity
+    }
+}
+
+impl<C: SWCurveConfig> ZeroInd<C> for () {
+    const IS_ZERO: Self = ();
+    const IS_NOT_ZERO: Self = ();
+    fn is_zero(point: &Affine<C>) -> bool {
+        point.x.is_zero() & point.y.is_zero()
     }
 }

--- a/test-curves/src/bls12_381/g1.rs
+++ b/test-curves/src/bls12_381/g1.rs
@@ -36,6 +36,8 @@ impl short_weierstrass::SWCurveConfig for Config {
     /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
     const GENERATOR: G1Affine = G1Affine::new_unchecked(G1_GENERATOR_X, G1_GENERATOR_Y);
 
+    type ZeroIndicator = ();
+
     #[inline(always)]
     fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()

--- a/test-curves/src/bls12_381/g1_swu_iso.rs
+++ b/test-curves/src/bls12_381/g1_swu_iso.rs
@@ -43,6 +43,7 @@ impl SWCurveConfig for SwuIsoConfig {
     const COEFF_B: Fq = MontFp!("2906670324641927570491258158026293881577086121416628140204402091718288198173574630967936031029026176254968826637280");
 
     const GENERATOR: G1Affine = G1Affine::new_unchecked(G1_GENERATOR_X, G1_GENERATOR_Y);
+    type ZeroIndicator = ();
 }
 
 /// Lexicographically smallest, valid x-coordinate of a point P on the curve (with its corresponding y) multiplied by the cofactor.

--- a/test-curves/src/bls12_381/g2.rs
+++ b/test-curves/src/bls12_381/g2.rs
@@ -53,6 +53,8 @@ impl short_weierstrass::SWCurveConfig for Config {
     /// AFFINE_GENERATOR_COEFFS = (G2_GENERATOR_X, G2_GENERATOR_Y)
     const GENERATOR: G2Affine = G2Affine::new_unchecked(G2_GENERATOR_X, G2_GENERATOR_Y);
 
+    type ZeroIndicator = bool;
+
     #[inline(always)]
     fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()

--- a/test-curves/src/bls12_381/g2_swu_iso.rs
+++ b/test-curves/src/bls12_381/g2_swu_iso.rs
@@ -56,6 +56,8 @@ impl SWCurveConfig for SwuIsoConfig {
     const COEFF_B: Fq2 = Fq2::new(MontFp!("1012"), MontFp!("1012"));
 
     const GENERATOR: G2Affine = G2Affine::new_unchecked(G2_GENERATOR_X, G2_GENERATOR_Y);
+
+    type ZeroIndicator = bool;
 }
 
 /// Lexicographically smallest, valid x-coordinate of a point P on the curve (with its corresponding y) multiplied by the cofactor.

--- a/test-curves/src/bn384_small_two_adicity/g1.rs
+++ b/test-curves/src/bn384_small_two_adicity/g1.rs
@@ -33,6 +33,9 @@ impl short_weierstrass::SWCurveConfig for Config {
     /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
     const GENERATOR: G1Affine = G1Affine::new_unchecked(G1_GENERATOR_X, G1_GENERATOR_Y);
 
+    /// We can use `()`, because the point `(0, 0)` is not on the curve.
+    type ZeroIndicator = ();
+
     #[inline(always)]
     fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()

--- a/test-curves/src/mnt4_753/g1.rs
+++ b/test-curves/src/mnt4_753/g1.rs
@@ -36,6 +36,9 @@ impl short_weierstrass::SWCurveConfig for Config {
 
     /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
     const GENERATOR: G1Affine = G1Affine::new_unchecked(G1_GENERATOR_X, G1_GENERATOR_Y);
+
+    /// We use `bool because `(0, 0)` could be on the curve.
+    type ZeroIndicator = bool;
 }
 
 // Generator of G1

--- a/test-curves/src/secp256k1/g1.rs
+++ b/test-curves/src/secp256k1/g1.rs
@@ -34,6 +34,9 @@ impl SWCurveConfig for Config {
     fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
     }
+
+    /// We use `()` because `(0, 0)` cannot be on the curve.
+    type ZeroIndicator = ();
 }
 
 /// G_GENERATOR_X = 55066263022277343669578718895168534326250603453777594175500187360389116729240


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR allows `short_weierstrass::Affine`'s layout to conditionally contain a `bool` flag indicating whether or not it is zero. This is helpful for compressing the representation of the point in memory. Note that due to the unfortunate lack of associated type defaults, we cannot set the type of the flag to be `bool` by default.

In the future, it would be nice to automatically derive this from certain conditions (e.g., `A.is_zero()`) 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
