### PR TITLE
Add From<i{int}> for signed integer conversion for Fields

### DIFF
--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -473,6 +473,29 @@ mod no_std_tests {
     }
 
     #[test]
+    pub fn test_from_ints() {
+        let felt2 = Fr::one() + Fr::one();
+        let felt16 = felt2 * felt2 * felt2 * felt2;
+
+        assert_eq!(Fr::from(1u8),  Fr::one());
+        assert_eq!(Fr::from(1u16), Fr::one());
+        assert_eq!(Fr::from(1u32), Fr::one());
+        assert_eq!(Fr::from(1u64), Fr::one());
+        assert_eq!(Fr::from(1u128), Fr::one());
+        assert_eq!(Fr::from(-1i8), -Fr::one());
+        assert_eq!(Fr::from(-1i64), -Fr::one());
+
+        assert_eq!(Fr::from(0), Fr::zero());
+
+        assert_eq!(Fr::from(-16i32), -felt16);
+        assert_eq!(Fr::from(16u32), felt16);
+        assert_eq!(Fr::from(16i64), felt16);
+
+        assert_eq!(Fr::from(-2i128), -felt2);
+        assert_eq!(Fr::from(2u16), felt2);
+    }
+
+    #[test]
     fn test_from_into_biguint() {
         let mut rng = ark_std::test_rng();
 

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -192,6 +192,11 @@ pub trait Field:
     + From<u32>
     + From<u16>
     + From<u8>
+    + From<i128>
+    + From<i64>
+    + From<i32>
+    + From<i16>
+    + From<i8>
     + From<bool>
     + Product<Self>
 {


### PR DESCRIPTION
Signed integer conversion is already integrated in the source code definition for `Fp` but it's not exposed from the trait