### PR TITLE
Fix the no-std issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,13 +166,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: thumbv6m-none-eabi
-          override: true
-
-      - name: Install Rust ARM64
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
           target: aarch64-unknown-none
           override: true
 
@@ -192,17 +185,17 @@ jobs:
                   --exclude ark-algebra-test-templates \
                   --exclude ark-algebra-bench-templates \
                   --exclude ark-poly-benches \
-                  --target thumbv6m-none-eabi"
+                  --target aarch64-unknown-none"
 
       - name: build
         uses: actions-rs/cargo@v1
         with:
             command: build
-            args: "--examples --workspace \
+            args: "--workspace \
                   --exclude ark-algebra-test-templates \
                   --exclude ark-algebra-bench-templates \
                   --exclude ark-poly-benches \
-                  --target thumbv6m-none-eabi"
+                  --target aarch64-unknown-none"
 
   test_against_curves:
     name: Test against curves

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -24,7 +24,7 @@ rayon = { version = "1", optional = true }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 hashbrown = "0.14.0"
 itertools = { version = "0.11", default-features = false }
-num-bigint = "0.4.3"
+num-bigint = { version = "0.4.3", default-features = false }
 
 [dev-dependencies]
 ark-test-curves = { version = "0.4.2", path = "../test-curves", default-features = false, features = ["bls12_381_curve"] }


### PR DESCRIPTION
## Description

It appears that the lack of no-default-features of num-bigint in ark-ec has caused no-std tests to fail in the upstream.

This is not previously detected because the no-std test in ark-algebra is testing on a different arch than the one used in the upstream. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
