### PR TITLE
Add a few simplifications around Mont inverse

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -470,8 +470,10 @@ impl<const N: usize> BigInteger for BigInt<N> {
     #[inline]
     fn div2(&mut self) {
         let mut t = 0;
-        for i in 0..N {
-            let a = &mut self.0[N - i - 1];
+        let mut i = N;
+        while i > 0 {
+            i -= 1;
+            let a = &mut self.0[i];
             let t2 = *a << 63;
             *a >>= 1;
             *a |= t;

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -470,10 +470,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
     #[inline]
     fn div2(&mut self) {
         let mut t = 0;
-        let mut i = N;
-        while i > 0 {
-            i -= 1;
-            let a = &mut self.0[i];
+        for a in self.0.iter_mut().rev() {
             let t2 = *a << 63;
             *a >>= 1;
             *a |= t;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->



- When using `div2` method of `BigInt`, we traverse the members in the opposite direction (big endian order) with a loop which until now was carried out in the little endian order. Therefore, in each iteration of the loop, the calculation of `N - i - 1` was necessary. If we go through the limbs in the opposite direction with a while as I propose here, the calculation is no longer carried out on each pass, because we take the member `i` directly.
- In the `inverse` method of the Montgomery back end, when we exit the following piece of code:
```rust
if a.is_zero() {
  None
}
```
there is no need for the else, because the rest will necessarily take place if `a` is not zero. Therefore, I removed the else here to avoid unnecessary indentations.

