### PR TITLE
Relax the visibility for G2 ell coeffs and related algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,12 @@
 - [\#736](https://github.com/arkworks-rs/algebra/pull/736) (`ark-ff`) Deprecate `divn()`, and use `core::ops::{Shr, ShrAssign}` instead.
 - [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate `muln()`, and use `core::ops::{Shl, ShlAssign}` instead.
 - [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for short Weierstrass curves of cofactor one.  
+- [\#817](https://github.com/arkworks-rs/algebra/pull/817) (`ark-ec`) Relax the visibility for G2 ell coeffs and related algorithms.
 
 ### Bugfixes
 
-- [\#747](https://github.com/arkworks-rs/algebra/pull/747) (`ark-ff-macros`) Fix fetching attributes in `MontConfig` macro
-- [\#803](https://github.com/arkworks-rs/algebra/pull/803) (`ark-ec`, `ark-test-template`) Fix incorrect decomposition in GLV
+- [\#747](https://github.com/arkworks-rs/algebra/pull/747) (`ark-ff-macros`) Fix fetching attributes in `MontConfig` macro.
+- [\#803](https://github.com/arkworks-rs/algebra/pull/803) (`ark-ec`, `ark-test-template`) Fix incorrect decomposition in GLV.
 
 ## v0.4.2
 

--- a/ec/src/models/bls12/g2.rs
+++ b/ec/src/models/bls12/g2.rs
@@ -27,7 +27,7 @@ pub struct G2Prepared<P: Bls12Config> {
     pub infinity: bool,
 }
 
-pub(crate) type EllCoeff<P> = (
+pub type EllCoeff<P> = (
     Fp2<<P as Bls12Config>::Fp2Config>,
     Fp2<<P as Bls12Config>::Fp2Config>,
     Fp2<<P as Bls12Config>::Fp2Config>,
@@ -39,7 +39,7 @@ pub(crate) type EllCoeff<P> = (
     Copy(bound = "P: Bls12Config"),
     Debug(bound = "P: Bls12Config")
 )]
-struct G2HomProjective<P: Bls12Config> {
+pub struct G2HomProjective<P: Bls12Config> {
     x: Fp2<P::Fp2Config>,
     y: Fp2<P::Fp2Config>,
     z: Fp2<P::Fp2Config>,

--- a/ec/src/models/bn/g2.rs
+++ b/ec/src/models/bn/g2.rs
@@ -31,7 +31,7 @@ pub struct G2Prepared<P: BnConfig> {
     pub infinity: bool,
 }
 
-pub(crate) type EllCoeff<P> = (
+pub type EllCoeff<P> = (
     Fp2<<P as BnConfig>::Fp2Config>,
     Fp2<<P as BnConfig>::Fp2Config>,
     Fp2<<P as BnConfig>::Fp2Config>,
@@ -43,14 +43,14 @@ pub(crate) type EllCoeff<P> = (
     Copy(bound = "P: BnConfig"),
     Debug(bound = "P: BnConfig")
 )]
-struct G2HomProjective<P: BnConfig> {
+pub struct G2HomProjective<P: BnConfig> {
     x: Fp2<P::Fp2Config>,
     y: Fp2<P::Fp2Config>,
     z: Fp2<P::Fp2Config>,
 }
 
 impl<P: BnConfig> G2HomProjective<P> {
-    fn double_in_place(&mut self, two_inv: &P::Fp) -> EllCoeff<P> {
+    pub fn double_in_place(&mut self, two_inv: &P::Fp) -> EllCoeff<P> {
         // Formula for line function when working with
         // homogeneous projective coordinates.
 
@@ -76,7 +76,7 @@ impl<P: BnConfig> G2HomProjective<P> {
         }
     }
 
-    fn add_in_place(&mut self, q: &G2Affine<P>) -> EllCoeff<P> {
+    pub fn add_in_place(&mut self, q: &G2Affine<P>) -> EllCoeff<P> {
         // Formula for line function when working with
         // homogeneous projective coordinates.
         let theta = self.y - &(q.y * &self.z);

--- a/ec/src/models/bw6/g2.rs
+++ b/ec/src/models/bw6/g2.rs
@@ -35,7 +35,7 @@ pub struct G2Prepared<P: BW6Config> {
     Copy(bound = "P: BW6Config"),
     Debug(bound = "P: BW6Config")
 )]
-struct G2HomProjective<P: BW6Config> {
+pub struct G2HomProjective<P: BW6Config> {
     x: P::Fp,
     y: P::Fp,
     z: P::Fp,
@@ -147,7 +147,7 @@ impl<P: BW6Config> G2Prepared<P> {
 }
 
 impl<P: BW6Config> G2HomProjective<P> {
-    fn double_in_place(&mut self) -> (P::Fp, P::Fp, P::Fp) {
+    pub fn double_in_place(&mut self) -> (P::Fp, P::Fp, P::Fp) {
         // Formula for line function when working with
         // homogeneous projective coordinates, as described in
         // <https://eprint.iacr.org/2013/722.pdf>.
@@ -173,7 +173,7 @@ impl<P: BW6Config> G2HomProjective<P> {
         }
     }
 
-    fn add_in_place(&mut self, q: &G2Affine<P>) -> (P::Fp, P::Fp, P::Fp) {
+    pub fn add_in_place(&mut self, q: &G2Affine<P>) -> (P::Fp, P::Fp, P::Fp) {
         // Formula for line function when working with
         // homogeneous projective coordinates, as described in https://eprint.iacr.org/2013/722.pdf.
         let theta = self.y - &(q.y * &self.z);

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -110,11 +110,11 @@ impl<'a, P: MNT4Config> From<&'a G2Projective<P>> for G2Prepared<P> {
     }
 }
 
-pub(super) struct G2ProjectiveExtended<P: MNT4Config> {
-    pub(crate) x: Fp2<P::Fp2Config>,
-    pub(crate) y: Fp2<P::Fp2Config>,
-    pub(crate) z: Fp2<P::Fp2Config>,
-    pub(crate) t: Fp2<P::Fp2Config>,
+pub struct G2ProjectiveExtended<P: MNT4Config> {
+    pub x: Fp2<P::Fp2Config>,
+    pub y: Fp2<P::Fp2Config>,
+    pub z: Fp2<P::Fp2Config>,
+    pub t: Fp2<P::Fp2Config>,
 }
 
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -105,11 +105,11 @@ impl<'a, P: MNT6Config> From<&'a G2Projective<P>> for G2Prepared<P> {
     }
 }
 
-pub(super) struct G2ProjectiveExtended<P: MNT6Config> {
-    pub(crate) x: Fp3<P::Fp3Config>,
-    pub(crate) y: Fp3<P::Fp3Config>,
-    pub(crate) z: Fp3<P::Fp3Config>,
-    pub(crate) t: Fp3<P::Fp3Config>,
+pub struct G2ProjectiveExtended<P: MNT6Config> {
+    pub x: Fp3<P::Fp3Config>,
+    pub y: Fp3<P::Fp3Config>,
+    pub z: Fp3<P::Fp3Config>,
+    pub t: Fp3<P::Fp3Config>,
 }
 
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]


### PR DESCRIPTION
## Description

This PR proposes to make it possible for a caller to use Arkworks-rs to obtain the ell coeffs and use it in other places.

Without this change, in the BitVM example here (https://github.com/BitVM/BitVM/blob/main/src/bn254/ell_coeffs.rs), one who wants to use Arkworks-rs's algorithm to get the ell coeffs would need to copy-paste the code. 

This PR suggests that, since these ell coeffs are useful to the outside, it may be worthwhile to reveal them.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
