### PR TITLE
Small fix in `two_adic_valuation`

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -189,8 +189,8 @@ impl<const N: usize> BigInt<N> {
     /// Compute the largest integer `s` such that `self = 2**s * t + 1` for odd `t`.
     #[doc(hidden)]
     pub const fn two_adic_valuation(mut self) -> u32 {
-        let mut two_adicity = 0;
         assert!(self.const_is_odd());
+        let mut two_adicity = 0;
         // Since `self` is odd, we can always subtract one
         // without a borrow
         self.0[0] -= 1;

--- a/ff/src/fields/field_hashers/expander/mod.rs
+++ b/ff/src/fields/field_hashers/expander/mod.rs
@@ -33,6 +33,7 @@ impl DST {
         DST(array)
     }
 
+    #[allow(dead_code)]
     pub fn new_xof<H: ExtendableOutput + Default>(dst: &[u8], k: usize) -> DST {
         let array = if dst.len() > MAX_DST_LENGTH {
             let mut long = H::default();
@@ -56,6 +57,7 @@ impl DST {
     }
 }
 
+#[allow(dead_code)]
 pub(super) struct ExpanderXof<H: ExtendableOutput + Clone + Default> {
     pub(super) xofer: PhantomData<H>,
     pub(super) dst: Vec<u8>,

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -83,7 +83,7 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
     /// Compute the inner product `<a, b>`.
     fn sum_of_products<const T: usize>(a: &[Fp<Self, N>; T], b: &[Fp<Self, N>; T]) -> Fp<Self, N>;
 
-    /// Set a *= b.
+    /// Set a *= a.
     fn square_in_place(a: &mut Fp<Self, N>);
 
     /// Compute a^{-1} if `a` is not zero.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

In the `two_adic_valuation` implementation we should first do the check to know is `self` is odd before creating the `two_adicity` mutable value. If the test fails, then the declaration would be useless.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
