### PR TITLE
A few adjustments in big integer `shr_assign`

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -821,10 +821,8 @@ impl<const N: usize> ShrAssign<u32> for BigInt<N> {
 
         while rhs >= 64 {
             let mut t = 0;
-            let mut limb = N;
-            while limb > 0 {
-                limb -= 1;
-                core::mem::swap(&mut t, &mut self.0[limb]);
+            for limb in self.0.iter_mut().rev() {
+                core::mem::swap(&mut t, limb);
             }
             rhs -= 64;
         }

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -440,7 +440,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
             carry = 0;
         }
 
-        return (Self(r.b0), Self(r.b1));
+        (Self(r.b0), Self(r.b1))
     }
 
     #[inline]
@@ -816,20 +816,25 @@ impl<const N: usize> ShrAssign<u32> for BigInt<N> {
     fn shr_assign(&mut self, mut rhs: u32) {
         if rhs >= (64 * N) as u32 {
             *self = Self::from(0u64);
+            return;
         }
 
         while rhs >= 64 {
             let mut t = 0;
-            for i in 0..N {
-                core::mem::swap(&mut t, &mut self.0[N - i - 1]);
+            let mut limb = N;
+            while limb > 0 {
+                limb -= 1;
+                core::mem::swap(&mut t, &mut self.0[limb]);
             }
             rhs -= 64;
         }
 
         if rhs > 0 {
             let mut t = 0;
-            for i in 0..N {
-                let a = &mut self.0[N - i - 1];
+            let mut limb = N;
+            while limb > 0 {
+                limb -= 1;
+                let a = &mut self.0[limb];
                 let t2 = *a << (64 - rhs);
                 *a >>= rhs;
                 *a |= t;

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -831,10 +831,7 @@ impl<const N: usize> ShrAssign<u32> for BigInt<N> {
 
         if rhs > 0 {
             let mut t = 0;
-            let mut limb = N;
-            while limb > 0 {
-                limb -= 1;
-                let a = &mut self.0[limb];
+            for a in self.0.iter_mut().rev() {
                 let t2 = *a << (64 - rhs);
                 *a >>= rhs;
                 *a |= t;


### PR DESCRIPTION
- If the number of bits shifted is larger than `N * 64`, the function can be exited at the beginning without having to do the rest of the calculations.
- As the limbs are traversed from the end to the beginning, it is generally less expensive to do a while starting from the end to avoid looking for an index at the opposite end of the table at each iteration.