### PR TITLE
Set `PairingOutput::default()` = `TargetField::one()`

### DIFF
--- a/ec/src/pairing.rs
+++ b/ec/src/pairing.rs
@@ -127,11 +127,17 @@ pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
     Eq(bound = "P: Pairing"),
     PartialOrd(bound = "P: Pairing"),
     Ord(bound = "P: Pairing"),
-    Default(bound = "P: Pairing"),
     Hash(bound = "P: Pairing")
 )]
 #[must_use]
 pub struct PairingOutput<P: Pairing>(pub P::TargetField);
+
+impl<P: Pairing> Default for PairingOutput<P> {
+    fn default() -> Self {
+        // Default value is AdditiveGroup::ZERO (i.e., P::TargetField::one())
+        Self::ZERO
+    }
+}
 
 impl<P: Pairing> CanonicalSerialize for PairingOutput<P> {
     #[allow(unused_qualifications)]


### PR DESCRIPTION
Previously, `PairingOutput<P>::default()` was set to `P::TargetField::zero()`. This is clearly incorrect, since 0 is not in the multiplicative subgroup that `PairingOutput` represents. This concretely lead to an unexpected error in https://github.com/arkworks-rs/ripp/pull/50.

This PR sets the default value to `P::TargetField::one()`. I don't think you have to treat this as a breaking change. It is very unlikely that someone was using this behavior successfully, since if you multiply (`Add`) this value with any other `PairingOutput`, you get 0.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (master)
- [X] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [X] Updated relevant documentation in the code
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
