### PR TITLE
Fix the incorrect `Affine - Projective` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [\#747](https://github.com/arkworks-rs/algebra/pull/747) (`ark-ff-macros`) Fix fetching attributes in `MontConfig` macro.
 - [\#803](https://github.com/arkworks-rs/algebra/pull/803) (`ark-ec`, `ark-test-template`) Fix incorrect decomposition in GLV.
 - [\#806](https://github.com/arkworks-rs/algebra/pull/806) (`ark-ff`) Fix the impl for `Display`ing zero element in Fp.
+- [\#822](https://github.com/arkworks-rs/algebra/pull/822) (`ark-ec`, `ark-test-template`) Fix the incorrect `Affine - Projective` implementation
 
 ## v0.4.2
 

--- a/ec/src/models/short_weierstrass/affine.rs
+++ b/ec/src/models/short_weierstrass/affine.rs
@@ -305,14 +305,14 @@ impl<P: SWCurveConfig, T: Borrow<Self>> Sub<T> for Affine<P> {
 impl<P: SWCurveConfig> Sub<Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: Projective<P>) -> Projective<P> {
-        other - self
+        self.into_group() - other
     }
 }
 
 impl<'a, P: SWCurveConfig> Sub<&'a Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: &'a Projective<P>) -> Projective<P> {
-        *other - self
+        self.into_group() - other
     }
 }
 

--- a/ec/src/models/short_weierstrass/affine.rs
+++ b/ec/src/models/short_weierstrass/affine.rs
@@ -305,14 +305,14 @@ impl<P: SWCurveConfig, T: Borrow<Self>> Sub<T> for Affine<P> {
 impl<P: SWCurveConfig> Sub<Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: Projective<P>) -> Projective<P> {
-        self.into_group() - other
+        self + (-other)
     }
 }
 
 impl<'a, P: SWCurveConfig> Sub<&'a Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: &'a Projective<P>) -> Projective<P> {
-        self.into_group() - other
+        self + (-*other)
     }
 }
 

--- a/ec/src/models/twisted_edwards/affine.rs
+++ b/ec/src/models/twisted_edwards/affine.rs
@@ -255,14 +255,14 @@ impl<P: TECurveConfig, T: Borrow<Self>> Sub<T> for Affine<P> {
 impl<P: TECurveConfig> Sub<Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: Projective<P>) -> Projective<P> {
-        other - self
+        self.into_group() - other
     }
 }
 
 impl<'a, P: TECurveConfig> Sub<&'a Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: &'a Projective<P>) -> Projective<P> {
-        *other - self
+        self.into_group() - other
     }
 }
 

--- a/ec/src/models/twisted_edwards/affine.rs
+++ b/ec/src/models/twisted_edwards/affine.rs
@@ -255,14 +255,14 @@ impl<P: TECurveConfig, T: Borrow<Self>> Sub<T> for Affine<P> {
 impl<P: TECurveConfig> Sub<Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: Projective<P>) -> Projective<P> {
-        self.into_group() - other
+        self + (-other)
     }
 }
 
 impl<'a, P: TECurveConfig> Sub<&'a Projective<P>> for Affine<P> {
     type Output = Projective<P>;
     fn sub(self, other: &'a Projective<P>) -> Projective<P> {
-        self.into_group() - other
+        self + (-*other)
     }
 }
 

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -67,6 +67,9 @@ macro_rules! __test_group {
 
                 assert_eq!(a - zero, a);
                 assert_eq!(b - zero, b);
+
+                // Affine - Projective
+                assert_eq!(a.into_affine() - b, a - b);
             }
         }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR fixes the incorrect implementation of subtraction between an affine point and a projective point by flipping the position of subtrahend and minuend.

closes: #821

No performance regression due to this PR is observed (tested on Intel Core i9-12900k):

```
Arithmetic for Bls12_381::G1/Subtraction
                        time:   [443.13 ns 445.52 ns 448.43 ns]
                        change: [-0.7657% -0.0664% +0.5887%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code (N/A)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
