### PR TITLE
Fix #715

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -799,15 +799,15 @@ pub trait BigInteger:
     + Into<BigUint>
     + BitXorAssign<Self>
     + for<'a> BitXorAssign<&'a Self>
-    + BitXor<Self>
+    + BitXor<Self, Output = Self>
     + for<'a> BitXor<&'a Self, Output = Self>
     + BitAndAssign<Self>
     + for<'a> BitAndAssign<&'a Self>
-    + BitAnd<Self>
+    + BitAnd<Self, Output = Self>
     + for<'a> BitAnd<&'a Self, Output = Self>
     + BitOrAssign<Self>
     + for<'a> BitOrAssign<&'a Self>
-    + BitOr<Self>
+    + BitOr<Self, Output = Self>
     + for<'a> BitOr<&'a Self, Output = Self>
 {
     /// Number of 64-bit limbs representing `Self`.

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -1,5 +1,4 @@
-use crate::{biginteger::BigInteger, BigInt, UniformRand};
-use ark_std::rand::Rng;
+use crate::{biginteger::BigInteger, UniformRand};
 use num_bigint::BigUint;
 
 // Test elementary math operations for BigInteger.
@@ -58,43 +57,43 @@ fn biginteger_bitwise_ops_test<B: BigInteger>() {
 
     // Test XOR
     // a xor a = 0
-    let a: BigInt<4> = UniformRand::rand(&mut rng);
-    assert_eq!(a ^ &a, BigInt::from(0_u64));
+    let a = B::rand(&mut rng);
+    assert_eq!(a ^ &a, B::from(0_u64));
 
     // Testing a xor b xor b
-    let a: BigInt<4> = UniformRand::rand(&mut rng);
-    let b: BigInt<4> = UniformRand::rand(&mut rng);
+    let a = B::rand(&mut rng);
+    let b = B::rand(&mut rng);
     let xor_ab = a ^ b;
     assert_eq!(xor_ab ^ b, a);
 
     // Test OR
     // a or a = a
-    let a = rng.gen::<BigInt<4>>();
+    let a = B::rand(&mut rng);
     assert_eq!(a | &a, a);
 
     // Testing a or b or b
-    let a = rng.gen::<BigInt<4>>();
-    let b = rng.gen::<BigInt<4>>();
+    let a = B::rand(&mut rng);
+    let b = B::rand(&mut rng);
     let or_ab = a | b;
     assert_eq!(or_ab | &b, a | b);
 
     // Test AND
     // a and a = a
-    let a = rng.gen::<BigInt<4>>();
+    let a = B::rand(&mut rng);
     assert_eq!(a & (&a), a);
 
     // Testing a and a and b.
-    let a = rng.gen::<BigInt<4>>();
-    let b = rng.gen::<BigInt<4>>();
+    let a = B::rand(&mut rng);
+    let b = B::rand(&mut rng);
     let b_clone = b.clone();
     let and_ab = a & b;
     assert_eq!(and_ab & b_clone, a & b);
 
     // Testing De Morgan's law
-    let a = rng.gen::<BigInt<4>>();
-    let b = rng.gen::<BigInt<4>>();
-    let de_morgan_lhs = !(a | b);
-    let de_morgan_rhs = (!a) & (!b);
+    let a = 0x1234567890abcdef_u64;
+    let b = 0xfedcba0987654321_u64;
+    let de_morgan_lhs = B::from(!(a | b));
+    let de_morgan_rhs = B::from(!a) & B::from(!b);
     assert_eq!(de_morgan_lhs, de_morgan_rhs);
 }
 


### PR DESCRIPTION
PR https://github.com/arkworks-rs/algebra/pull/713 introduced underdefined trait constraints for BigInteger and tests
were not really using the `BigInteger` trait.