### PR TITLE
fix msm comment:the default msm implementation in fact checks length

### DIFF
--- a/ec/src/scalar_mul/variable_base/mod.rs
+++ b/ec/src/scalar_mul/variable_base/mod.rs
@@ -24,7 +24,7 @@ pub trait VariableBaseMSM: ScalarMul {
         Self::msm_bigint(bases, &bigints)
     }
 
-    /// Performs multi-scalar multiplication, without checking that `bases.len() == scalars.len()`.
+    /// Performs multi-scalar multiplication.
     ///
     /// # Warning
     ///


### PR DESCRIPTION
The msm method checks that `bases` and `scalars` have the same length.