### PR TITLE
fix typo : fixed minor typo in poly/src/valuation/dense.rs

### DIFF
--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -96,7 +96,7 @@ impl<F: Field> MultilinearExtension<F> for DenseMultilinearExtension<F> {
     /// // The two-variate polynomial x_0 + 3 * x_0 * x_1 + 2 evaluates to [2, 3, 2, 6]
     /// // in the two-dimensional hypercube with points [00, 10, 01, 11]
     /// let mle = DenseMultilinearExtension::from_evaluations_vec(
-    ///     2, vec![2, 3, 3, 6].iter().map(|x| Fr::from(*x as u64)).collect()
+    ///     2, vec![2, 3, 2, 6].iter().map(|x| Fr::from(*x as u64)).collect()
     /// );
     ///
     /// // By the uniqueness of MLEs, `mle` is precisely the above polynomial, which


### PR DESCRIPTION

## Description

--> in this PR, fixed some minor typo in `dense.rs`. In the line 96 ~ 97, i think the hypercube operation result should be changed.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [v] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
