### PR TITLE
Docstring and `#[doc(hidden)]` for Montgomery form inside of `Fp` model

### DIFF
--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -114,7 +114,7 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
 )]
 pub struct Fp<P: FpConfig<N>, const N: usize>(
     /// Contains the element in Montgomery form for efficient multiplication.
-    /// To convert an element to a [`BigInt`], use `into_bigint` or `into`.
+    /// To convert an element to a [`BigInt`](struct@BigInt), use `into_bigint` or `into`.
     #[doc(hidden)]
     pub BigInt<N>,
     #[derivative(Debug = "ignore")]

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -113,6 +113,9 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
     Eq(bound = "")
 )]
 pub struct Fp<P: FpConfig<N>, const N: usize>(
+    /// Contains the element in Montgomery form for efficient multiplication.
+    /// To convert an element to a [`BigInt`], use `into_bigint` or `into`.
+    #[doc(hidden)]
     pub BigInt<N>,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]


### PR DESCRIPTION
## Description
As discussed in [this GH discussion](https://github.com/orgs/arkworks-rs/discussions/3#discussioncomment-6899162), it's a bit surprising that the following fails:
```
let inner_int: BigInteger256 = BLSFr::from(1u8).0;
let into_int: BigInteger256 = BLSFr::from(1u8).into();
assert_eq!(inner_int, into_int); # fails!
```

The reason makes sense: the "inner" BigInt is actually the Montgomery form, for fast multiplication. It's not meant for public use. Hence this new docstring + `#[doc(hidden)]` attribute.

## Checklist
- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests: n/a (doc-only)
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`: unsure if this is relevant given the small scope of this PR. Please let me know if this is needed and I'll add something!
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
