### PR TITLE
Replace Ahash with Fnv for Hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,7 @@ num-integer = { version = "0.1", default-features = false }
 criterion = "0.5.0"
 derivative = "2"
 digest = { version = "0.10", default-features = false }
-hashbrown = { version = "0.14", default-features = false }
-fnv = { version = "1.0", default-features = false }
+hashbrown = { version = "0.14", default-features = false, features = ["inline-more", "allocator-api2"] }
 hex = "0.4"
 itertools = { version = "0.12", default-features = false }
 libtest-mimic = "0.7.0"
@@ -69,7 +68,6 @@ sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 blake2 = { version = "0.10", default-features = false }
 zeroize = { version = "1", default-features = false }
-
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ num-integer = { version = "0.1", default-features = false }
 criterion = "0.5.0"
 derivative = "2"
 digest = { version = "0.10", default-features = false }
-hashbrown = "0.14"
+hashbrown = { version = "0.14", default-features = false }
+fnv = { version = "1.0", default-features = false }
 hex = "0.4"
 itertools = { version = "0.12", default-features = false }
 libtest-mimic = "0.7.0"

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -27,8 +27,13 @@ num-integer.workspace = true
 rayon = { workspace = true, optional = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 hashbrown.workspace = true
-fnv.workspace = true
 itertools.workspace = true
+
+[target.'cfg(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr"))'.dependencies]
+ahash = { version = "0.8", default-features = false}
+
+[target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
+fnv = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 ark-test-curves = { workspace = true, features = ["bls12_381_curve"] }

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -27,6 +27,7 @@ num-integer.workspace = true
 rayon = { workspace = true, optional = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 hashbrown.workspace = true
+fnv.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]

--- a/ec/src/hashing/curve_maps/elligator2.rs
+++ b/ec/src/hashing/curve_maps/elligator2.rs
@@ -275,7 +275,8 @@ mod test {
             );
         }
 
-        let mut counts = HashMap::new();
+        let mut counts =
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
 
         let mode = map_range
             .iter()

--- a/ec/src/hashing/curve_maps/elligator2.rs
+++ b/ec/src/hashing/curve_maps/elligator2.rs
@@ -149,6 +149,24 @@ impl<P: Elligator2Config> MapToCurve<Projective<P>> for Elligator2Map<P> {
 
 #[cfg(test)]
 mod test {
+    #[cfg(all(
+        target_has_atomic = "8",
+        target_has_atomic = "16",
+        target_has_atomic = "32",
+        target_has_atomic = "64",
+        target_has_atomic = "ptr"
+    ))]
+    type DefaultHasher = ahash::AHasher;
+
+    #[cfg(not(all(
+        target_has_atomic = "8",
+        target_has_atomic = "16",
+        target_has_atomic = "32",
+        target_has_atomic = "64",
+        target_has_atomic = "ptr"
+    )))]
+    type DefaultHasher = fnv::FnvHasher;
+
     use crate::{
         hashing::{map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve},
         CurveConfig,
@@ -276,7 +294,7 @@ mod test {
         }
 
         let mut counts =
-            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<DefaultHasher>::default());
 
         let mode = map_range
             .iter()

--- a/ec/src/hashing/curve_maps/swu.rs
+++ b/ec/src/hashing/curve_maps/swu.rs
@@ -255,7 +255,8 @@ mod test {
             map_range.push(SWUMap::<TestSWUMapToCurveConfig>::map_to_curve(element).unwrap());
         }
 
-        let mut counts = HashMap::new();
+        let mut counts =
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
 
         let mode = map_range
             .iter()

--- a/ec/src/hashing/curve_maps/swu.rs
+++ b/ec/src/hashing/curve_maps/swu.rs
@@ -142,6 +142,24 @@ impl<P: SWUConfig> MapToCurve<Projective<P>> for SWUMap<P> {
 
 #[cfg(test)]
 mod test {
+    #[cfg(all(
+        target_has_atomic = "8",
+        target_has_atomic = "16",
+        target_has_atomic = "32",
+        target_has_atomic = "64",
+        target_has_atomic = "ptr"
+    ))]
+    type DefaultHasher = ahash::AHasher;
+
+    #[cfg(not(all(
+        target_has_atomic = "8",
+        target_has_atomic = "16",
+        target_has_atomic = "32",
+        target_has_atomic = "64",
+        target_has_atomic = "ptr"
+    )))]
+    type DefaultHasher = fnv::FnvHasher;
+
     use crate::{
         hashing::{map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve},
         CurveConfig,
@@ -256,7 +274,7 @@ mod test {
         }
 
         let mut counts =
-            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<DefaultHasher>::default());
 
         let mode = map_range
             .iter()

--- a/ec/src/scalar_mul/variable_base/mod.rs
+++ b/ec/src/scalar_mul/variable_base/mod.rs
@@ -9,6 +9,24 @@ pub use stream_pippenger::*;
 
 use super::ScalarMul;
 
+#[cfg(all(
+    target_has_atomic = "8",
+    target_has_atomic = "16",
+    target_has_atomic = "32",
+    target_has_atomic = "64",
+    target_has_atomic = "ptr"
+))]
+type DefaultHasher = ahash::AHasher;
+
+#[cfg(not(all(
+    target_has_atomic = "8",
+    target_has_atomic = "16",
+    target_has_atomic = "32",
+    target_has_atomic = "64",
+    target_has_atomic = "ptr"
+)))]
+type DefaultHasher = fnv::FnvHasher;
+
 pub trait VariableBaseMSM: ScalarMul {
     /// Computes an inner product between the [`PrimeField`] elements in `scalars`
     /// and the corresponding group elements in `bases`.

--- a/ec/src/scalar_mul/variable_base/stream_pippenger.rs
+++ b/ec/src/scalar_mul/variable_base/stream_pippenger.rs
@@ -67,7 +67,7 @@ impl<G: VariableBaseMSM> ChunkedPippenger<G> {
 
 /// Hash map struct for Pippenger algorithm.
 pub struct HashMapPippenger<G: VariableBaseMSM> {
-    buffer: HashMap<G::MulBase, G::ScalarField>,
+    buffer: HashMap<G::MulBase, G::ScalarField, core::hash::BuildHasherDefault<fnv::FnvHasher>>,
     result: G,
     buf_size: usize,
 }
@@ -76,7 +76,10 @@ impl<G: VariableBaseMSM> HashMapPippenger<G> {
     /// Produce a new hash map with the maximum msm buffer size.
     pub fn new(max_msm_buffer: usize) -> Self {
         Self {
-            buffer: HashMap::with_capacity(max_msm_buffer),
+            buffer: HashMap::with_capacity_and_hasher(
+                max_msm_buffer,
+                core::hash::BuildHasherDefault::<fnv::FnvHasher>::default(),
+            ),
             result: G::zero(),
             buf_size: max_msm_buffer,
         }

--- a/ec/src/scalar_mul/variable_base/stream_pippenger.rs
+++ b/ec/src/scalar_mul/variable_base/stream_pippenger.rs
@@ -4,7 +4,7 @@ use ark_ff::{PrimeField, Zero};
 use ark_std::{borrow::Borrow, vec::*};
 use hashbrown::HashMap;
 
-use super::VariableBaseMSM;
+use super::{DefaultHasher, VariableBaseMSM};
 
 /// Struct for the chunked Pippenger algorithm.
 pub struct ChunkedPippenger<G: VariableBaseMSM> {
@@ -67,7 +67,7 @@ impl<G: VariableBaseMSM> ChunkedPippenger<G> {
 
 /// Hash map struct for Pippenger algorithm.
 pub struct HashMapPippenger<G: VariableBaseMSM> {
-    buffer: HashMap<G::MulBase, G::ScalarField, core::hash::BuildHasherDefault<fnv::FnvHasher>>,
+    buffer: HashMap<G::MulBase, G::ScalarField, core::hash::BuildHasherDefault<DefaultHasher>>,
     result: G,
     buf_size: usize,
 }
@@ -78,7 +78,7 @@ impl<G: VariableBaseMSM> HashMapPippenger<G> {
         Self {
             buffer: HashMap::with_capacity_and_hasher(
                 max_msm_buffer,
-                core::hash::BuildHasherDefault::<fnv::FnvHasher>::default(),
+                core::hash::BuildHasherDefault::<DefaultHasher>::default(),
             ),
             result: G::zero(),
             buf_size: max_msm_buffer,

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -22,6 +22,7 @@ ark-std.workspace = true
 rayon = { workspace = true, optional = true }
 derivative = { workspace = true, features = [ "use_core" ] }
 hashbrown.workspace = true
+fnv.workspace = true
 
 [dev-dependencies]
 ark-test-curves = { path = "../test-curves", default-features = false, features = [ "bls12_381_curve", "bn384_small_two_adicity_curve", "mnt4_753_curve"] }

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -22,7 +22,12 @@ ark-std.workspace = true
 rayon = { workspace = true, optional = true }
 derivative = { workspace = true, features = [ "use_core" ] }
 hashbrown.workspace = true
-fnv.workspace = true
+
+[target.'cfg(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr"))'.dependencies]
+ahash = { version = "0.8", default-features = false}
+
+[target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
+fnv = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 ark-test-curves = { path = "../test-curves", default-features = false, features = [ "bls12_381_curve", "bn384_small_two_adicity_curve", "mnt4_753_curve"] }

--- a/poly/src/evaluations/multivariate/multilinear/mod.rs
+++ b/poly/src/evaluations/multivariate/multilinear/mod.rs
@@ -18,6 +18,24 @@ use ark_std::rand::Rng;
 
 use crate::Polynomial;
 
+#[cfg(all(
+    target_has_atomic = "8",
+    target_has_atomic = "16",
+    target_has_atomic = "32",
+    target_has_atomic = "64",
+    target_has_atomic = "ptr"
+))]
+type DefaultHasher = ahash::AHasher;
+
+#[cfg(not(all(
+    target_has_atomic = "8",
+    target_has_atomic = "16",
+    target_has_atomic = "32",
+    target_has_atomic = "64",
+    target_has_atomic = "ptr"
+)))]
+type DefaultHasher = fnv::FnvHasher;
+
 /// This trait describes an interface for the multilinear extension
 /// of an array.
 /// The latter is a multilinear polynomial represented in terms of its

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -66,7 +66,8 @@ impl<F: Field> SparseMultilinearExtension<F> {
     ) -> Self {
         assert!(num_nonzero_entries <= (1 << num_vars));
 
-        let mut map = HashMap::new();
+        let mut map =
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
         for _ in 0..num_nonzero_entries {
             let mut index = usize::rand(rng) & ((1 << num_vars) - 1);
             while map.get(&index).is_some() {
@@ -173,7 +174,8 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
             point = &point[focus_length..];
             let pre = precompute_eq(focus);
             let dim = focus.len();
-            let mut result = HashMap::new();
+            let mut result =
+                HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
             for src_entry in last.iter() {
                 let old_idx = *src_entry.0;
                 let gz = pre[old_idx & ((1 << dim) - 1)];
@@ -261,7 +263,8 @@ impl<'a, 'b, F: Field> Add<&'a SparseMultilinearExtension<F>>
             "trying to add non-zero polynomial with different number of variables"
         );
         // simply merge the evaluations
-        let mut evaluations = HashMap::new();
+        let mut evaluations =
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
         for (&i, &v) in self.evaluations.iter().chain(rhs.evaluations.iter()) {
             *(evaluations.entry(i).or_insert(F::zero())) += v;
         }
@@ -395,11 +398,13 @@ fn tuples_to_treemap<F: Field>(tuples: &[(usize, F)]) -> BTreeMap<usize, F> {
     BTreeMap::from_iter(tuples.iter().map(|(i, v)| (*i, *v)))
 }
 
-fn treemap_to_hashmap<F: Field>(map: &BTreeMap<usize, F>) -> HashMap<usize, F> {
+fn treemap_to_hashmap<F: Field>(
+    map: &BTreeMap<usize, F>,
+) -> HashMap<usize, F, core::hash::BuildHasherDefault<fnv::FnvHasher>> {
     HashMap::from_iter(map.iter().map(|(i, v)| (*i, *v)))
 }
 
-fn hashmap_to_treemap<F: Field>(map: &HashMap<usize, F>) -> BTreeMap<usize, F> {
+fn hashmap_to_treemap<F: Field, S>(map: &HashMap<usize, F, S>) -> BTreeMap<usize, F> {
     BTreeMap::from_iter(map.iter().map(|(i, v)| (*i, *v)))
 }
 

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -19,6 +19,8 @@ use hashbrown::HashMap;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+use super::DefaultHasher;
+
 /// Stores a multilinear polynomial in sparse evaluation form.
 #[derive(Clone, PartialEq, Eq, Hash, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct SparseMultilinearExtension<F: Field> {
@@ -67,7 +69,7 @@ impl<F: Field> SparseMultilinearExtension<F> {
         assert!(num_nonzero_entries <= (1 << num_vars));
 
         let mut map =
-            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<DefaultHasher>::default());
         for _ in 0..num_nonzero_entries {
             let mut index = usize::rand(rng) & ((1 << num_vars) - 1);
             while map.get(&index).is_some() {
@@ -175,7 +177,7 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
             let pre = precompute_eq(focus);
             let dim = focus.len();
             let mut result =
-                HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
+                HashMap::with_hasher(core::hash::BuildHasherDefault::<DefaultHasher>::default());
             for src_entry in last.iter() {
                 let old_idx = *src_entry.0;
                 let gz = pre[old_idx & ((1 << dim) - 1)];
@@ -264,7 +266,7 @@ impl<'a, 'b, F: Field> Add<&'a SparseMultilinearExtension<F>>
         );
         // simply merge the evaluations
         let mut evaluations =
-            HashMap::with_hasher(core::hash::BuildHasherDefault::<fnv::FnvHasher>::default());
+            HashMap::with_hasher(core::hash::BuildHasherDefault::<DefaultHasher>::default());
         for (&i, &v) in self.evaluations.iter().chain(rhs.evaluations.iter()) {
             *(evaluations.entry(i).or_insert(F::zero())) += v;
         }
@@ -400,7 +402,7 @@ fn tuples_to_treemap<F: Field>(tuples: &[(usize, F)]) -> BTreeMap<usize, F> {
 
 fn treemap_to_hashmap<F: Field>(
     map: &BTreeMap<usize, F>,
-) -> HashMap<usize, F, core::hash::BuildHasherDefault<fnv::FnvHasher>> {
+) -> HashMap<usize, F, core::hash::BuildHasherDefault<DefaultHasher>> {
     HashMap::from_iter(map.iter().map(|(i, v)| (*i, *v)))
 }
 


### PR DESCRIPTION
Alternative to #824 , will fix #812 too for systems without atomics. Fnv provides no key randomization, but it shouldn't be required for commitment scheme.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
