### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/bench-templates/Cargo.toml
+++ b/bench-templates/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/algebra/"
 keywords = ["cryptography", "finite-fields", "elliptic-curves", "pairing"]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
 

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-ec/"
 keywords = ["cryptography", "elliptic-curves", "pairing"]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "doc", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
 

--- a/ec/src/scalar_mul/mod.rs
+++ b/ec/src/scalar_mul/mod.rs
@@ -4,8 +4,8 @@ pub mod wnaf;
 pub mod fixed_base;
 pub mod variable_base;
 
-use crate::PrimeGroup;
 use crate::short_weierstrass::{Affine, Projective, SWCurveConfig};
+use crate::PrimeGroup;
 use ark_ff::{AdditiveGroup, Zero};
 use ark_std::{
     ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},

--- a/ff-asm/Cargo.toml
+++ b/ff-asm/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-ff-asm/"
 keywords = ["cryptography", "finite-fields", "assembly" ]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.60"
 

--- a/ff-macros/Cargo.toml
+++ b/ff-macros/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-ff-asm/"
 keywords = ["cryptography", "finite-fields", "assembly" ]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.60"
 

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-ff/"
 keywords = ["cryptography", "finite-fields" ]
 categories = ["cryptography"]
 include = ["Cargo.toml", "build.rs", "src", "doc", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
 

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-poly/"
 keywords = ["cryptography", "finite-fields", "fft", "polynomials"]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
 

--- a/serialize-derive/Cargo.toml
+++ b/serialize-derive/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/algebra/"
 keywords = ["cryptography", "finite-fields", "elliptic-curves", "serialization"]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.60"
 

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-serialize/"
 keywords = ["cryptography", "serialization" ]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
 

--- a/test-curves/Cargo.toml
+++ b/test-curves/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-test-curves/"
 keywords = ["cryptography", "serialization" ]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
 

--- a/test-templates/Cargo.toml
+++ b/test-templates/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ark-curve-tests/"
 keywords = ["cryptography", "finite-fields", "elliptic-curves" ]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.63"
 


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields