### PR TITLE
faster `is_in_correct_subgroup_assuming_on_curve` when cofactor is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@
 ### Improvements
 
 - [\#736](https://github.com/arkworks-rs/algebra/pull/736) (`ark-ff`) Deprecate `divn()`, and use `core::ops::{Shr, ShrAssign}` instead.
-- [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate `muln()`, and use `core::ops::{Shl, ShlAssign}` instead.
+- [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate
+  `muln()`, and use `core::ops::{Shl, ShlAssign}` instead.
+- [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive
+  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for
+  short Weierstrass curves of cofactor one.  
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,8 @@
 ### Improvements
 
 - [\#736](https://github.com/arkworks-rs/algebra/pull/736) (`ark-ff`) Deprecate `divn()`, and use `core::ops::{Shr, ShrAssign}` instead.
-- [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate
-  `muln()`, and use `core::ops::{Shl, ShlAssign}` instead.
-- [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive
-  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for
-  short Weierstrass curves of cofactor one.  
+- [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate `muln()`, and use `core::ops::{Shl, ShlAssign}` instead.
+- [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for short Weierstrass curves of cofactor one.  
 
 ### Bugfixes
 

--- a/ec/src/models/short_weierstrass/mod.rs
+++ b/ec/src/models/short_weierstrass/mod.rs
@@ -65,13 +65,18 @@ pub trait SWCurveConfig: super::CurveConfig {
     /// Check if the provided curve point is in the prime-order subgroup.
     ///
     /// The default implementation multiplies `item` by the order `r` of the
-    /// prime-order subgroup, and checks if the result is zero.
+    /// prime-order subgroup, and checks if the result is zero. If the
+    /// curve's cofactor is one, this check automatically returns true.
     /// Implementors can choose to override this default impl
     /// if the given curve has faster methods
     /// for performing this check (for example, via leveraging curve
     /// isomorphisms).
     fn is_in_correct_subgroup_assuming_on_curve(item: &Affine<Self>) -> bool {
-        Self::mul_affine(item, Self::ScalarField::characteristic()).is_zero()
+        if Self::cofactor_is_one() {
+            true
+        } else {
+            Self::mul_affine(item, Self::ScalarField::characteristic()).is_zero()
+        }
     }
 
     /// Performs cofactor clearing.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This is a two-line fix to speed up the function `is_in_correct_subgroup_assuming_on_curve` for short Weierstrass curve points:
if the cofactor is one, it skips the expensive operation of performing a scalar multiplication by the scalar field's characteristic. 

The cofactor is _always_ one when the curve forms part of a cycle, so this is relevant for the curves used for most
recursive SNARKs (e.g. `bn254`, etc.). 

This speeds up operations like `CanonicalDeserialize::deserialize_compressed`, which can otherwise take a very
long time for large vectors of curve points. It should also reduce the number of constraints needed to allocate 
a curve variable.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
    - existing test coverage should suffice, since no new functionality is introduced.
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
