### PR TITLE
Simplify `from_bits_be`in big int by reusing `from_bits_le` inside

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -549,20 +549,9 @@ impl<const N: usize> BigInteger for BigInt<N> {
 
     #[inline]
     fn from_bits_be(bits: &[bool]) -> Self {
-        let mut res = Self::default();
-        let mut acc: u64 = 0;
-
         let mut bits = bits.to_vec();
         bits.reverse();
-        for (i, bits64) in bits.chunks(64).enumerate() {
-            for bit in bits64.iter().rev() {
-                acc <<= 1;
-                acc += *bit as u64;
-            }
-            res.0[i] = acc;
-            acc = 0;
-        }
-        res
+        Self::from_bits_le(&bits)
     }
 
     fn from_bits_le(bits: &[bool]) -> Self {

--- a/ff/src/biginteger/tests.rs
+++ b/ff/src/biginteger/tests.rs
@@ -206,6 +206,12 @@ fn biginteger_bits_test<B: BigInteger>() {
     assert!(!thirty_two.get_bit(4));
     // 5th bit of BigInteger representing 32 is 1
     assert!(thirty_two.get_bit(5), "{:?}", thirty_two);
+
+    // Generates a random BigInteger and tests bit construction methods.
+    let mut rng = ark_std::test_rng();
+    let a: B = UniformRand::rand(&mut rng);
+    assert_eq!(B::from_bits_be(&a.to_bits_be()), a);
+    assert_eq!(B::from_bits_le(&a.to_bits_le()), a);
 }
 
 // Test conversion from BigInteger to BigUint


### PR DESCRIPTION
### Description
The current implementation of the `from_bits_be` function in the BigInt module involves reversing the input `bits` array and then doing some operations. This can be simplified by directly using `from_bits_le` with a reversed copy of the `bits` array, achieving the same functionality in a more concise and readable manner.

