### PR TITLE
If the poly has 1 evaluation, we should fix the window size to 1

### DIFF
--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -156,13 +156,16 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
         let dim = partial_point.len();
         assert!(dim <= self.num_vars, "invalid partial point dimension");
 
-        let window = ark_std::log2(self.evaluations.len()) as usize;
+        let mut window = ark_std::log2(self.evaluations.len()) as usize;
+        if window == 0 {
+            window = 1;
+        }
         let mut point = partial_point;
         let mut last = treemap_to_hashmap(&self.evaluations);
 
         // batch evaluation
         while !point.is_empty() {
-            let focus_length = if window > 0 && point.len() > window {
+            let focus_length = if point.len() > window {
                 window
             } else {
                 point.len()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

See https://github.com/arkworks-rs/algebra/issues/686#issuecomment-1791466580

Benchmark results, adapted to fix num of non-zero entries to 1:

```
current code

SparseMultilinear/Eval with num_vars = 12/1
                        time:   [99.986 µs 101.35 µs 102.87 µs]

SparseMultilinear/Eval with num_vars = 16/1
                        time:   [1.8933 ms 1.8994 ms 1.9054 ms]

SparseMultilinear/Eval with num_vars = 20/1
                        time:   [31.248 ms 31.336 ms 31.423 ms]

```

with this change:
```
SparseMultilinear/Eval with num_vars = 12/1
                        time:   [1.2256 µs 1.2330 µs 1.2405 µs]
                        change: [-98.786% -98.773% -98.759%] (p = 0.00 < 0.05)

SparseMultilinear/Eval with num_vars = 16/1
                        time:   [1.5618 µs 1.5716 µs 1.5816 µs]
                        change: [-99.917% -99.917% -99.916%] (p = 0.00 < 0.05)

SparseMultilinear/Eval with num_vars = 20/1
                        time:   [1.9683 µs 1.9809 µs 1.9949 µs]
                        change: [-99.994% -99.994% -99.994%] (p = 0.00 < 0.05)
```


closes: #686 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
