### PR TITLE
Allow multiplication of extension field elements directly by the `BasePrimeField` element

### DIFF
--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -349,7 +349,7 @@ pub trait Field:
         Some(res)
     }
 
-    fn mul_by_base_field_elem(&self, elem: &Self::BasePrimeField) -> Self;
+    fn mul_by_base_prime_field(&self, elem: &Self::BasePrimeField) -> Self;
 }
 
 // Given a vector of field elements {v_i}, compute the vector {v_i^(-1)}

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -341,11 +341,11 @@ impl<P: CubicExtConfig> Field for CubicExtField<P> {
         P::mul_base_field_by_frob_coeff(&mut self.c1, &mut self.c2, power);
     }
 
-    fn mul_by_base_field_elem(&self, elem: &Self::BasePrimeField) -> Self {
+    fn mul_by_base_prime_field(&self, elem: &Self::BasePrimeField) -> Self {
         let mut result = *self;
-        result.c0 = result.c0.mul_by_base_field_elem(elem);
-        result.c1 = result.c1.mul_by_base_field_elem(elem);
-        result.c2 = result.c2.mul_by_base_field_elem(elem);
+        result.c0 = result.c0.mul_by_base_prime_field(elem);
+        result.c1 = result.c1.mul_by_base_prime_field(elem);
+        result.c2 = result.c2.mul_by_base_prime_field(elem);
         result
     }
 }

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -347,7 +347,7 @@ impl<P: FpConfig<N>, const N: usize> Field for Fp<P, N> {
 
     /// Fp is already a "BasePrimeField", so it's just mul by self
     #[inline]
-    fn mul_by_base_field_elem(&self, elem: &Self::BasePrimeField) -> Self {
+    fn mul_by_base_prime_field(&self, elem: &Self::BasePrimeField) -> Self {
         *self * elem
     }
 }

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -448,10 +448,10 @@ impl<P: QuadExtConfig> Field for QuadExtField<P> {
         })
     }
 
-    fn mul_by_base_field_elem(&self, elem: &Self::BasePrimeField) -> Self {
+    fn mul_by_base_prime_field(&self, elem: &Self::BasePrimeField) -> Self {
         let mut result = *self;
-        result.c0 = result.c0.mul_by_base_field_elem(elem);
-        result.c1 = result.c1.mul_by_base_field_elem(elem);
+        result.c0 = result.c0.mul_by_base_prime_field(elem);
+        result.c1 = result.c1.mul_by_base_prime_field(elem);
         result
     }
 }

--- a/test-templates/src/fields.rs
+++ b/test-templates/src/fields.rs
@@ -364,7 +364,7 @@ macro_rules! __test_field {
                 let b = <<$field as Field>::BasePrimeField>::rand(rng);
 
                 let mut a = <$field>::from_base_prime_field_elems(a).unwrap();
-                let computed = a.mul_by_base_field_elem(&b);
+                let computed = a.mul_by_base_prime_field(&b);
 
                 let embedded_b = <$field as Field>::from_base_prime_field(b);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Note, there was already a method to multiply by the extension field's `BaseField`: but for a field tower, a `BaseField` might not necessarily be the `BasePrimeField`, but rather an extension field itself.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
