### PR TITLE
Fix fetching attributes in MontConfig macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Bugfixes
 
+- [\#747](https://github.com/arkworks-rs/algebra/pull/747) (`ark-ff-macros`) Fix fetching attributes in `MontConfig` macro
+
 ## v0.4.2
 
 ### Breaking changes

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -106,27 +106,22 @@ pub fn unroll_for_loops(args: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Fetch an attribute string from the derived struct.
 fn fetch_attr(name: &str, attrs: &[syn::Attribute]) -> Option<String> {
-    for attr in attrs {
-        if let Ok(meta) = attr.parse_meta() {
-            match meta {
-                syn::Meta::NameValue(nv) => {
-                    if nv.path.get_ident().map(|i| i.to_string()) == Some(name.to_string()) {
-                        match nv.lit {
-                            syn::Lit::Str(ref s) => return Some(s.value()),
-                            _ => {
-                                panic!("attribute {} should be a string", name);
-                            },
-                        }
-                    }
-                },
-                _ => {
-                    panic!("attribute {} should be a string", name);
-                },
-            }
+    attrs.iter().find_map(|attr| {
+        let meta = attr.parse_meta().ok()?;
+        match meta {
+            syn::Meta::NameValue(nv)
+                if nv.path.get_ident().map(|i| i.to_string()) == Some(name.to_string()) =>
+            {
+                match nv.lit {
+                    syn::Lit::Str(ref s) => Some(s.value()),
+                    _ => {
+                        panic!("attribute {} should be a string", name);
+                    },
+                }
+            },
+            _ => None,
         }
-    }
-
-    None
+    })
 }
 
 #[test]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Previously fetching function was panicing on every different attribute. Now it simply skips attributes of different format.  As a result, it is possible now to apply other attributes when defining strucutre with MontConfig.

closes: #704

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
