### PR TITLE
Cleaning `add_with_carry` and `sub_with_borrow` for bigint

### DIFF
--- a/curves/bls12_381/benches/bls12_381.rs
+++ b/curves/bls12_381/benches/bls12_381.rs
@@ -3,18 +3,13 @@ use ark_bls12_381::{
     fq::Fq, fq2::Fq2, fr::Fr, Bls12_381, Fq12, G1Projective as G1, G2Projective as G2,
 };
 
-// bench!(
-//     Name = "Bls12_381",
-//     Pairing = Bls12_381,
-//     G1 = G1,
-//     G2 = G2,
-//     ScalarField = Fr,
-//     G1BaseField = Fq,
-//     G2BaseField = Fq2,
-//     TargetField = Fq12,
-// );
-
-
-f_bench!(prime, "Bls12_381", Fr);
-
-criterion_main!(fr::benches);
+bench!(
+    Name = "Bls12_381",
+    Pairing = Bls12_381,
+    G1 = G1,
+    G2 = G2,
+    ScalarField = Fr,
+    G1BaseField = Fq,
+    G2BaseField = Fq2,
+    TargetField = Fq12,
+);

--- a/curves/bls12_381/benches/bls12_381.rs
+++ b/curves/bls12_381/benches/bls12_381.rs
@@ -3,13 +3,18 @@ use ark_bls12_381::{
     fq::Fq, fq2::Fq2, fr::Fr, Bls12_381, Fq12, G1Projective as G1, G2Projective as G2,
 };
 
-bench!(
-    Name = "Bls12_381",
-    Pairing = Bls12_381,
-    G1 = G1,
-    G2 = G2,
-    ScalarField = Fr,
-    G1BaseField = Fq,
-    G2BaseField = Fq2,
-    TargetField = Fq12,
-);
+// bench!(
+//     Name = "Bls12_381",
+//     Pairing = Bls12_381,
+//     G1 = G1,
+//     G2 = G2,
+//     ScalarField = Fr,
+//     G1BaseField = Fq,
+//     G2BaseField = Fq2,
+//     TargetField = Fq12,
+// );
+
+
+f_bench!(prime, "Bls12_381", Fr);
+
+criterion_main!(fr::benches);

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -109,8 +109,7 @@ macro_rules! const_modulo {
         // https://en.wikipedia.org/wiki/Division_algorithm
         assert!(!$divisor.const_is_zero());
         let mut remainder = Self::new([0u64; N]);
-        let end = $a.num_bits();
-        let mut i = (end - 1) as isize;
+        let mut i = ($a.num_bits() - 1) as isize;
         let mut carry;
         while i >= 0 {
             (remainder, carry) = remainder.const_mul2_with_carry();
@@ -295,69 +294,27 @@ impl<const N: usize> BigInt<N> {
 impl<const N: usize> BigInteger for BigInt<N> {
     const NUM_LIMBS: usize = N;
 
+    #[unroll_for_loops(12)]
     #[inline]
     fn add_with_carry(&mut self, other: &Self) -> bool {
-        {
-            use arithmetic::adc_for_add_with_carry as adc;
+        let mut carry = 0;
 
-            let a = &mut self.0;
-            let b = &other.0;
-            let mut carry = 0;
-
-            if N >= 1 {
-                carry = adc(&mut a[0], b[0], carry);
-            }
-            if N >= 2 {
-                carry = adc(&mut a[1], b[1], carry);
-            }
-            if N >= 3 {
-                carry = adc(&mut a[2], b[2], carry);
-            }
-            if N >= 4 {
-                carry = adc(&mut a[3], b[3], carry);
-            }
-            if N >= 5 {
-                carry = adc(&mut a[4], b[4], carry);
-            }
-            if N >= 6 {
-                carry = adc(&mut a[5], b[5], carry);
-            }
-            for i in 6..N {
-                carry = adc(&mut a[i], b[i], carry);
-            }
-            carry != 0
+        for i in 0..N {
+            carry = arithmetic::adc_for_add_with_carry(&mut self.0[i], other.0[i], carry);
         }
+
+        carry != 0
     }
 
+    #[unroll_for_loops(12)]
     #[inline]
     fn sub_with_borrow(&mut self, other: &Self) -> bool {
-        use arithmetic::sbb_for_sub_with_borrow as sbb;
+        let mut borrow = 0;
 
-        let a = &mut self.0;
-        let b = &other.0;
-        let mut borrow = 0u8;
+        for i in 0..N {
+            borrow = arithmetic::sbb_for_sub_with_borrow(&mut self.0[i], other.0[i], borrow);
+        }
 
-        if N >= 1 {
-            borrow = sbb(&mut a[0], b[0], borrow);
-        }
-        if N >= 2 {
-            borrow = sbb(&mut a[1], b[1], borrow);
-        }
-        if N >= 3 {
-            borrow = sbb(&mut a[2], b[2], borrow);
-        }
-        if N >= 4 {
-            borrow = sbb(&mut a[3], b[3], borrow);
-        }
-        if N >= 5 {
-            borrow = sbb(&mut a[4], b[4], borrow);
-        }
-        if N >= 6 {
-            borrow = sbb(&mut a[5], b[5], borrow);
-        }
-        for i in 6..N {
-            borrow = sbb(&mut a[i], b[i], borrow);
-        }
         borrow != 0
     }
 

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -294,7 +294,7 @@ impl<const N: usize> BigInt<N> {
 impl<const N: usize> BigInteger for BigInt<N> {
     const NUM_LIMBS: usize = N;
 
-    #[unroll_for_loops(12)]
+    #[unroll_for_loops(6)]
     #[inline]
     fn add_with_carry(&mut self, other: &Self) -> bool {
         let mut carry = 0;
@@ -306,7 +306,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
         carry != 0
     }
 
-    #[unroll_for_loops(12)]
+    #[unroll_for_loops(6)]
     #[inline]
     fn sub_with_borrow(&mut self, other: &Self) -> bool {
         let mut borrow = 0;


### PR DESCRIPTION
The functions `add_with_carry` and `sub_with_borrow` of the big integer implementation are inlined and I placed the unrolled loops so that doing the loop or ifs one after the other is absolutely identical. It's just a matter of clean up clarity here. Here is a benchmark carried out which shows that there is no impact on performance after this change:

```shell
Arithmetic for Bls12_381::Fr/Addition
                        time:   [4.0965 ns 4.0990 ns 4.1019 ns]
                        change: [-0.3189% -0.1913% -0.0743%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
Arithmetic for Bls12_381::Fr/Subtraction
                        time:   [6.5650 ns 6.6135 ns 6.6672 ns]
                        change: [-1.3703% -0.3289% +0.7317%] (p = 0.54 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
Arithmetic for Bls12_381::Fr/Negation
                        time:   [5.4351 ns 5.4370 ns 5.4393 ns]
                        change: [-0.5334% -0.3004% -0.1192%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe
Arithmetic for Bls12_381::Fr/Double
                        time:   [4.7062 ns 4.7083 ns 4.7110 ns]
                        change: [-0.3550% -0.2382% -0.1323%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
Arithmetic for Bls12_381::Fr/Multiplication
                        time:   [26.269 ns 26.302 ns 26.357 ns]
                        change: [-0.2325% -0.1190% +0.0066%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
Arithmetic for Bls12_381::Fr/Square
                        time:   [21.645 ns 21.675 ns 21.714 ns]
                        change: [-0.3349% -0.1618% +0.0091%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
Arithmetic for Bls12_381::Fr/Inverse
                        time:   [5.6003 µs 5.6053 µs 5.6112 µs]
                        change: [+0.0846% +0.2328% +0.3654%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
```