### PR TITLE
Fix compilation on WASM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 - [\#772](https://github.com/arkworks-rs/algebra/pull/772) (`ark-ff`) Implementation of `mul` method for `BigInteger`.
+- [\#794](https://github.com/arkworks-rs/algebra/pull/794) (`ark-ff`) Fix `wasm` compilation.
 
 ### Breaking changes
 

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -368,7 +368,8 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
     }
 
     #[inline]
-    #[unroll_for_loops(12)]
+    #[cfg_attr(not(target_family = "wasm"), unroll_for_loops(12))]
+    #[cfg_attr(target_family = "wasm", unroll_for_loops(6))]
     #[allow(clippy::modulo_one)]
     fn into_bigint(a: Fp<MontBackend<Self, N>, N>) -> BigInt<N> {
         let mut tmp = a.0;


### PR DESCRIPTION
Disable loop unrolling for `Fp::into_bigint` that led to WASM miscompilations with too many local variables:

```
Error: failed to deserialize wasm module

Caused by:
    0: failed to parse code section
    1: locals exceed maximum (at offset 16977)
```

Issue diagnosed by @paberr and @ii-cruz.

Fixes #615.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] ~Wrote unit tests~ -- not applicable, this is about compilation failure
- [ ] ~Updated relevant documentation in the code~ -- not applicable
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
