### PR TITLE
Added CanonicalSerialize/Deserialize support for VecDeque and LinkedList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- [\#689](https://github.com/arkworks-rs/algebra/pull/689) (`ark-serialize`) Add `CanonicalSerialize` and `CanonicalDeserialize` impls for `VecDeque` and `LinkedList`.
+
 ### Breaking changes
 
 - [\#577](https://github.com/arkworks-rs/algebra/pull/577) (`ark-ff`, `ark-ec`) Add `AdditiveGroup`, a trait for additive groups (equipped with scalar field).

--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -1,6 +1,6 @@
 use ark_std::{
-    borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
+    borrow::{Borrow, Cow},
+    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
     io::{Read, Write},
     marker::PhantomData,
     rc::Rc,
@@ -529,27 +529,178 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Vec<T> {
     }
 }
 
-impl<T: CanonicalSerialize> CanonicalSerialize for [T] {
+// Helper function. Serializes any sequential data type to the format
+//     n as u64 || data[0].serialize() || ... || data[n].serialize()
+#[inline]
+fn serialize_seq<T, B, W>(
+    seq: impl ExactSizeIterator<Item = B>,
+    mut writer: W,
+    compress: Compress,
+) -> Result<(), SerializationError>
+where
+    T: CanonicalSerialize,
+    B: Borrow<T>,
+    W: Write,
+{
+    let len = seq.len() as u64;
+    len.serialize_with_mode(&mut writer, compress)?;
+    for item in seq {
+        item.borrow().serialize_with_mode(&mut writer, compress)?;
+    }
+    Ok(())
+}
+
+// Helper function. Describes the size of any data serialized using the above function
+#[inline]
+fn get_serialized_size_of_seq<T, B>(
+    seq: impl ExactSizeIterator<Item = B>,
+    compress: Compress,
+) -> usize
+where
+    T: CanonicalSerialize,
+    B: Borrow<T>,
+{
+    8 + seq
+        .map(|item| item.borrow().serialized_size(compress))
+        .sum::<usize>()
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for VecDeque<T> {
     #[inline]
     fn serialize_with_mode<W: Write>(
         &self,
-        mut writer: W,
+        writer: W,
         compress: Compress,
     ) -> Result<(), SerializationError> {
-        let len = self.len() as u64;
-        len.serialize_with_mode(&mut writer, compress)?;
-        for item in self.iter() {
-            item.serialize_with_mode(&mut writer, compress)?;
-        }
-        Ok(())
+        serialize_seq::<T, _, _>(self.iter(), writer, compress)
     }
 
     #[inline]
     fn serialized_size(&self, compress: Compress) -> usize {
-        8 + self
-            .iter()
-            .map(|item| item.serialized_size(compress))
-            .sum::<usize>()
+        get_serialized_size_of_seq::<T, _>(self.iter(), compress)
+    }
+}
+
+// Identical to Valid for Vec<T>
+impl<T: Valid> Valid for VecDeque<T> {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        T::batch_check(self.iter())
+    }
+
+    #[inline]
+    fn batch_check<'a>(
+        batch: impl Iterator<Item = &'a Self> + Send,
+    ) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        T::batch_check(batch.flat_map(|v| v.iter()))
+    }
+}
+
+// Identical to CanonicalSerialize for Vec<T>, except using the push_back() method
+impl<T: CanonicalDeserialize> CanonicalDeserialize for VecDeque<T> {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let len = u64::deserialize_with_mode(&mut reader, compress, validate)?
+            .try_into()
+            .map_err(|_| SerializationError::NotEnoughSpace)?;
+        let mut values = VecDeque::with_capacity(len);
+        for _ in 0..len {
+            values.push_back(T::deserialize_with_mode(
+                &mut reader,
+                compress,
+                Validate::No,
+            )?);
+        }
+
+        if let Validate::Yes = validate {
+            T::batch_check(values.iter())?
+        }
+        Ok(values)
+    }
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for LinkedList<T> {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        serialize_seq::<T, _, _>(self.iter(), writer, compress)
+    }
+
+    #[inline]
+    fn serialized_size(&self, compress: Compress) -> usize {
+        get_serialized_size_of_seq::<T, _>(self.iter(), compress)
+    }
+}
+
+// Identical to Valid for Vec<T>
+impl<T: Valid> Valid for LinkedList<T> {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        T::batch_check(self.iter())
+    }
+
+    #[inline]
+    fn batch_check<'a>(
+        batch: impl Iterator<Item = &'a Self> + Send,
+    ) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        T::batch_check(batch.flat_map(|v| v.iter()))
+    }
+}
+
+// Identical to CanonicalSerialize for Vec<T>, except using the push_back() method, and the new()
+// constructor.
+impl<T: CanonicalDeserialize> CanonicalDeserialize for LinkedList<T> {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let len = u64::deserialize_with_mode(&mut reader, compress, validate)?
+            .try_into()
+            .map_err(|_| SerializationError::NotEnoughSpace)?;
+        let mut values = LinkedList::new();
+        for _ in 0..len {
+            values.push_back(T::deserialize_with_mode(
+                &mut reader,
+                compress,
+                Validate::No,
+            )?);
+        }
+
+        if let Validate::Yes = validate {
+            T::batch_check(values.iter())?
+        }
+        Ok(values)
+    }
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for [T] {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        serialize_seq::<T, _, _>(self.iter(), writer, compress)
+    }
+
+    #[inline]
+    fn serialized_size(&self, compress: Compress) -> usize {
+        get_serialized_size_of_seq::<T, _>(self.iter(), compress)
     }
 }
 

--- a/serialize/src/test.rs
+++ b/serialize/src/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use ark_std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
     rand::RngCore,
     string::String,
     vec,
@@ -130,6 +130,18 @@ fn test_array() {
 fn test_vec() {
     test_serialize(vec![1u64, 2, 3, 4, 5]);
     test_serialize(Vec::<u64>::new());
+}
+
+#[test]
+fn test_vecdeque() {
+    test_serialize([1u64, 2, 3, 4, 5].into_iter().collect::<VecDeque<_>>());
+    test_serialize(VecDeque::<u64>::new());
+}
+
+#[test]
+fn test_linkedlist() {
+    test_serialize([1u64, 2, 3, 4, 5].into_iter().collect::<LinkedList<_>>());
+    test_serialize(LinkedList::<u64>::new());
 }
 
 #[test]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

I implemented `CanonicalSerialize`/`CanonicalDeserialize` for the remaining sequential data structures in `std::collections`. The implementation isn't interesting. I ripped out the serialization routine for `[T]` and made it generic for any `ExactSizeIterator<T>`. And the deserialization is also all the same: call constructor, then deserialize iteratively and `push` or `push_back`.

I decided not to make the `CanonicalDeserialize` impls into a macro, just bc it's only 3. But lmk if you think it should be a macro.

I also wrote unit tests for the new data structures.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (master)
- [X] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [X] Updated relevant documentation in the code
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
