### PR TITLE
Move Hashbrown to be optional

### DIFF
--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -26,8 +26,8 @@ num-traits.workspace = true
 num-integer.workspace = true
 rayon = { workspace = true, optional = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
-hashbrown.workspace = true
 itertools.workspace = true
+hashbrown = { workspace = true, optional = true }
 
 [dev-dependencies]
 ark-test-curves = { workspace = true, features = ["bls12_381_curve"] }
@@ -37,8 +37,10 @@ serde.workspace = true
 serde_json.workspace = true
 serde_derive.workspace = true
 hex.workspace = true
+hashbrown.workspace = true
 
 [features]
 default = []
+variable_base_msm = ["hashbrown"]
 std = [ "ark-std/std", "ark-ff/std", "ark-serialize/std" ]
 parallel = [ "std", "rayon", "ark-std/parallel" ]

--- a/ec/src/models/short_weierstrass/group.rs
+++ b/ec/src/models/short_weierstrass/group.rs
@@ -1,8 +1,9 @@
 use super::{Affine, SWCurveConfig};
-use crate::{
-    scalar_mul::{variable_base::VariableBaseMSM, ScalarMul},
-    AffineRepr, CurveGroup, PrimeGroup,
-};
+use crate::{scalar_mul::ScalarMul, AffineRepr, CurveGroup, PrimeGroup};
+
+#[cfg(feature = "variable_base_msm")]
+use crate::scalar_mul::variable_base::VariableBaseMSM;
+
 use ark_ff::{fields::Field, AdditiveGroup, PrimeField, ToConstraintField, UniformRand};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
@@ -646,6 +647,7 @@ impl<P: SWCurveConfig> ScalarMul for Projective<P> {
     }
 }
 
+#[cfg(feature = "variable_base_msm")]
 impl<P: SWCurveConfig> VariableBaseMSM for Projective<P> {
     fn msm(bases: &[Self::MulBase], bigints: &[Self::ScalarField]) -> Result<Self, usize> {
         P::msm(bases, bigints)

--- a/ec/src/models/twisted_edwards/group.rs
+++ b/ec/src/models/twisted_edwards/group.rs
@@ -24,10 +24,10 @@ use zeroize::Zeroize;
 use rayon::prelude::*;
 
 use super::{Affine, MontCurveConfig, TECurveConfig};
-use crate::{
-    scalar_mul::{variable_base::VariableBaseMSM, ScalarMul},
-    AffineRepr, CurveGroup, PrimeGroup,
-};
+use crate::{scalar_mul::ScalarMul, AffineRepr, CurveGroup, PrimeGroup};
+
+#[cfg(feature = "variable_base_msm")]
+use crate::scalar_mul::variable_base::VariableBaseMSM;
 
 /// `Projective` implements Extended Twisted Edwards Coordinates
 /// as described in [\[HKCD08\]](https://eprint.iacr.org/2008/522.pdf).
@@ -500,6 +500,7 @@ impl<P: TECurveConfig> ScalarMul for Projective<P> {
     }
 }
 
+#[cfg(feature = "variable_base_msm")]
 impl<P: TECurveConfig> VariableBaseMSM for Projective<P> {
     fn msm(bases: &[Self::MulBase], bigints: &[Self::ScalarField]) -> Result<Self, usize> {
         P::msm(bases, bigints)

--- a/ec/src/pairing.rs
+++ b/ec/src/pairing.rs
@@ -17,7 +17,10 @@ use ark_std::{
 use derivative::Derivative;
 use zeroize::Zeroize;
 
-use crate::{AffineRepr, CurveGroup, PrimeGroup, VariableBaseMSM};
+use crate::{AffineRepr, CurveGroup, PrimeGroup};
+
+#[cfg(feature = "variable_base_msm")]
+use crate::VariableBaseMSM;
 
 /// Collection of types (mainly fields and curves) that together describe
 /// how to compute a pairing over a pairing-friendly curve.
@@ -324,6 +327,7 @@ impl<P: Pairing> crate::ScalarMul for PairingOutput<P> {
     }
 }
 
+#[cfg(feature = "variable_base_msm")]
 impl<P: Pairing> VariableBaseMSM for PairingOutput<P> {}
 
 /// Represents the output of the Miller loop of the pairing.

--- a/ec/src/scalar_mul/mod.rs
+++ b/ec/src/scalar_mul/mod.rs
@@ -1,6 +1,7 @@
 pub mod glv;
 pub mod wnaf;
 
+#[cfg(feature = "variable_base_msm")]
 pub mod variable_base;
 
 use crate::{

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -21,18 +21,18 @@ ark-serialize = { workspace = true, features = ["derive"] }
 ark-std.workspace = true
 rayon = { workspace = true, optional = true }
 derivative = { workspace = true, features = [ "use_core" ] }
-hashbrown.workspace = true
+hashbrown = { workspace = true, optional = true }
 
 [dev-dependencies]
 ark-test-curves = { path = "../test-curves", default-features = false, features = [ "bls12_381_curve", "bn384_small_two_adicity_curve", "mnt4_753_curve"] }
 criterion = "0.5.1"
-
+hashbrown.workspace = true
 
 [features]
 default = []
+multivariate = ["hashbrown"]
 std = [ "ark-std/std", "ark-ff/std" ]
 parallel = [ "std", "ark-ff/parallel", "rayon", "ark-std/parallel" ]
-
 
 [[bench]]
 name = "fft"

--- a/poly/src/evaluations/mod.rs
+++ b/poly/src/evaluations/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "multivariate")]
 pub mod multivariate;
+
 pub mod univariate;

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -29,12 +29,16 @@ pub mod polynomial;
 pub use domain::{
     EvaluationDomain, GeneralEvaluationDomain, MixedRadixEvaluationDomain, Radix2EvaluationDomain,
 };
+
+#[cfg(feature = "multivariate")]
 pub use evaluations::{
     multivariate::multilinear::{
         DenseMultilinearExtension, MultilinearExtension, SparseMultilinearExtension,
     },
     univariate::Evaluations,
 };
+
+pub use evaluations::univariate::Evaluations;
 pub use polynomial::{multivariate, univariate, DenseMVPolynomial, DenseUVPolynomial, Polynomial};
 
 #[cfg(test)]

--- a/test-templates/Cargo.toml
+++ b/test-templates/Cargo.toml
@@ -30,5 +30,5 @@ hex.workspace = true
 sha2.workspace = true
 
 [features]
-default = []
+default = ["ark-ec/variable_base_msm"]
 std = [ "ark-std/std", "ark-ff/std", "ark-serialize/std", "ark-ec/std" ]


### PR DESCRIPTION
## Description

Moves Hashbrown as optional dependency to allow compiling on systems without atomics. Long story short - unfortunately just making Hashbrown's `ahash` optional on the workspace will not solve everything as it removes `HashMap::new()` too, that is used in few places. Here is a variant that moves multivariate commits under feature flag, that were the only part that depends on the Hashbrown. At the moment benchmarks in `poly` part are broken as they depend on multivariate part. I believe it's possible to fix one way or another, just need to know which one.

Another option would be to try to make hash use explicit (and not use `ahash`), will be posted in alternative PR

Fixes #812 


- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
