### PR TITLE
Add `in_place` suffix for `BigInteger` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@
 
 ### Improvements
 
-- [\#736](https://github.com/arkworks-rs/algebra/pull/736) (`ark-ff`) Deprecate `divn()`, and use `core::ops::{Shr, ShrAssign}` instead.
-- [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate `muln()`, and use `core::ops::{Shl, ShlAssign}` instead.
-- [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for short Weierstrass curves of cofactor one.  
+- [\#736](https://github.com/arkworks-rs/algebra/pull/736) (`ark-ff`) Deprecate `divn_in_place()`, and use `core::ops::{Shr, ShrAssign}` instead.
+- [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate `muln_in_place()`, and use `core::ops::{Shl, ShlAssign}` instead.
+- [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for short Weierstrass curves of cofactor one.
 
 ### Bugfixes
 
@@ -91,7 +91,7 @@
     - Rename `Fp*Parameters` to `Fp*Config`.
     - Add `From<u32>`, `From<u16>`, and `From<u8>` `impl`s for `BigInt<N>`.
     - Remove `FftConfig`; move its contents to `FftField`.
-- [\#383](https://github.com/arkworks-rs/algebra/pull/383) (`ark-ff`) Rename `BigInteger::add_nocarry` to `add_with_carry` and `sub_noborrow` to `sub_with_borrow`.
+- [\#383](https://github.com/arkworks-rs/algebra/pull/383) (`ark-ff`) Rename `BigInteger::add_nocarry` to `add_with_carry_in_place` and `sub_noborrow` to `sub_with_borrow_in_place`.
 - [\#386](https://github.com/arkworks-rs/algebra/pull/386) (`ark-ff`) Remove `PrimeField::GENERATOR`, since it already exists on `FftField`.
 - [\#393](https://github.com/arkworks-rs/algebra/pull/393) (`ark-ec`, `ark-ff`) Rename `FpXParams` to `FpXConfig` and `FpXParamsWrapper` to `FpXConfigWrapper`.
 - [\#396](https://github.com/arkworks-rs/algebra/pull/396) (`ark-ec`) Remove `mul_bits` feature, and remove default implementations of `mul` and `mul_by_cofactor_to_projective`.

--- a/bench-templates/src/macros/field.rs
+++ b/bench-templates/src/macros/field.rs
@@ -291,10 +291,10 @@ macro_rules! prime_field {
                     let mut tmp2 = BigInt::rand(&mut rng);
                     // Shave a few bits off to avoid overflow.
                     for _ in 0..3 {
-                        tmp1.div2();
-                        tmp2.div2();
+                        tmp1.div2_in_place();
+                        tmp2.div2_in_place();
                     }
-                    tmp2.div2();
+                    tmp2.div2_in_place();
                     (tmp1, tmp2)
                 })
                 .unzip();
@@ -304,7 +304,7 @@ macro_rules! prime_field {
                 b.iter(|| {
                     i = (i + 1) % SAMPLES;
                     let mut tmp = v1[i];
-                    (tmp, tmp.add_with_carry(&v2[i]))
+                    (tmp, tmp.add_with_carry_in_place(&v2[i]))
                 })
             });
             arithmetic.bench_function("Subtraction with borrow", |b| {
@@ -312,7 +312,7 @@ macro_rules! prime_field {
                 b.iter(|| {
                     i = (i + 1) % SAMPLES;
                     let mut tmp = v1[i];
-                    (tmp, tmp.sub_with_borrow(&v2[i]))
+                    (tmp, tmp.sub_with_borrow_in_place(&v2[i]))
                 })
             });
             arithmetic.bench_function("Multiplication by 2", |b| {
@@ -320,7 +320,7 @@ macro_rules! prime_field {
                 b.iter(|| {
                     i = (i + 1) % SAMPLES;
                     let mut tmp = v1[i];
-                    tmp.mul2()
+                    tmp.mul2_in_place()
                 })
             });
             arithmetic.bench_function("Division by 2", |b| {
@@ -328,7 +328,7 @@ macro_rules! prime_field {
                 b.iter(|| {
                     i = (i + 1) % SAMPLES;
                     let mut tmp = v1[i];
-                    tmp.div2()
+                    tmp.div2_in_place()
                 })
             });
             arithmetic.finish();

--- a/curves/bls12_377/src/fields/tests.rs
+++ b/curves/bls12_377/src/fields/tests.rs
@@ -49,7 +49,7 @@ fn test_fq_repr_num_bits() {
     a = BigInteger384::from(1u64);
     for i in 1..385 {
         assert_eq!(i, a.num_bits());
-        a.mul2();
+        a.mul2_in_place();
     }
     assert_eq!(0, a.num_bits());
 }

--- a/curves/bls12_381/src/fields/tests.rs
+++ b/curves/bls12_381/src/fields/tests.rs
@@ -772,7 +772,7 @@ fn test_fq_repr_div2() {
         0x41f82777bd13fdb,
         0xf43944578f9b771b,
     ]);
-    a.div2();
+    a.div2_in_place();
     assert_eq!(
         a,
         BigInt::new([
@@ -785,7 +785,7 @@ fn test_fq_repr_div2() {
         ])
     );
     for _ in 0..10 {
-        a.div2();
+        a.div2_in_place();
     }
     assert_eq!(
         a,
@@ -799,21 +799,21 @@ fn test_fq_repr_div2() {
         ])
     );
     for _ in 0..300 {
-        a.div2();
+        a.div2_in_place();
     }
     assert_eq!(
         a,
         BigInt::new([0x7288af1f36ee3608, 0x1e8, 0x0, 0x0, 0x0, 0x0])
     );
     for _ in 0..50 {
-        a.div2();
+        a.div2_in_place();
     }
     assert_eq!(a, BigInt::new([0x7a1ca2, 0x0, 0x0, 0x0, 0x0, 0x0]));
     for _ in 0..22 {
-        a.div2();
+        a.div2_in_place();
     }
     assert_eq!(a, BigInt::new([0x1, 0x0, 0x0, 0x0, 0x0, 0x0]));
-    a.div2();
+    a.div2_in_place();
     assert!(a.is_zero());
 }
 
@@ -885,31 +885,31 @@ fn test_fq_repr_shr() {
 #[test]
 fn test_fq_repr_mul2() {
     let mut a = BigInteger384::from(23712937547u64);
-    a.mul2();
+    a.mul2_in_place();
     assert_eq!(a, BigInt::new([0xb0acd6c96, 0x0, 0x0, 0x0, 0x0, 0x0]));
     for _ in 0..60 {
-        a.mul2();
+        a.mul2_in_place();
     }
     assert_eq!(
         a,
         BigInt::new([0x6000000000000000, 0xb0acd6c9, 0x0, 0x0, 0x0, 0x0])
     );
     for _ in 0..300 {
-        a.mul2();
+        a.mul2_in_place();
     }
     assert_eq!(
         a,
         BigInt::new([0x0, 0x0, 0x0, 0x0, 0x0, 0xcd6c960000000000])
     );
     for _ in 0..17 {
-        a.mul2();
+        a.mul2_in_place();
     }
     assert_eq!(
         a,
         BigInt::new([0x0, 0x0, 0x0, 0x0, 0x0, 0x2c00000000000000])
     );
     for _ in 0..6 {
-        a.mul2();
+        a.mul2_in_place();
     }
     assert!(a.is_zero());
 }
@@ -921,7 +921,7 @@ fn test_fq_repr_num_bits() {
     a = BigInteger384::from(1u64);
     for i in 1..385 {
         assert_eq!(i, a.num_bits());
-        a.mul2();
+        a.mul2_in_place();
     }
     assert_eq!(0, a.num_bits());
 }
@@ -938,7 +938,7 @@ fn test_fq_repr_sub_noborrow() {
         0xad0eb3948a5c34fd,
         0xd56f7b5ab8b5ce8,
     ]);
-    t.sub_with_borrow(&BigInt::new([
+    t.sub_with_borrow_in_place(&BigInt::new([
         0xc7867917187ca02b,
         0x5d75679d4911ffef,
         0x8c5b3e48b1a71c15,
@@ -962,23 +962,23 @@ fn test_fq_repr_sub_noborrow() {
         a.0[5] >>= 30;
         let mut b = a;
         for _ in 0..10 {
-            b.mul2();
+            b.mul2_in_place();
         }
         let mut c = b;
         for _ in 0..10 {
-            c.mul2();
+            c.mul2_in_place();
         }
 
         assert!(a < b);
         assert!(b < c);
 
         let mut csub_ba = c;
-        csub_ba.sub_with_borrow(&b);
-        csub_ba.sub_with_borrow(&a);
+        csub_ba.sub_with_borrow_in_place(&b);
+        csub_ba.sub_with_borrow_in_place(&a);
 
         let mut csub_ab = c;
-        csub_ab.sub_with_borrow(&a);
-        csub_ab.sub_with_borrow(&b);
+        csub_ab.sub_with_borrow_in_place(&a);
+        csub_ab.sub_with_borrow_in_place(&b);
 
         assert_eq!(csub_ab, csub_ba);
     }
@@ -992,7 +992,7 @@ fn test_fq_repr_sub_noborrow() {
         0x4b1ba7b6434bacd7,
         0x1a0111ea397fe69a,
     ]);
-    qplusone.sub_with_borrow(&BigInt::new([
+    qplusone.sub_with_borrow_in_place(&BigInt::new([
         0xb9feffffffffaaac,
         0x1eabfffeb153ffff,
         0x6730d2a0f6b0f624,
@@ -1025,7 +1025,7 @@ fn test_fq_repr_add_nocarry() {
         0xad0eb3948a5c34fd,
         0xd56f7b5ab8b5ce8,
     ]);
-    t.add_with_carry(&BigInt::new([
+    t.add_with_carry_in_place(&BigInt::new([
         0xc7867917187ca02b,
         0x5d75679d4911ffef,
         0x8c5b3e48b1a71c15,
@@ -1056,28 +1056,28 @@ fn test_fq_repr_add_nocarry() {
         c.0[5] >>= 3;
 
         let mut abc = a;
-        abc.add_with_carry(&b);
-        abc.add_with_carry(&c);
+        abc.add_with_carry_in_place(&b);
+        abc.add_with_carry_in_place(&c);
 
         let mut acb = a;
-        acb.add_with_carry(&c);
-        acb.add_with_carry(&b);
+        acb.add_with_carry_in_place(&c);
+        acb.add_with_carry_in_place(&b);
 
         let mut bac = b;
-        bac.add_with_carry(&a);
-        bac.add_with_carry(&c);
+        bac.add_with_carry_in_place(&a);
+        bac.add_with_carry_in_place(&c);
 
         let mut bca = b;
-        bca.add_with_carry(&c);
-        bca.add_with_carry(&a);
+        bca.add_with_carry_in_place(&c);
+        bca.add_with_carry_in_place(&a);
 
         let mut cab = c;
-        cab.add_with_carry(&a);
-        cab.add_with_carry(&b);
+        cab.add_with_carry_in_place(&a);
+        cab.add_with_carry_in_place(&b);
 
         let mut cba = c;
-        cba.add_with_carry(&b);
-        cba.add_with_carry(&a);
+        cba.add_with_carry_in_place(&b);
+        cba.add_with_carry_in_place(&a);
 
         assert_eq!(abc, acb);
         assert_eq!(abc, bac);
@@ -1095,7 +1095,7 @@ fn test_fq_repr_add_nocarry() {
         0xffffffffffffffff,
         0xffffffffffffffff,
     ]);
-    x.add_with_carry(&BigInteger384::from(1u64));
+    x.add_with_carry_in_place(&BigInteger384::from(1u64));
     assert!(x.is_zero());
 }
 

--- a/curves/bn254/src/fields/tests.rs
+++ b/curves/bn254/src/fields/tests.rs
@@ -48,7 +48,7 @@ fn test_fq_repr_num_bits() {
     a = BigInteger256::from(1u64);
     for i in 1..257 {
         assert_eq!(i, a.num_bits());
-        a.mul2();
+        a.mul2_in_place();
     }
     assert_eq!(0, a.num_bits());
 }

--- a/ec/src/hashing/curve_maps/swu.rs
+++ b/ec/src/hashing/curve_maps/swu.rs
@@ -73,9 +73,9 @@ impl<P: SWUConfig> MapToCurve<Projective<P>> for SWUMap<P> {
         let div = a * if ta.is_zero() { P::ZETA } else { -ta };
 
         let num2_x1 = num_x1.square();
-        let div2 = div.square();
-        let div3 = div2 * div;
-        let num_gx1 = (num2_x1 + a * div2) * num_x1 + b * div3;
+        let div2_in_place = div.square();
+        let div3 = div2_in_place * div;
+        let num_gx1 = (num2_x1 + a * div2_in_place) * num_x1 + b * div3;
 
         // 5. x2 = Z * u^2 * x1
         let num_x2 = zeta_u2 * num_x1; // same div

--- a/ff-macros/src/montgomery/double.rs
+++ b/ff-macros/src/montgomery/double.rs
@@ -2,14 +2,14 @@ pub(super) fn double_in_place_impl(modulus_has_spare_bit: bool) -> proc_macro2::
     if modulus_has_spare_bit {
         quote::quote! {
             // This cannot exceed the backing capacity.
-            a.0.mul2();
+            a.0.mul2_in_place();
             // However, it may need to be reduced.
             __subtract_modulus(a);
         }
     } else {
         quote::quote! {
             // This cannot exceed the backing capacity.
-            let c = a.0.mul2();
+            let c = a.0.mul2_in_place();
             // However, it may need to be reduced.
             __subtract_modulus_with_carry(a, c);
         }

--- a/ff-macros/src/montgomery/mod.rs
+++ b/ff-macros/src/montgomery/mod.rs
@@ -69,8 +69,8 @@ pub fn mont_config_helper(
     };
     let modulus = quote::quote! { BigInt([ #( #modulus_limbs ),* ]) };
 
-    let add_with_carry = add_with_carry_impl(limbs);
-    let sub_with_borrow = sub_with_borrow_impl(limbs);
+    let add_with_carry_in_place = add_with_carry_impl(limbs);
+    let sub_with_borrow_in_place = sub_with_borrow_impl(limbs);
     let subtract_modulus = subtract_modulus_impl(&modulus);
     let add_assign = add_assign_impl(modulus_has_spare_bit);
     let double_in_place = double_in_place_impl(modulus_has_spare_bit);
@@ -165,9 +165,9 @@ pub fn mont_config_helper(
 
             #subtract_modulus
 
-            #add_with_carry
+            #add_with_carry_in_place
 
-            #sub_with_borrow
+            #sub_with_borrow_in_place
         }
     }
 }

--- a/ff/src/biginteger/arithmetic.rs
+++ b/ff/src/biginteger/arithmetic.rs
@@ -149,7 +149,7 @@ pub fn find_naf(num: &[u64]) -> Vec<i8> {
             carry = adc(a, b, carry);
         }
     };
-    let div2 = |num: &mut [u64]| {
+    let div2_in_place = |num: &mut [u64]| {
         let mut t = 0;
         for i in num.iter_mut().rev() {
             let t2 = *i << 63;
@@ -175,7 +175,7 @@ pub fn find_naf(num: &[u64]) -> Vec<i8> {
             z = 0;
         }
         res.push(z);
-        div2(&mut num);
+        div2_in_place(&mut num);
     }
 
     res

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -296,7 +296,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
     const NUM_LIMBS: usize = N;
 
     #[inline]
-    fn add_with_carry(&mut self, other: &Self) -> bool {
+    fn add_with_carry_in_place(&mut self, other: &Self) -> bool {
         {
             use arithmetic::adc_for_add_with_carry as adc;
 
@@ -330,7 +330,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
     }
 
     #[inline]
-    fn sub_with_borrow(&mut self, other: &Self) -> bool {
+    fn sub_with_borrow_in_place(&mut self, other: &Self) -> bool {
         use arithmetic::sbb_for_sub_with_borrow as sbb;
 
         let a = &mut self.0;
@@ -363,7 +363,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
 
     #[inline]
     #[allow(unused)]
-    fn mul2(&mut self) -> bool {
+    fn mul2_in_place(&mut self) -> bool {
         #[cfg(all(target_arch = "x86_64", feature = "asm"))]
         #[allow(unsafe_code)]
         {
@@ -394,7 +394,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
     }
 
     #[inline]
-    fn muln(&mut self, mut n: u32) {
+    fn muln_in_place(&mut self, mut n: u32) {
         if n >= (64 * N) as u32 {
             *self = Self::from(0u64);
             return;
@@ -468,7 +468,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
     }
 
     #[inline]
-    fn div2(&mut self) {
+    fn div2_in_place(&mut self) {
         let mut t = 0;
         for i in 0..N {
             let a = &mut self.0[N - i - 1];
@@ -480,7 +480,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
     }
 
     #[inline]
-    fn divn(&mut self, mut n: u32) {
+    fn divn_in_place(&mut self, mut n: u32) {
         if n >= (64 * N) as u32 {
             *self = Self::from(0u64);
             return;
@@ -1003,17 +1003,17 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let (mut one, mut x) = (B::from(1u64), B::from(2u64));
-    /// let carry = x.add_with_carry(&one);
+    /// let carry = x.add_with_carry_in_place(&one);
     /// assert_eq!(x, B::from(3u64));
     /// assert_eq!(carry, false);
     ///
     /// // Edge-Case
     /// let mut x = B::from(u64::MAX);
-    /// let carry = x.add_with_carry(&one);
+    /// let carry = x.add_with_carry_in_place(&one);
     /// assert_eq!(x, B::from(0u64));
     /// assert_eq!(carry, true)
     /// ```
-    fn add_with_carry(&mut self, other: &Self) -> bool;
+    fn add_with_carry_in_place(&mut self, other: &Self) -> bool;
 
     /// Subtract another [`BigInteger`] from this one. This method stores the result in
     /// `self`, and returns a borrow.
@@ -1025,16 +1025,16 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let (mut one_sub, two, mut three_sub) = (B::from(1u64), B::from(2u64), B::from(3u64));
-    /// let borrow = three_sub.sub_with_borrow(&two);
+    /// let borrow = three_sub.sub_with_borrow_in_place(&two);
     /// assert_eq!(three_sub, one_sub);
     /// assert_eq!(borrow, false);
     ///
     /// // Edge-Case
-    /// let borrow = one_sub.sub_with_borrow(&two);
+    /// let borrow = one_sub.sub_with_borrow_in_place(&two);
     /// assert_eq!(one_sub, B::from(u64::MAX));
     /// assert_eq!(borrow, true);
     /// ```
-    fn sub_with_borrow(&mut self, other: &Self) -> bool;
+    fn sub_with_borrow_in_place(&mut self, other: &Self) -> bool;
 
     /// Performs a leftwise bitshift of this number, effectively multiplying
     /// it by 2. Overflow is ignored.
@@ -1045,21 +1045,21 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let mut two_mul = B::from(2u64);
-    /// two_mul.mul2();
+    /// two_mul.mul2_in_place();
     /// assert_eq!(two_mul, B::from(4u64));
     ///
     /// // Edge-Cases
     /// let mut zero = B::from(0u64);
-    /// zero.mul2();
+    /// zero.mul2_in_place();
     /// assert_eq!(zero, B::from(0u64));
     ///
     /// let mut arr: [bool; 64] = [false; 64];
     /// arr[0] = true;
     /// let mut mul = B::from_bits_be(&arr);
-    /// mul.mul2();
+    /// mul.mul2_in_place();
     /// assert_eq!(mul, B::from(0u64));
     /// ```
-    fn mul2(&mut self) -> bool;
+    fn mul2_in_place(&mut self) -> bool;
 
     /// Performs a leftwise bitshift of this number by n bits, effectively multiplying
     /// it by 2^n. Overflow is ignored.
@@ -1070,22 +1070,22 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let mut one_mul = B::from(1u64);
-    /// one_mul.muln(5);
+    /// one_mul.muln_in_place(5);
     /// assert_eq!(one_mul, B::from(32u64));
     ///
     /// // Edge-Case
     /// let mut zero = B::from(0u64);
-    /// zero.muln(5);
+    /// zero.muln_in_place(5);
     /// assert_eq!(zero, B::from(0u64));
     ///
     /// let mut arr: [bool; 64] = [false; 64];
     /// arr[4] = true;
     /// let mut mul = B::from_bits_be(&arr);
-    /// mul.muln(5);
+    /// mul.muln_in_place(5);
     /// assert_eq!(mul, B::from(0u64));
     /// ```
     #[deprecated(since = "0.4.2", note = "please use the operator `<<` instead")]
-    fn muln(&mut self, amt: u32);
+    fn muln_in_place(&mut self, amt: u32);
 
     /// Multiplies this [`BigInteger`] by another `BigInteger`, storing the result in `self`.
     /// Overflow is ignored.
@@ -1142,7 +1142,7 @@ pub trait BigInteger:
     /// // Edge-Case
     /// let mut x = B::from(u64::MAX);
     /// let mut max_plus_max = x;
-    /// max_plus_max.add_with_carry(&x);
+    /// max_plus_max.add_with_carry_in_place(&x);
     /// let (low_bits, high_bits) = x.mul(&B::from(2u64));
     /// assert_eq!(low_bits, max_plus_max);
     /// assert_eq!(high_bits, B::from(1u64));
@@ -1158,19 +1158,19 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let (mut two, mut four_div) = (B::from(2u64), B::from(4u64));
-    /// four_div.div2();
+    /// four_div.div2_in_place();
     /// assert_eq!(two, four_div);
     ///
     /// // Edge-Case
     /// let mut zero = B::from(0u64);
-    /// zero.div2();
+    /// zero.div2_in_place();
     /// assert_eq!(zero, B::from(0u64));
     ///
     /// let mut one = B::from(1u64);
-    /// one.div2();
+    /// one.div2_in_place();
     /// assert_eq!(one, B::from(0u64));
     /// ```
-    fn div2(&mut self);
+    fn div2_in_place(&mut self);
 
     /// Performs a rightwise bitshift of this number by some amount.
     /// # Example
@@ -1180,18 +1180,18 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let (mut one, mut thirty_two_div) = (B::from(1u64), B::from(32u64));
-    /// thirty_two_div.divn(5);
+    /// thirty_two_div.divn_in_place(5);
     /// assert_eq!(one, thirty_two_div);
     ///
     /// // Edge-Case
     /// let mut arr: [bool; 64] = [false; 64];
     /// arr[4] = true;
     /// let mut div = B::from_bits_le(&arr);
-    /// div.divn(5);
+    /// div.divn_in_place(5);
     /// assert_eq!(div, B::from(0u64));
     /// ```
     #[deprecated(since = "0.4.2", note = "please use the operator `>>` instead")]
-    fn divn(&mut self, amt: u32);
+    fn divn_in_place(&mut self, amt: u32);
 
     /// Returns true iff this number is odd.
     /// # Example
@@ -1359,15 +1359,15 @@ pub trait BigInteger:
                 if e.is_odd() {
                     z = signed_mod_reduction(e.as_ref()[0], 1 << w);
                     if z >= 0 {
-                        e.sub_with_borrow(&Self::from(z as u64));
+                        e.sub_with_borrow_in_place(&Self::from(z as u64));
                     } else {
-                        e.add_with_carry(&Self::from((-z) as u64));
+                        e.add_with_carry_in_place(&Self::from((-z) as u64));
                     }
                 } else {
                     z = 0;
                 }
                 res.push(z);
-                e.div2();
+                e.div2_in_place();
             }
 
             Some(res)

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -14,27 +14,27 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B, max: B) {
 
     // a + 0 = a
     let mut a0_add = a;
-    let carry = a0_add.add_with_carry(&zero);
+    let carry = a0_add.add_with_carry_in_place(&zero);
     assert_eq!(a0_add, a);
     assert_eq!(carry, false);
 
     // a - 0 = a
     let mut a0_sub = a;
-    let borrow = a0_sub.sub_with_borrow(&zero);
+    let borrow = a0_sub.sub_with_borrow_in_place(&zero);
     assert_eq!(a0_sub, a);
     assert_eq!(borrow, false);
 
     // a - a = 0
     let mut aa_sub = a;
-    let borrow = aa_sub.sub_with_borrow(&a);
+    let borrow = aa_sub.sub_with_borrow_in_place(&a);
     assert_eq!(aa_sub, zero);
     assert_eq!(borrow, false);
 
     // a + b = b + a
     let mut ab_add = a;
-    let ab_carry = ab_add.add_with_carry(&b);
+    let ab_carry = ab_add.add_with_carry_in_place(&b);
     let mut ba_add = b;
-    let ba_carry = ba_add.add_with_carry(&a);
+    let ba_carry = ba_add.add_with_carry_in_place(&a);
     assert_eq!(ab_add, ba_add);
     assert_eq!(ab_carry, ba_carry);
 
@@ -45,9 +45,9 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B, max: B) {
 
     // a * 2 = a + a
     let mut a_mul2 = a;
-    a_mul2.mul2();
+    a_mul2.mul2_in_place();
     let mut a_plus_a = a;
-    let carry_a_plus_a = a_plus_a.add_with_carry(&a); // Won't assert anything about carry bit.
+    let carry_a_plus_a = a_plus_a.add_with_carry_in_place(&a); // Won't assert anything about carry bit.
     assert_eq!(a_mul2, a_plus_a);
 
     // a * 1 = a
@@ -92,7 +92,7 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B, max: B) {
 
     // max + max = max * 2
     let mut max_plus_max = max;
-    max_plus_max.add_with_carry(&max);
+    max_plus_max.add_with_carry_in_place(&max);
     assert_eq!(max.mul(&B::from(2u64)), (max_plus_max, B::from(1u64)));
     assert_eq!(max.mul_high(&B::from(2u64)), B::from(1u64));
 }

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -144,14 +144,14 @@ impl<P: FpConfig<N>, const N: usize> Fp<P, N> {
     #[inline]
     fn subtract_modulus(&mut self) {
         if self.is_geq_modulus() {
-            self.0.sub_with_borrow(&Self::MODULUS);
+            self.0.sub_with_borrow_in_place(&Self::MODULUS);
         }
     }
 
     #[inline]
     fn subtract_modulus_with_carry(&mut self, carry: bool) {
         if carry || self.is_geq_modulus() {
-            self.0.sub_with_borrow(&Self::MODULUS);
+            self.0.sub_with_borrow_in_place(&Self::MODULUS);
         }
     }
 

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -408,8 +408,8 @@ impl<P: QuadExtConfig> Field for QuadExtField<P> {
         // This is cheaper than `P::BaseField::one().double().inverse()`
         let mut two_inv = P::BasePrimeField::MODULUS;
 
-        two_inv.add_with_carry(&1u64.into());
-        two_inv.div2();
+        two_inv.add_with_carry_in_place(&1u64.into());
+        two_inv.div2_in_place();
 
         let two_inv = P::BasePrimeField::from(two_inv);
         let two_inv = P::BaseField::from_base_prime_field(two_inv);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This pull request introduces a standardized naming convention for methods in the `BigInteger` module, specifically targeting functions where the `self` mutable value is modified in-place. The convention adds the `in_place` suffix to method names to provide clarity and consistency in the codebase.

closes: #781 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
