### PR TITLE
Remove useless variable decl in `into_bigint` Mont

### DIFF
--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -371,7 +371,7 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
     #[unroll_for_loops(12)]
     #[allow(clippy::modulo_one)]
     fn into_bigint(a: Fp<MontBackend<Self, N>, N>) -> BigInt<N> {
-        let mut r = a.0 .0;
+        let mut r = (a.0).0;
         // Montgomery Reduction
         for i in 0..N {
             let k = r[i].wrapping_mul(Self::INV);

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -371,8 +371,7 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
     #[unroll_for_loops(12)]
     #[allow(clippy::modulo_one)]
     fn into_bigint(a: Fp<MontBackend<Self, N>, N>) -> BigInt<N> {
-        let mut tmp = a.0;
-        let mut r = tmp.0;
+        let mut r = a.0 .0;
         // Montgomery Reduction
         for i in 0..N {
             let k = r[i].wrapping_mul(Self::INV);
@@ -385,8 +384,8 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
             }
             r[i % N] = carry;
         }
-        tmp.0 = r;
-        tmp
+
+        BigInt::new(r)
     }
 
     #[unroll_for_loops(12)]


### PR DESCRIPTION
In this pull request, it is proposed to streamline the code by eliminating the unnecessary `tmp` variable. 

Currently, the `tmp` variable serves the sole purpose of holding the `[u64; N]` array temporarily to store the final `BigInt` returned at the end of the function. 

However, this approach can be made more readable and concise. Therefore, I suggest removing the `tmp` variable and replacing it with a direct declaration of `BigInt` at the function's conclusion. This modification enhances code clarity and removes redundant assignments.