### PR TITLE
add `mul` method for `BigInteger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- [\#772](https://github.com/arkworks-rs/algebra/pull/772) (`ark-ff`) Implementation of `mul` method for `BigInteger`.
+
 ### Breaking changes
 
 - [\#577](https://github.com/arkworks-rs/algebra/pull/577) (`ark-ff`, `ark-ec`) Add `AdditiveGroup`, a trait for additive groups (equipped with scalar field).

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -422,7 +422,29 @@ impl<const N: usize> BigInteger for BigInt<N> {
     }
 
     #[inline]
-    fn mul(&mut self, other: &Self) {
+    fn mul(&self, other: &Self) -> (Self, Self) {
+        if self.is_zero() || other.is_zero() {
+            let zero = Self::zero();
+            return (zero, zero);
+        }
+
+        let mut r = crate::const_helpers::MulBuffer::<N>::zeroed();
+
+        let mut carry = 0;
+
+        for i in 0..N {
+            for j in 0..N {
+                r[i + j] = mac_with_carry!(r[i + j], self.0[i], other.0[j], &mut carry);
+            }
+            r.b1[i] = carry;
+            carry = 0;
+        }
+
+        return (Self(r.b0), Self(r.b1));
+    }
+
+    #[inline]
+    fn mul_low(&mut self, other: &Self) {
         if self.is_zero() || other.is_zero() {
             *self = Self::zero();
             return;
@@ -439,6 +461,11 @@ impl<const N: usize> BigInteger for BigInt<N> {
         }
 
         *self = res
+    }
+
+    #[inline]
+    fn mul_high(&self, other: &Self) -> Self {
+        self.mul(other).1
     }
 
     #[inline]
@@ -1072,15 +1099,63 @@ pub trait BigInteger:
     /// // Basic
     /// let mut a = B::from(42u64);
     /// let b = B::from(3u64);
-    /// a.mul(&b);
+    /// a.mul_low(&b);
     /// assert_eq!(a, B::from(126u64));
     ///
     /// // Edge-Case
     /// let mut zero = B::from(0u64);
-    /// zero.mul(&B::from(5u64));
+    /// zero.mul_low(&B::from(5u64));
     /// assert_eq!(zero, B::from(0u64));
     /// ```
-    fn mul(&mut self, other: &Self);
+    fn mul_low(&mut self, other: &Self);
+
+    /// Multiplies this [`BigInteger`] by another `BigInteger`, returning the high bits of the result.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ark_ff::{biginteger::BigInteger64 as B, BigInteger as _};
+    ///
+    /// // Basic
+    /// let (one, x) = (B::from(1u64), B::from(2u64));
+    /// let r = x.mul_high(&one);
+    /// assert_eq!(r, B::from(0u64));
+    ///
+    /// // Edge-Case
+    /// let mut x = B::from(u64::MAX);
+    /// let r = x.mul_high(&B::from(2u64));
+    /// assert_eq!(r, B::from(1u64))
+    /// ```
+    fn mul_high(&self, other: &Self) -> Self;
+
+    /// Multiplies this [`BigInteger`] by another `BigInteger`, returning both low and high bits of the result.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ark_ff::{biginteger::BigInteger64 as B, BigInteger as _};
+    ///
+    /// // Basic
+    /// let mut a = B::from(42u64);
+    /// let b = B::from(3u64);
+    /// let (low_bits, high_bits) = a.mul(&b);
+    /// assert_eq!(low_bits, B::from(126u64));
+    /// assert_eq!(high_bits, B::from(0u64));
+    ///
+    /// // Edge-Case
+    /// let mut x = B::from(u64::MAX);
+    /// let (low_bits, high_bits) = x.mul(&B::from(2u64));
+    /// assert_eq!(low_bits, B::from(u64::MAX));
+    /// assert_eq!(high_bits, B::from(u64::MAX));
+    ///
+    /// let mut x = B::from(u64::MAX);
+    /// let mut max_plus_max = x;
+    /// max_plus_max.add_with_carry(&x);
+    /// let (low_bits, high_bits) = x.mul(&B::from(2u64));
+    /// assert_eq!(low_bits, max_plus_max);
+    /// assert_eq!(high_bits, B::from(1u64));
+    /// ```
+    fn mul(&self, other: &Self) -> (Self, Self);
 
     /// Performs a rightwise bitshift of this number, effectively dividing
     /// it by 2.

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -1077,7 +1077,7 @@ pub trait BigInteger:
     ///
     /// // Edge-Case
     /// let mut zero = B::from(0u64);
-    /// zero.mul(5);
+    /// zero.mul(&B::from(5u64));
     /// assert_eq!(zero, B::from(0u64));
     /// ```
     fn mul(&mut self, other: &Self);

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -917,7 +917,7 @@ pub type BigInteger768 = BigInt<12>;
 pub type BigInteger832 = BigInt<13>;
 
 #[cfg(test)]
-pub mod tests;
+mod tests;
 
 /// This defines a `BigInteger`, a smart wrapper around a
 /// sequence of `u64` limbs, least-significant limb first.

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -1144,11 +1144,6 @@ pub trait BigInteger:
     ///
     /// // Edge-Case
     /// let mut x = B::from(u64::MAX);
-    /// let (low_bits, high_bits) = x.mul(&B::from(2u64));
-    /// assert_eq!(low_bits, B::from(u64::MAX));
-    /// assert_eq!(high_bits, B::from(u64::MAX));
-    ///
-    /// let mut x = B::from(u64::MAX);
     /// let mut max_plus_max = x;
     /// max_plus_max.add_with_carry(&x);
     /// let (low_bits, high_bits) = x.mul(&B::from(2u64));

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -1,6 +1,5 @@
 use crate::{biginteger::BigInteger, UniformRand};
 use num_bigint::BigUint;
-// use std::println;
 
 // Test elementary math operations for BigInteger.
 fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -1,5 +1,6 @@
 use crate::{biginteger::BigInteger, UniformRand};
 use num_bigint::BigUint;
+// use std::println;
 
 // Test elementary math operations for BigInteger.
 fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
@@ -49,6 +50,33 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
     let mut a_plus_a = a;
     a_plus_a.add_with_carry(&a); // Won't assert anything about carry bit.
     assert_eq!(a_mul2, a_plus_a);
+
+    // a * 1 = a
+    let mut a_mul = a;
+    a_mul.mul(&B::from(1u64));
+    assert_eq!(a_mul, a);
+
+    // a * 2 = a
+    a_mul.mul(&B::from(2u64));
+    assert_eq!(a_mul, a_plus_a);
+
+    // a * 2 * b = b * 2 * a
+    a_mul.mul(&b);
+    let mut b_mul = b;
+    b_mul.mul(&B::from(2u64));
+    b_mul.mul(&a);
+    assert_eq!(a_mul, b_mul);
+
+    // a * 2 * b * 0 = 0
+    a_mul.mul(&zero);
+    assert!(a_mul.is_zero());
+
+    // a * 2 * ... * 2  = a * 2^n
+    let mut a_mul_n = a;
+    for _ in 0..20 {
+        a_mul_n.mul(&B::from(2u64));
+    }
+    assert_eq!(a_mul_n, a << 20);
 }
 
 fn biginteger_shr<B: BigInteger>() {

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -2,7 +2,7 @@ use crate::{biginteger::BigInteger, UniformRand};
 use num_bigint::BigUint;
 
 // Test elementary math operations for BigInteger.
-fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
+fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B, max: B) {
     // zero == zero
     assert_eq!(zero, zero);
 
@@ -47,35 +47,62 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
     let mut a_mul2 = a;
     a_mul2.mul2();
     let mut a_plus_a = a;
-    a_plus_a.add_with_carry(&a); // Won't assert anything about carry bit.
+    let carry_a_plus_a = a_plus_a.add_with_carry(&a); // Won't assert anything about carry bit.
     assert_eq!(a_mul2, a_plus_a);
 
     // a * 1 = a
     let mut a_mul = a;
-    a_mul.mul(&B::from(1u64));
+    a_mul.mul_low(&B::from(1u64));
     assert_eq!(a_mul, a);
 
     // a * 2 = a
-    a_mul.mul(&B::from(2u64));
+    a_mul.mul_low(&B::from(2u64));
     assert_eq!(a_mul, a_plus_a);
 
     // a * 2 * b = b * 2 * a
-    a_mul.mul(&b);
+    a_mul.mul_low(&b);
     let mut b_mul = b;
-    b_mul.mul(&B::from(2u64));
-    b_mul.mul(&a);
+    b_mul.mul_low(&B::from(2u64));
+    b_mul.mul_low(&a);
     assert_eq!(a_mul, b_mul);
 
     // a * 2 * b * 0 = 0
-    a_mul.mul(&zero);
+    a_mul.mul_low(&zero);
     assert!(a_mul.is_zero());
 
     // a * 2 * ... * 2  = a * 2^n
     let mut a_mul_n = a;
     for _ in 0..20 {
-        a_mul_n.mul(&B::from(2u64));
+        a_mul_n.mul_low(&B::from(2u64));
     }
     assert_eq!(a_mul_n, a << 20);
+
+    // a * 0 = (0, 0)
+    assert_eq!(a.mul(&zero), (zero, zero));
+
+    // a * 1 = (a, 0)
+    assert_eq!(a.mul(&B::from(1u64)), (a, zero));
+
+    // a * 1 = 0 (high part of the result)
+    assert_eq!(a.mul_high(&B::from(1u64)), (zero));
+
+    // a * 0 = 0 (high part of the result)
+    assert!(a.mul_high(&zero).is_zero());
+
+    // If a + a has a carry
+    if carry_a_plus_a {
+        // a + a has a carry: high part of a * 2 is not zero
+        assert_ne!(a.mul_high(&B::from(2u64)), zero);
+    } else {
+        // a + a has no carry: high part of a * 2 is zero
+        assert_eq!(a.mul_high(&B::from(2u64)), zero);
+    }
+
+    // max + max = max * 2
+    let mut max_plus_max = max;
+    max_plus_max.add_with_carry(&max);
+    assert_eq!(max.mul(&B::from(2u64)), (max_plus_max, B::from(1u64)));
+    assert_eq!(max.mul_high(&B::from(2u64)), B::from(1u64));
 }
 
 fn biginteger_shr<B: BigInteger>() {
@@ -201,11 +228,11 @@ fn biginteger_conversion_test<B: BigInteger>() {
 }
 
 // Wrapper test function for BigInteger
-fn test_biginteger<B: BigInteger>(zero: B) {
+fn test_biginteger<B: BigInteger>(max: B, zero: B) {
     let mut rng = ark_std::test_rng();
     let a: B = UniformRand::rand(&mut rng);
     let b: B = UniformRand::rand(&mut rng);
-    biginteger_arithmetic_test(a, b, zero);
+    biginteger_arithmetic_test(a, b, zero, max);
     biginteger_bits_test::<B>();
     biginteger_conversion_test::<B>();
     biginteger_bitwise_ops_test::<B>();
@@ -216,41 +243,41 @@ fn test_biginteger<B: BigInteger>(zero: B) {
 #[test]
 fn test_biginteger64() {
     use crate::biginteger::BigInteger64 as B;
-    test_biginteger(B::new([0u64; 1]));
+    test_biginteger(B::new([u64::MAX; 1]), B::new([0u64; 1]));
 }
 
 #[test]
 fn test_biginteger128() {
     use crate::biginteger::BigInteger128 as B;
-    test_biginteger(B::new([0u64; 2]));
+    test_biginteger(B::new([u64::MAX; 2]), B::new([0u64; 2]));
 }
 
 #[test]
 fn test_biginteger256() {
     use crate::biginteger::BigInteger256 as B;
-    test_biginteger(B::new([0u64; 4]));
+    test_biginteger(B::new([u64::MAX; 4]), B::new([0u64; 4]));
 }
 
 #[test]
 fn test_biginteger384() {
     use crate::biginteger::BigInteger384 as B;
-    test_biginteger(B::new([0u64; 6]));
+    test_biginteger(B::new([u64::MAX; 6]), B::new([0u64; 6]));
 }
 
 #[test]
 fn test_biginteger448() {
     use crate::biginteger::BigInteger448 as B;
-    test_biginteger(B::new([0u64; 7]));
+    test_biginteger(B::new([u64::MAX; 7]), B::new([0u64; 7]));
 }
 
 #[test]
 fn test_biginteger768() {
     use crate::biginteger::BigInteger768 as B;
-    test_biginteger(B::new([0u64; 12]));
+    test_biginteger(B::new([u64::MAX; 12]), B::new([0u64; 12]));
 }
 
 #[test]
 fn test_biginteger832() {
     use crate::biginteger::BigInteger832 as B;
-    test_biginteger(B::new([0u64; 13]));
+    test_biginteger(B::new([u64::MAX; 13]), B::new([0u64; 13]));
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This pull request introduces a new `mul` method for the `BigInteger` trait. The `mul` method allows efficient in-place multiplication of two `BigInteger` values, providing a convenient and performant way to compute the product of two instances. 

This enhancement complements the existing set of arithmetic operations supported by the `BigInteger` trait, contributing to the versatility and usability of the library.

Should be part of #645.

---


- [X] Targeted PR against correct branch (master)
- [X] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [X] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
