### PR TITLE
Implementation of bitwise operations between `BigInteger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [\#689](https://github.com/arkworks-rs/algebra/pull/689) (`ark-serialize`) Add `CanonicalSerialize` and `CanonicalDeserialize` impls for `VecDeque` and `LinkedList`.
 - [\#693](https://github.com/arkworks-rs/algebra/pull/693) (`ark-serialize`) Add `serialize_to_vec!` convenience macro.
-- [\#713](https://github.com/arkworks-rs/algebra/pull/713) (`ark-ff`) Add support for bitwise operations AND, OR and XOR between `BigInteger`.
+- [\#713](https://github.com/arkworks-rs/algebra/pull/713) (`ark-ff`) Add support for bitwise operations AND, OR, NOT, and XOR between `BigInteger`.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [\#689](https://github.com/arkworks-rs/algebra/pull/689) (`ark-serialize`) Add `CanonicalSerialize` and `CanonicalDeserialize` impls for `VecDeque` and `LinkedList`.
 - [\#693](https://github.com/arkworks-rs/algebra/pull/693) (`ark-serialize`) Add `serialize_to_vec!` convenience macro.
+- [\#713](https://github.com/arkworks-rs/algebra/pull/713) (`ark-ff`) Add support for bitwise operations AND, OR and XOR between `BigInteger`.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [\#689](https://github.com/arkworks-rs/algebra/pull/689) (`ark-serialize`) Add `CanonicalSerialize` and `CanonicalDeserialize` impls for `VecDeque` and `LinkedList`.
 - [\#693](https://github.com/arkworks-rs/algebra/pull/693) (`ark-serialize`) Add `serialize_to_vec!` convenience macro.
-- [\#713](https://github.com/arkworks-rs/algebra/pull/713) (`ark-ff`) Add support for bitwise operations AND, OR, NOT, and XOR between `BigInteger`.
+- [\#713](https://github.com/arkworks-rs/algebra/pull/713) (`ark-ff`) Add support for bitwise operations AND, OR, and XOR between `BigInteger`.
 
 ### Breaking changes
 

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -1,3 +1,5 @@
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
+
 use crate::{
     bits::{BitIteratorBE, BitIteratorLE},
     const_for, UniformRand,
@@ -681,6 +683,61 @@ impl<const N: usize> From<BigInt<N>> for BigUint {
     }
 }
 
+// ===================================
+// Bitwise operators
+// ===================================
+
+impl<const N: usize> BitXorAssign for BigInt<N> {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        for i in 0..N {
+            self.0[i] ^= rhs.0[i];
+        }
+    }
+}
+
+impl<const N: usize> BitXor for BigInt<N> {
+    type Output = Self;
+
+    fn bitxor(mut self, rhs: Self) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+impl<const N: usize> BitAndAssign for BigInt<N> {
+    fn bitand_assign(&mut self, rhs: Self) {
+        for i in 0..N {
+            self.0[i] &= rhs.0[i];
+        }
+    }
+}
+
+impl<const N: usize> BitAnd for BigInt<N> {
+    type Output = Self;
+
+    fn bitand(mut self, rhs: Self) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+impl<const N: usize> BitOrAssign for BigInt<N> {
+    fn bitor_assign(&mut self, rhs: Self) {
+        for i in 0..N {
+            self.0[i] |= rhs.0[i];
+        }
+    }
+}
+
+impl<const N: usize> BitOr for BigInt<N> {
+    type Output = Self;
+
+    fn bitor(mut self, rhs: Self) -> Self::Output {
+        self |= rhs;
+        self
+    }
+}
+
 /// Compute the signed modulo operation on a u64 representation, returning the result.
 /// If n % modulus > modulus / 2, return modulus - n
 /// # Example
@@ -737,6 +794,12 @@ pub trait BigInteger:
     + From<u8>
     + TryFrom<BigUint, Error = ()>
     + Into<BigUint>
+    + BitXorAssign<Self>
+    + BitXor<Self>
+    + BitAndAssign<Self>
+    + BitAnd<Self>
+    + BitOrAssign<Self>
+    + BitOr<Self>
 {
     /// Number of 64-bit limbs representing `Self`.
     const NUM_LIMBS: usize;

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -1,4 +1,4 @@
-use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 use crate::{
     bits::{BitIteratorBE, BitIteratorLE},
@@ -738,6 +738,18 @@ impl<const N: usize> BitOr for BigInt<N> {
     }
 }
 
+impl<const N: usize> Not for BigInt<N> {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        let mut result = Self::zero();
+        for i in 0..N {
+            result.0[i] = !self.0[i];
+        }
+        result
+    }
+}
+
 /// Compute the signed modulo operation on a u64 representation, returning the result.
 /// If n % modulus > modulus / 2, return modulus - n
 /// # Example
@@ -800,6 +812,7 @@ pub trait BigInteger:
     + BitAnd<Self>
     + BitOrAssign<Self>
     + BitOr<Self>
+    + Not
 {
     /// Number of 64-bit limbs representing `Self`.
     const NUM_LIMBS: usize;

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -10,6 +10,7 @@ use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
 };
 use ark_std::{
+    borrow::Borrow,
     convert::TryFrom,
     fmt::{Debug, Display, UpperHex},
     io::{Read, Write},
@@ -683,56 +684,46 @@ impl<const N: usize> From<BigInt<N>> for BigUint {
     }
 }
 
-// ===================================
-// Bitwise operators
-// ===================================
-
-impl<const N: usize> BitXorAssign for BigInt<N> {
-    fn bitxor_assign(&mut self, rhs: Self) {
-        for i in 0..N {
-            self.0[i] ^= rhs.0[i];
-        }
+impl<B: Borrow<Self>, const N: usize> BitXorAssign<B> for BigInt<N> {
+    fn bitxor_assign(&mut self, rhs: B) {
+        (0..N).for_each(|i| self.0[i] ^= rhs.borrow().0[i])
     }
 }
 
-impl<const N: usize> BitXor for BigInt<N> {
+impl<B: Borrow<Self>, const N: usize> BitXor<B> for BigInt<N> {
     type Output = Self;
 
-    fn bitxor(mut self, rhs: Self) -> Self::Output {
+    fn bitxor(mut self, rhs: B) -> Self::Output {
         self ^= rhs;
         self
     }
 }
 
-impl<const N: usize> BitAndAssign for BigInt<N> {
-    fn bitand_assign(&mut self, rhs: Self) {
-        for i in 0..N {
-            self.0[i] &= rhs.0[i];
-        }
+impl<B: Borrow<Self>, const N: usize> BitAndAssign<B> for BigInt<N> {
+    fn bitand_assign(&mut self, rhs: B) {
+        (0..N).for_each(|i| self.0[i] &= rhs.borrow().0[i])
     }
 }
 
-impl<const N: usize> BitAnd for BigInt<N> {
+impl<B: Borrow<Self>, const N: usize> BitAnd<B> for BigInt<N> {
     type Output = Self;
 
-    fn bitand(mut self, rhs: Self) -> Self::Output {
+    fn bitand(mut self, rhs: B) -> Self::Output {
         self &= rhs;
         self
     }
 }
 
-impl<const N: usize> BitOrAssign for BigInt<N> {
-    fn bitor_assign(&mut self, rhs: Self) {
-        for i in 0..N {
-            self.0[i] |= rhs.0[i];
-        }
+impl<B: Borrow<Self>, const N: usize> BitOrAssign<B> for BigInt<N> {
+    fn bitor_assign(&mut self, rhs: B) {
+        (0..N).for_each(|i| self.0[i] |= rhs.borrow().0[i])
     }
 }
 
-impl<const N: usize> BitOr for BigInt<N> {
+impl<B: Borrow<Self>, const N: usize> BitOr<B> for BigInt<N> {
     type Output = Self;
 
-    fn bitor(mut self, rhs: Self) -> Self::Output {
+    fn bitor(mut self, rhs: B) -> Self::Output {
         self |= rhs;
         self
     }
@@ -807,12 +798,17 @@ pub trait BigInteger:
     + TryFrom<BigUint, Error = ()>
     + Into<BigUint>
     + BitXorAssign<Self>
+    + for<'a> BitXorAssign<&'a Self>
     + BitXor<Self>
+    + for<'a> BitXor<&'a Self, Output = Self>
     + BitAndAssign<Self>
+    + for<'a> BitAndAssign<&'a Self>
     + BitAnd<Self>
+    + for<'a> BitAnd<&'a Self, Output = Self>
     + BitOrAssign<Self>
+    + for<'a> BitOrAssign<&'a Self>
     + BitOr<Self>
-    + Not
+    + for<'a> BitOr<&'a Self, Output = Self>
 {
     /// Number of 64-bit limbs representing `Self`.
     const NUM_LIMBS: usize;
@@ -1025,7 +1021,7 @@ pub trait BigInteger:
     /// arr[63] = true;
     /// let mut one = B::from(1u64);
     /// assert_eq!(B::from_bits_be(&arr), one);
-    /// ```   
+    /// ```
     fn from_bits_be(bits: &[bool]) -> Self;
 
     /// Returns the big integer representation of a given little endian boolean
@@ -1039,7 +1035,7 @@ pub trait BigInteger:
     /// arr[0] = true;
     /// let mut one = B::from(1u64);
     /// assert_eq!(B::from_bits_le(&arr), one);
-    /// ```   
+    /// ```
     fn from_bits_le(bits: &[bool]) -> Self;
 
     /// Returns the bit representation in a big endian boolean array,
@@ -1054,7 +1050,7 @@ pub trait BigInteger:
     /// let mut vec = vec![false; 64];
     /// vec[63] = true;
     /// assert_eq!(arr, vec);
-    /// ```  
+    /// ```
     fn to_bits_be(&self) -> Vec<bool> {
         BitIteratorBE::new(self).collect::<Vec<_>>()
     }

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -1,4 +1,5 @@
 use crate::{biginteger::BigInteger, BigInt, UniformRand};
+use ark_std::rand::Rng;
 use num_bigint::BigUint;
 
 // Test elementary math operations for BigInteger.
@@ -58,46 +59,40 @@ fn biginteger_bitwise_ops_test<B: BigInteger>() {
     // Test XOR
     // a xor a = 0
     let a: BigInt<4> = UniformRand::rand(&mut rng);
-    let a_clone = a.clone();
-    assert_eq!(a ^ a_clone, BigInt::from(0_u64));
+    assert_eq!(a ^ &a, BigInt::from(0_u64));
 
     // Testing a xor b xor b
     let a: BigInt<4> = UniformRand::rand(&mut rng);
     let b: BigInt<4> = UniformRand::rand(&mut rng);
-    let a_clone = a.clone();
-    let b_clone = b.clone();
     let xor_ab = a ^ b;
-    assert_eq!(xor_ab ^ b_clone, a_clone);
+    assert_eq!(xor_ab ^ b, a);
 
     // Test OR
     // a or a = a
-    let a: BigInt<4> = UniformRand::rand(&mut rng);
-    let a_clone = a.clone();
-    assert_eq!(a | a_clone, a);
+    let a = rng.gen::<BigInt<4>>();
+    assert_eq!(a | &a, a);
 
     // Testing a or b or b
-    let a: BigInt<4> = UniformRand::rand(&mut rng);
-    let b: BigInt<4> = UniformRand::rand(&mut rng);
-    let b_clone = b.clone();
+    let a = rng.gen::<BigInt<4>>();
+    let b = rng.gen::<BigInt<4>>();
     let or_ab = a | b;
-    assert_eq!(or_ab | b_clone, a | b);
+    assert_eq!(or_ab | &b, a | b);
 
     // Test AND
     // a and a = a
-    let a: BigInt<4> = UniformRand::rand(&mut rng);
-    let a_clone = a.clone();
-    assert_eq!(a & a_clone, a);
+    let a = rng.gen::<BigInt<4>>();
+    assert_eq!(a & (&a), a);
 
     // Testing a and a and b.
-    let a: BigInt<4> = UniformRand::rand(&mut rng);
-    let b: BigInt<4> = UniformRand::rand(&mut rng);
+    let a = rng.gen::<BigInt<4>>();
+    let b = rng.gen::<BigInt<4>>();
     let b_clone = b.clone();
     let and_ab = a & b;
     assert_eq!(and_ab & b_clone, a & b);
 
     // Testing De Morgan's law
-    let a: BigInt<4> = UniformRand::rand(&mut rng);
-    let b = UniformRand::rand(&mut rng);
+    let a = rng.gen::<BigInt<4>>();
+    let b = rng.gen::<BigInt<4>>();
     let de_morgan_lhs = !(a | b);
     let de_morgan_rhs = (!a) & (!b);
     assert_eq!(de_morgan_lhs, de_morgan_rhs);

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -59,7 +59,7 @@ fn biginteger_bitwise_ops_test<B: BigInteger>() {
     let a_clone = a.clone();
     assert_eq!(a ^ a_clone, BigInt::from(0_u64));
 
-    // Testing a xor b xor b 
+    // Testing a xor b xor b
     let a: BigInt<4> = BigInt::from(4_u64);
     let b = BigInt::from(5_u64);
     let b_clone = b.clone();

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -53,44 +53,54 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
 
 // Test for BigInt's bitwise operations
 fn biginteger_bitwise_ops_test<B: BigInteger>() {
+    let mut rng = ark_std::test_rng();
+
     // Test XOR
     // a xor a = 0
-    let a: BigInt<4> = BigInt::from(4_u64);
+    let a: BigInt<4> = UniformRand::rand(&mut rng);
     let a_clone = a.clone();
     assert_eq!(a ^ a_clone, BigInt::from(0_u64));
 
     // Testing a xor b xor b
-    let a: BigInt<4> = BigInt::from(4_u64);
-    let b = BigInt::from(5_u64);
+    let a: BigInt<4> = UniformRand::rand(&mut rng);
+    let b: BigInt<4> = UniformRand::rand(&mut rng);
+    let a_clone = a.clone();
     let b_clone = b.clone();
     let xor_ab = a ^ b;
-    assert_eq!(xor_ab ^ b_clone, BigInt::from(4_u64));
+    assert_eq!(xor_ab ^ b_clone, a_clone);
 
     // Test OR
-    // 1 or 1 = 1
-    let a: BigInt<4> = BigInt::from(1_u64);
+    // a or a = a
+    let a: BigInt<4> = UniformRand::rand(&mut rng);
     let a_clone = a.clone();
-    assert_eq!(a | a_clone, BigInt::from(1_u64));
+    assert_eq!(a | a_clone, a);
 
     // Testing a or b or b
-    let a: BigInt<4> = BigInt::from(4_u64);
-    let b = BigInt::from(5_u64);
+    let a: BigInt<4> = UniformRand::rand(&mut rng);
+    let b: BigInt<4> = UniformRand::rand(&mut rng);
     let b_clone = b.clone();
     let or_ab = a | b;
-    assert_eq!(or_ab | b_clone, BigInt::from(5_u64));
+    assert_eq!(or_ab | b_clone, a | b);
 
     // Test AND
     // a and a = a
-    let a: BigInt<4> = BigInt::from(2_u64);
+    let a: BigInt<4> = UniformRand::rand(&mut rng);
     let a_clone = a.clone();
-    assert_eq!(a & a_clone, BigInt::from(2_u64));
+    assert_eq!(a & a_clone, a);
 
     // Testing a and a and b.
-    let a: BigInt<4> = BigInt::from(4_u64);
-    let b = BigInt::from(5_u64);
+    let a: BigInt<4> = UniformRand::rand(&mut rng);
+    let b: BigInt<4> = UniformRand::rand(&mut rng);
     let b_clone = b.clone();
     let and_ab = a & b;
-    assert_eq!(and_ab & b_clone, BigInt::from(4_u64));
+    assert_eq!(and_ab & b_clone, a & b);
+
+    // Testing De Morgan's law
+    let a: BigInt<4> = UniformRand::rand(&mut rng);
+    let b = UniformRand::rand(&mut rng);
+    let de_morgan_lhs = !(a | b);
+    let de_morgan_rhs = (!a) & (!b);
+    assert_eq!(de_morgan_lhs, de_morgan_rhs);
 }
 
 // Test correctness of BigInteger's bit values

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -1,4 +1,4 @@
-use crate::{biginteger::BigInteger, UniformRand};
+use crate::{biginteger::BigInteger, BigInt, UniformRand};
 use num_bigint::BigUint;
 
 // Test elementary math operations for BigInteger.
@@ -51,6 +51,48 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
     assert_eq!(a_mul2, a_plus_a);
 }
 
+// Test for BigInt's bitwise operations
+fn biginteger_bitwise_ops_test<B: BigInteger>() {
+    // Test XOR
+    // a xor a = 0
+    let a: BigInt<4> = BigInt::from(4_u64);
+    let a_clone = a.clone();
+    assert_eq!(a ^ a_clone, BigInt::from(0_u64));
+
+    // Testing a xor b xor b 
+    let a: BigInt<4> = BigInt::from(4_u64);
+    let b = BigInt::from(5_u64);
+    let b_clone = b.clone();
+    let xor_ab = a ^ b;
+    assert_eq!(xor_ab ^ b_clone, BigInt::from(4_u64));
+
+    // Test OR
+    // 1 or 1 = 1
+    let a: BigInt<4> = BigInt::from(1_u64);
+    let a_clone = a.clone();
+    assert_eq!(a | a_clone, BigInt::from(1_u64));
+
+    // Testing a or b or b
+    let a: BigInt<4> = BigInt::from(4_u64);
+    let b = BigInt::from(5_u64);
+    let b_clone = b.clone();
+    let or_ab = a | b;
+    assert_eq!(or_ab | b_clone, BigInt::from(5_u64));
+
+    // Test AND
+    // a and a = a
+    let a: BigInt<4> = BigInt::from(2_u64);
+    let a_clone = a.clone();
+    assert_eq!(a & a_clone, BigInt::from(2_u64));
+
+    // Testing a and a and b.
+    let a: BigInt<4> = BigInt::from(4_u64);
+    let b = BigInt::from(5_u64);
+    let b_clone = b.clone();
+    let and_ab = a & b;
+    assert_eq!(and_ab & b_clone, BigInt::from(4_u64));
+}
+
 // Test correctness of BigInteger's bit values
 fn biginteger_bits_test<B: BigInteger>() {
     let mut one = B::from(1u64);
@@ -93,6 +135,7 @@ fn test_biginteger<B: BigInteger>(zero: B) {
     biginteger_arithmetic_test(a, b, zero);
     biginteger_bits_test::<B>();
     biginteger_conversion_test::<B>();
+    biginteger_bitwise_ops_test::<B>()
 }
 
 #[test]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

I implemented bitwise operations between BigInteger: AND, XOR, NOT, and OR. In the modifications, the trait BigInteger now implements the necessary traits to support the mentioned bitwise operations, and I included the implementations for those operations for the BigInt struct. Also, I wrote some tests for this functionality.

This PR doesn't close any issue. It's just a feature that I found missing in the library.

