### PR TITLE
Field::from_base_prime_field_elems takes Iterator, not slice.

### DIFF
--- a/ff/src/fields/field_hashers/mod.rs
+++ b/ff/src/fields/field_hashers/mod.rs
@@ -81,7 +81,7 @@ impl<F: Field, H: Default + DynDigest + Clone, const SEC_PARAM: usize> HashToFie
                 );
                 base_prime_field_elems.push(val);
             }
-            let f = F::from_base_prime_field_elems(&base_prime_field_elems).unwrap();
+            let f = F::from_base_prime_field_elems(base_prime_field_elems.drain(..)).unwrap();
             output.push(f);
         }
 

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -6,9 +6,9 @@ use ark_serialize::{
     CanonicalSerializeWithFlags, EmptyFlags, Flags,
 };
 use ark_std::{
-    iter::IntoIterator,
     fmt::{Debug, Display},
     hash::Hash,
+    iter::IntoIterator,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -225,7 +225,9 @@ pub trait Field:
 
     /// Convert a slice of base prime field elements into a field element.
     /// If the slice length != Self::extension_degree(), must return None.
-    fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self>;
+    fn from_base_prime_field_elems(
+        elems: impl IntoIterator<Item = Self::BasePrimeField>,
+    ) -> Option<Self>;
 
     /// Constructs a field element from a single base prime field elements.
     /// ```

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -6,6 +6,7 @@ use ark_serialize::{
     CanonicalSerializeWithFlags, EmptyFlags, Flags,
 };
 use ark_std::{
+    iter::IntoIterator,
     fmt::{Debug, Display},
     hash::Hash,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -224,7 +225,7 @@ pub trait Field:
 
     /// Convert a slice of base prime field elements into a field element.
     /// If the slice length != Self::extension_degree(), must return None.
-    fn from_base_prime_field_elems(elems: &[Self::BasePrimeField]) -> Option<Self>;
+    fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self>;
 
     /// Constructs a field element from a single base prime field elements.
     /// ```

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -6,7 +6,7 @@ use ark_std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt,
     io::{Read, Write},
-    iter::{Chain,IntoIterator},
+    iter::{Chain, IntoIterator},
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -216,14 +216,16 @@ impl<P: CubicExtConfig> Field for CubicExtField<P> {
         )
     }
 
-    fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self> {
+    fn from_base_prime_field_elems(
+        elems: impl IntoIterator<Item = Self::BasePrimeField>,
+    ) -> Option<Self> {
         let mut elems = elems.into_iter();
         let elems = elems.by_ref();
         let base_ext_deg = P::BaseField::extension_degree() as usize;
         let element = Some(Self::new(
-            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
-            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
-            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg))?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg))?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg))?,
         ));
         if elems.next().is_some() {
             None

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -6,7 +6,7 @@ use ark_std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt,
     io::{Read, Write},
-    iter::Chain,
+    iter::{Chain,IntoIterator},
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -216,17 +216,20 @@ impl<P: CubicExtConfig> Field for CubicExtField<P> {
         )
     }
 
-    fn from_base_prime_field_elems(elems: &[Self::BasePrimeField]) -> Option<Self> {
-        if elems.len() != (Self::extension_degree() as usize) {
-            return None;
-        }
+    fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self> {
+        let mut elems = elems.into_iter();
+        let elems = elems.by_ref();
         let base_ext_deg = P::BaseField::extension_degree() as usize;
-        Some(Self::new(
-            P::BaseField::from_base_prime_field_elems(&elems[0..base_ext_deg]).unwrap(),
-            P::BaseField::from_base_prime_field_elems(&elems[base_ext_deg..2 * base_ext_deg])
-                .unwrap(),
-            P::BaseField::from_base_prime_field_elems(&elems[2 * base_ext_deg..]).unwrap(),
-        ))
+        let element = Some(Self::new(
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
+        ));
+        if elems.next().is_some() {
+            None
+        } else {
+            element
+        }
     }
 
     #[inline]
@@ -734,7 +737,7 @@ mod cube_ext_tests {
             for _ in 0..d {
                 random_coeffs.push(Fq::rand(&mut test_rng()));
             }
-            let res = Fq6::from_base_prime_field_elems(&random_coeffs);
+            let res = Fq6::from_base_prime_field_elems(random_coeffs);
             assert_eq!(res, None);
         }
         // Test on slice lengths that are equal to the extension degree
@@ -745,12 +748,13 @@ mod cube_ext_tests {
             for _ in 0..ext_degree {
                 random_coeffs.push(Fq::rand(&mut test_rng()));
             }
-            let actual = Fq6::from_base_prime_field_elems(&random_coeffs).unwrap();
 
             let expected_0 = Fq2::new(random_coeffs[0], random_coeffs[1]);
             let expected_1 = Fq2::new(random_coeffs[2], random_coeffs[3]);
             let expected_2 = Fq2::new(random_coeffs[3], random_coeffs[4]);
             let expected = Fq6::new(expected_0, expected_1, expected_2);
+
+            let actual = Fq6::from_base_prime_field_elems(random_coeffs).unwrap();
             assert_eq!(actual, expected);
         }
     }
@@ -766,7 +770,7 @@ mod cube_ext_tests {
             random_coeffs[0] = random_coeff;
             assert_eq!(
                 res,
-                Fq6::from_base_prime_field_elems(&random_coeffs).unwrap()
+                Fq6::from_base_prime_field_elems(random_coeffs).unwrap()
             );
         }
     }

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -232,9 +232,11 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
         iter::once(*self)
     }
 
-    fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self> {
+    fn from_base_prime_field_elems(
+        elems: impl IntoIterator<Item = Self::BasePrimeField>,
+    ) -> Option<Self> {
         let mut elems = elems.into_iter();
-        let elem = elems.next() ?;
+        let elem = elems.next()?;
         if elems.next().is_some() {
             return None;
         }

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -232,11 +232,13 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
         iter::once(*self)
     }
 
-    fn from_base_prime_field_elems(elems: &[Self::BasePrimeField]) -> Option<Self> {
-        if elems.len() != (Self::extension_degree() as usize) {
+    fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self> {
+        let mut elems = elems.into_iter();
+        let elem = elems.next() ?;
+        if elems.next().is_some() {
             return None;
         }
-        Some(elems[0])
+        Some(elem)
     }
 
     #[inline]

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -6,7 +6,7 @@ use ark_std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt,
     io::{Read, Write},
-    iter::{Chain,IntoIterator},
+    iter::{Chain, IntoIterator},
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -242,13 +242,15 @@ impl<P: QuadExtConfig> Field for QuadExtField<P> {
             .chain(self.c1.to_base_prime_field_elements())
     }
 
-        fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self> {
+    fn from_base_prime_field_elems(
+        elems: impl IntoIterator<Item = Self::BasePrimeField>,
+    ) -> Option<Self> {
         let mut elems = elems.into_iter();
         let elems = elems.by_ref();
         let base_ext_deg = P::BaseField::extension_degree() as usize;
         let element = Some(Self::new(
-            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
-            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg))?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg))?,
         ));
         if elems.next().is_some() {
             None

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -6,7 +6,7 @@ use ark_std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt,
     io::{Read, Write},
-    iter::Chain,
+    iter::{Chain,IntoIterator},
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     vec::Vec,
 };
@@ -242,15 +242,19 @@ impl<P: QuadExtConfig> Field for QuadExtField<P> {
             .chain(self.c1.to_base_prime_field_elements())
     }
 
-    fn from_base_prime_field_elems(elems: &[Self::BasePrimeField]) -> Option<Self> {
-        if elems.len() != (Self::extension_degree() as usize) {
-            return None;
-        }
+        fn from_base_prime_field_elems(elems: impl IntoIterator<Item=Self::BasePrimeField>) -> Option<Self> {
+        let mut elems = elems.into_iter();
+        let elems = elems.by_ref();
         let base_ext_deg = P::BaseField::extension_degree() as usize;
-        Some(Self::new(
-            P::BaseField::from_base_prime_field_elems(&elems[0..base_ext_deg]).unwrap(),
-            P::BaseField::from_base_prime_field_elems(&elems[base_ext_deg..]).unwrap(),
-        ))
+        let element = Some(Self::new(
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
+            P::BaseField::from_base_prime_field_elems(elems.take(base_ext_deg)) ?,
+        ));
+        if elems.next().is_some() {
+            None
+        } else {
+            element
+        }
     }
 
     fn square(&self) -> Self {
@@ -794,7 +798,7 @@ mod quad_ext_tests {
             for _ in 0..d {
                 random_coeffs.push(Fq::rand(&mut test_rng()));
             }
-            let res = Fq2::from_base_prime_field_elems(&random_coeffs);
+            let res = Fq2::from_base_prime_field_elems(random_coeffs);
             assert_eq!(res, None);
         }
         // Test on slice lengths that are equal to the extension degree
@@ -805,8 +809,8 @@ mod quad_ext_tests {
             for _ in 0..ext_degree {
                 random_coeffs.push(Fq::rand(&mut test_rng()));
             }
-            let actual = Fq2::from_base_prime_field_elems(&random_coeffs).unwrap();
             let expected = Fq2::new(random_coeffs[0], random_coeffs[1]);
+            let actual = Fq2::from_base_prime_field_elems(random_coeffs).unwrap();
             assert_eq!(actual, expected);
         }
     }
@@ -822,7 +826,7 @@ mod quad_ext_tests {
             random_coeffs[0] = random_coeff;
             assert_eq!(
                 res,
-                Fq2::from_base_prime_field_elems(&random_coeffs).unwrap()
+                Fq2::from_base_prime_field_elems(random_coeffs).unwrap()
             );
         }
     }

--- a/test-templates/src/h2c/mod.rs
+++ b/test-templates/src/h2c/mod.rs
@@ -63,8 +63,8 @@ macro_rules! test_h2c {
                     let y = read_fq_vec(&v.p.y);
                     let got = g1_mapper.hash(&v.msg.as_bytes()).unwrap();
                     let want = Affine::<$group>::new_unchecked(
-                        <$field>::from_base_prime_field_elems(&x[..]).unwrap(),
-                        <$field>::from_base_prime_field_elems(&y[..]).unwrap(),
+                        <$field>::from_base_prime_field_elems(x).unwrap(),
+                        <$field>::from_base_prime_field_elems(y).unwrap(),
                     );
                     assert!(got.is_on_curve());
                     assert!(want.is_on_curve());


### PR DESCRIPTION
## Description

We'll avoid some allocations elsewhere by taking an iterator instead of a slice here.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
