### PR TITLE
Define `Zero` next to `AdditiveGroup`

### DIFF
--- a/ff/README.md
+++ b/ff/README.md
@@ -150,10 +150,10 @@ to implement the [`PrimeField`][prime_field] trait for it. This provides access 
 additional APIs:
 
 ```rust
-use ark_ff::{Field, PrimeField, FpConfig, BigInteger};
+use ark_ff::{Field, PrimeField, FpConfig, BigInteger, Zero};
 // Now we'll use the prime field underlying the BLS12-381 G1 curve.
 use ark_test_curves::bls12_381::Fq as F;
-use ark_std::{One, Zero, UniformRand};
+use ark_std::{One, UniformRand};
 
 let mut rng = ark_std::test_rng();
 let a = F::rand(&mut rng);

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -14,7 +14,7 @@ use ark_std::{
 };
 
 pub use ark_ff_macros;
-use num_traits::{One, Zero};
+pub use num_traits::{One, Zero};
 use zeroize::Zeroize;
 
 pub mod utils;

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -1,3 +1,7 @@
+use crate::{
+    fields::{Field, PrimeField},
+    AdditiveGroup, LegendreSymbol, One, SqrtPrecomputation, ToConstraintField, UniformRand, Zero,
+};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, Compress, EmptyFlags, Flags, SerializationError, Valid, Validate,
@@ -8,21 +12,13 @@ use ark_std::{
     io::{Read, Write},
     iter::{Chain, IntoIterator},
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    rand::{
+        distributions::{Distribution, Standard},
+        Rng,
+    },
     vec::Vec,
 };
-
-use num_traits::{One, Zero};
 use zeroize::Zeroize;
-
-use ark_std::rand::{
-    distributions::{Distribution, Standard},
-    Rng,
-};
-
-use crate::{
-    fields::{Field, PrimeField},
-    AdditiveGroup, LegendreSymbol, SqrtPrecomputation, ToConstraintField, UniformRand,
-};
 
 /// Defines a Cubic extension field from a cubic non-residue.
 pub trait CubicExtConfig: 'static + Send + Sync + Sized {

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -1,5 +1,7 @@
-use core::iter;
-
+use crate::{
+    AdditiveGroup, BigInt, BigInteger, FftField, Field, LegendreSymbol, One, PrimeField,
+    SqrtPrecomputation, Zero,
+};
 use ark_serialize::{
     buffer_byte_size, CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, Compress, EmptyFlags, Flags, SerializationError, Valid, Validate,
@@ -11,17 +13,13 @@ use ark_std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     str::FromStr,
     string::ToString,
-    One, Zero,
 };
+use core::iter;
 
 #[macro_use]
 mod montgomery_backend;
 pub use montgomery_backend::*;
 
-use crate::{
-    AdditiveGroup, BigInt, BigInteger, FftField, Field, LegendreSymbol, PrimeField,
-    SqrtPrecomputation,
-};
 /// A trait that specifies the configuration of a prime field.
 /// Also specifies how to perform arithmetic on field elements.
 pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -1,8 +1,9 @@
-use ark_std::{marker::PhantomData, Zero};
-
 use super::{Fp, FpConfig};
-use crate::{biginteger::arithmetic as fa, BigInt, BigInteger, PrimeField, SqrtPrecomputation};
+use crate::{
+    biginteger::arithmetic as fa, BigInt, BigInteger, PrimeField, SqrtPrecomputation, Zero,
+};
 use ark_ff_macros::unroll_for_loops;
+use ark_std::marker::PhantomData;
 
 /// A trait that specifies the constants and arithmetic procedures
 /// for Montgomery arithmetic over the prime field defined by `MODULUS`.
@@ -161,9 +162,9 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
             {
                 #[cfg(
                     all(
-                        feature = "asm", 
-                        target_feature = "bmi2", 
-                        target_feature = "adx", 
+                        feature = "asm",
+                        target_feature = "bmi2",
+                        target_feature = "adx",
                         target_arch = "x86_64"
                     )
                 )]

--- a/ff/src/fields/models/fp12_2over3over2.rs
+++ b/ff/src/fields/models/fp12_2over3over2.rs
@@ -1,12 +1,10 @@
-use ark_std::Zero;
-
 use super::quadratic_extension::{QuadExtConfig, QuadExtField};
 use crate::{
     fields::{
         fp6_3over2::{Fp6, Fp6Config},
         Field, Fp2, Fp2Config as Fp2ConfigTrait,
     },
-    AdditiveGroup, CyclotomicMultSubgroup,
+    AdditiveGroup, CyclotomicMultSubgroup, Zero,
 };
 use core::{
     marker::PhantomData,

--- a/ff/src/fields/models/fp2.rs
+++ b/ff/src/fields/models/fp2.rs
@@ -1,7 +1,5 @@
-use ark_std::Zero;
-
 use super::quadratic_extension::{QuadExtConfig, QuadExtField};
-use crate::{fields::PrimeField, CyclotomicMultSubgroup};
+use crate::{fields::PrimeField, CyclotomicMultSubgroup, Zero};
 use core::{marker::PhantomData, ops::Not};
 
 /// Trait that specifies constants and methods for defining degree-two extension fields.

--- a/ff/src/fields/models/fp4.rs
+++ b/ff/src/fields/models/fp4.rs
@@ -1,12 +1,9 @@
-use ark_std::Zero;
-
 use super::quadratic_extension::{QuadExtConfig, QuadExtField};
-use core::{marker::PhantomData, ops::Not};
-
 use crate::{
     fields::{Fp2, Fp2Config},
-    CyclotomicMultSubgroup,
+    CyclotomicMultSubgroup, Zero,
 };
+use core::{marker::PhantomData, ops::Not};
 
 pub trait Fp4Config: 'static + Send + Sync {
     type Fp2Config: Fp2Config;

--- a/ff/src/fields/models/fp6_2over3.rs
+++ b/ff/src/fields/models/fp6_2over3.rs
@@ -1,14 +1,11 @@
-use ark_std::Zero;
-
 use super::quadratic_extension::{QuadExtConfig, QuadExtField};
+use crate::{
+    fields::{Fp3, Fp3Config},
+    CyclotomicMultSubgroup, Zero,
+};
 use core::{
     marker::PhantomData,
     ops::{MulAssign, Not},
-};
-
-use crate::{
-    fields::{Fp3, Fp3Config},
-    CyclotomicMultSubgroup,
 };
 
 pub trait Fp6Config: 'static + Send + Sync {

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -1,3 +1,8 @@
+use crate::{
+    biginteger::BigInteger,
+    fields::{Field, LegendreSymbol, PrimeField},
+    AdditiveGroup, One, SqrtPrecomputation, ToConstraintField, UniformRand, Zero,
+};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, Compress, EmptyFlags, Flags, SerializationError, Valid, Validate,
@@ -8,22 +13,13 @@ use ark_std::{
     io::{Read, Write},
     iter::{Chain, IntoIterator},
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    rand::{
+        distributions::{Distribution, Standard},
+        Rng,
+    },
     vec::Vec,
 };
-
-use num_traits::{One, Zero};
 use zeroize::Zeroize;
-
-use ark_std::rand::{
-    distributions::{Distribution, Standard},
-    Rng,
-};
-
-use crate::{
-    biginteger::BigInteger,
-    fields::{Field, LegendreSymbol, PrimeField},
-    AdditiveGroup, SqrtPrecomputation, ToConstraintField, UniformRand,
-};
 
 /// Defines a Quadratic extension field from a quadratic non-residue.
 pub trait QuadExtConfig: 'static + Send + Sync + Sized {

--- a/ff/src/fields/prime.rs
+++ b/ff/src/fields/prime.rs
@@ -3,11 +3,11 @@ use crate::{BigInteger, FftField, Field};
 use ark_std::{cmp::min, str::FromStr};
 use num_bigint::BigUint;
 
-/// The interface for a prime field, i.e. the field of integers modulo a prime $p$.  
+/// The interface for a prime field, i.e. the field of integers modulo a prime $p$.
 /// In the following example we'll use the prime field underlying the BLS12-381 G1 curve.
 /// ```rust
-/// use ark_ff::{BigInteger, Field, PrimeField};
-/// use ark_std::{test_rng, One, UniformRand, Zero};
+/// use ark_ff::{BigInteger, Field, PrimeField, Zero};
+/// use ark_std::{test_rng, One, UniformRand};
 /// use ark_test_curves::bls12_381::Fq as F;
 ///
 /// let mut rng = test_rng();

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -37,19 +37,16 @@ pub use ark_std::UniformRand;
 mod to_field_vec;
 pub use to_field_vec::ToConstraintField;
 
-pub use num_traits::{One, Zero};
-
 #[doc(hidden)]
 pub use ark_ff_asm::*;
 #[doc(hidden)]
 pub use ark_std::vec;
 
 pub mod prelude {
-    pub use crate::biginteger::BigInteger;
-
-    pub use crate::fields::{Field, PrimeField};
-
+    pub use crate::{
+        biginteger::BigInteger,
+        fields::{Field, PrimeField},
+        One, Zero,
+    };
     pub use ark_std::UniformRand;
-
-    pub use num_traits::{One, Zero};
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Right now `Zero` is in `ark_std` but here, its definition is re-exported in `ark-ff` next to `AdditiveGroup`.

closes: #670

