### PR TITLE
Replace derivative with educe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 
 criterion = "0.5.0"
-derivative = "2"
+educe = "0.5.0"
 digest = { version = "0.10", default-features = false }
 hashbrown = "0.14"
 hex = "0.4"

--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -20,7 +20,7 @@ ark-std.workspace = true
 ark-serialize.workspace = true
 ark-ff.workspace = true
 ark-poly.workspace = true
-derivative = { workspace = true, features = ["use_core"] }
+educe.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
 num-integer.workspace = true

--- a/ec/src/models/bls12/g1.rs
+++ b/ec/src/models/bls12/g1.rs
@@ -5,18 +5,13 @@ use crate::{
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::*;
-use derivative::Derivative;
+use educe::Educe;
 
 pub type G1Affine<P> = Affine<<P as Bls12Config>::G1Config>;
 pub type G1Projective<P> = Projective<<P as Bls12Config>::G1Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: Bls12Config"),
-    Debug(bound = "P: Bls12Config"),
-    PartialEq(bound = "P: Bls12Config"),
-    Eq(bound = "P: Bls12Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct G1Prepared<P: Bls12Config>(pub G1Affine<P>);
 
 impl<P: Bls12Config> From<G1Affine<P>> for G1Prepared<P> {

--- a/ec/src/models/bls12/g2.rs
+++ b/ec/src/models/bls12/g2.rs
@@ -1,7 +1,7 @@
 use ark_ff::{AdditiveGroup, BitIteratorBE, Field, Fp2};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{vec::*, One};
-use derivative::Derivative;
+use educe::Educe;
 
 use crate::{
     bls12::{Bls12Config, TwistType},
@@ -13,13 +13,8 @@ use crate::{
 pub type G2Affine<P> = Affine<<P as Bls12Config>::G2Config>;
 pub type G2Projective<P> = Projective<<P as Bls12Config>::G2Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: Bls12Config"),
-    Debug(bound = "P: Bls12Config"),
-    PartialEq(bound = "P: Bls12Config"),
-    Eq(bound = "P: Bls12Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct G2Prepared<P: Bls12Config> {
     /// Stores the coefficients of the line evaluations as calculated in
     /// <https://eprint.iacr.org/2013/722.pdf>
@@ -33,12 +28,8 @@ pub type EllCoeff<P> = (
     Fp2<<P as Bls12Config>::Fp2Config>,
 );
 
-#[derive(Derivative)]
-#[derivative(
-    Clone(bound = "P: Bls12Config"),
-    Copy(bound = "P: Bls12Config"),
-    Debug(bound = "P: Bls12Config")
-)]
+#[derive(Educe)]
+#[educe(Clone, Copy, Debug)]
 pub struct G2HomProjective<P: Bls12Config> {
     x: Fp2<P::Fp2Config>,
     y: Fp2<P::Fp2Config>,

--- a/ec/src/models/bls12/mod.rs
+++ b/ec/src/models/bls12/mod.rs
@@ -13,7 +13,7 @@ use ark_ff::{
     BitIteratorBE, CyclotomicMultSubgroup, Field, PrimeField,
 };
 use ark_std::{cfg_chunks_mut, marker::PhantomData, vec::*};
-use derivative::Derivative;
+use educe::Educe;
 use num_traits::{One, Zero};
 
 #[cfg(feature = "parallel")]
@@ -165,8 +165,8 @@ pub use self::{
     g2::{G2Affine, G2Prepared, G2Projective},
 };
 
-#[derive(Derivative)]
-#[derivative(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Bls12<P: Bls12Config>(PhantomData<fn() -> P>);
 
 impl<P: Bls12Config> Bls12<P> {

--- a/ec/src/models/bn/g1.rs
+++ b/ec/src/models/bn/g1.rs
@@ -5,18 +5,13 @@ use crate::{
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::*;
-use derivative::Derivative;
+use educe::Educe;
 
 pub type G1Affine<P> = Affine<<P as BnConfig>::G1Config>;
 pub type G1Projective<P> = Projective<<P as BnConfig>::G1Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: BnConfig"),
-    Debug(bound = "P: BnConfig"),
-    PartialEq(bound = "P: BnConfig"),
-    Eq(bound = "P: BnConfig")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct G1Prepared<P: BnConfig>(pub G1Affine<P>);
 
 impl<P: BnConfig> From<G1Affine<P>> for G1Prepared<P> {

--- a/ec/src/models/bn/g2.rs
+++ b/ec/src/models/bn/g2.rs
@@ -4,7 +4,7 @@ use ark_ff::{
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::*;
-use derivative::Derivative;
+use educe::Educe;
 use num_traits::One;
 
 use crate::{
@@ -17,13 +17,8 @@ use crate::{
 pub type G2Affine<P> = Affine<<P as BnConfig>::G2Config>;
 pub type G2Projective<P> = Projective<<P as BnConfig>::G2Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: BnConfig"),
-    Debug(bound = "P: BnConfig"),
-    PartialEq(bound = "P: BnConfig"),
-    Eq(bound = "P: BnConfig")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct G2Prepared<P: BnConfig> {
     /// Stores the coefficients of the line evaluations as calculated in
     /// <https://eprint.iacr.org/2013/722.pdf>
@@ -37,12 +32,8 @@ pub type EllCoeff<P> = (
     Fp2<<P as BnConfig>::Fp2Config>,
 );
 
-#[derive(Derivative)]
-#[derivative(
-    Clone(bound = "P: BnConfig"),
-    Copy(bound = "P: BnConfig"),
-    Debug(bound = "P: BnConfig")
-)]
+#[derive(Educe)]
+#[educe(Clone, Copy, Debug)]
 pub struct G2HomProjective<P: BnConfig> {
     x: Fp2<P::Fp2Config>,
     y: Fp2<P::Fp2Config>,

--- a/ec/src/models/bn/mod.rs
+++ b/ec/src/models/bn/mod.rs
@@ -12,7 +12,7 @@ use ark_ff::{
     CyclotomicMultSubgroup,
 };
 use ark_std::{cfg_chunks_mut, marker::PhantomData, vec::*};
-use derivative::Derivative;
+use educe::Educe;
 use itertools::Itertools;
 use num_traits::One;
 
@@ -175,8 +175,8 @@ pub use self::{
     g2::{G2Affine, G2Prepared, G2Projective},
 };
 
-#[derive(Derivative)]
-#[derivative(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Bn<P: BnConfig>(PhantomData<fn() -> P>);
 
 impl<P: BnConfig> Bn<P> {

--- a/ec/src/models/bw6/g1.rs
+++ b/ec/src/models/bw6/g1.rs
@@ -5,19 +5,13 @@ use crate::{
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::*;
-use derivative::Derivative;
+use educe::Educe;
 
 pub type G1Affine<P> = Affine<<P as BW6Config>::G1Config>;
 pub type G1Projective<P> = Projective<<P as BW6Config>::G1Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Copy(bound = "P: BW6Config"),
-    Clone(bound = "P: BW6Config"),
-    Debug(bound = "P: BW6Config"),
-    PartialEq(bound = "P: BW6Config"),
-    Eq(bound = "P: BW6Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct G1Prepared<P: BW6Config>(pub G1Affine<P>);
 
 impl<P: BW6Config> From<G1Affine<P>> for G1Prepared<P> {

--- a/ec/src/models/bw6/g2.rs
+++ b/ec/src/models/bw6/g2.rs
@@ -1,7 +1,7 @@
 use ark_ff::{AdditiveGroup, BitIteratorBE, Field};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::*;
-use derivative::Derivative;
+use educe::Educe;
 use num_traits::One;
 
 use crate::{
@@ -14,13 +14,8 @@ use crate::{
 pub type G2Affine<P> = Affine<<P as BW6Config>::G2Config>;
 pub type G2Projective<P> = Projective<<P as BW6Config>::G2Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: BW6Config"),
-    Debug(bound = "P: BW6Config"),
-    PartialEq(bound = "P: BW6Config"),
-    Eq(bound = "P: BW6Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct G2Prepared<P: BW6Config> {
     /// Stores the coefficients of the line evaluations as calculated in
     /// <https://eprint.iacr.org/2013/722.pdf>
@@ -29,12 +24,8 @@ pub struct G2Prepared<P: BW6Config> {
     pub infinity: bool,
 }
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: BW6Config"),
-    Copy(bound = "P: BW6Config"),
-    Debug(bound = "P: BW6Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Copy, Debug)]
 pub struct G2HomProjective<P: BW6Config> {
     x: P::Fp,
     y: P::Fp,

--- a/ec/src/models/bw6/mod.rs
+++ b/ec/src/models/bw6/mod.rs
@@ -11,7 +11,7 @@ use ark_ff::{
     BitIteratorBE, CyclotomicMultSubgroup,
 };
 use ark_std::cfg_chunks_mut;
-use derivative::Derivative;
+use educe::Educe;
 use itertools::Itertools;
 use num_traits::One;
 
@@ -185,8 +185,8 @@ pub use self::{
     g2::{G2Affine, G2Prepared, G2Projective},
 };
 
-#[derive(Derivative)]
-#[derivative(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct BW6<P: BW6Config>(PhantomData<fn() -> P>);
 
 impl<P: BW6Config> BW6<P> {

--- a/ec/src/models/mnt4/g1.rs
+++ b/ec/src/models/mnt4/g1.rs
@@ -6,19 +6,13 @@ use crate::{
 use ark_ff::Fp2;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::*;
-use derivative::Derivative;
+use educe::Educe;
 
 pub type G1Affine<P> = Affine<<P as MNT4Config>::G1Config>;
 pub type G1Projective<P> = Projective<<P as MNT4Config>::G1Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Copy(bound = "P: MNT4Config"),
-    Clone(bound = "P: MNT4Config"),
-    Debug(bound = "P: MNT4Config"),
-    PartialEq(bound = "P: MNT4Config"),
-    Eq(bound = "P: MNT4Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct G1Prepared<P: MNT4Config> {
     pub x: P::Fp,
     pub y: P::Fp,

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -9,19 +9,14 @@ use crate::{
 use ark_ff::fields::{Field, Fp2};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{vec, vec::*};
-use derivative::Derivative;
+use educe::Educe;
 use num_traits::One;
 
 pub type G2Affine<P> = Affine<<P as MNT4Config>::G2Config>;
 pub type G2Projective<P> = Projective<<P as MNT4Config>::G2Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: MNT4Config"),
-    Debug(bound = "P: MNT4Config"),
-    PartialEq(bound = "P: MNT4Config"),
-    Eq(bound = "P: MNT4Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct G2Prepared<P: MNT4Config> {
     pub x: Fp2<P::Fp2Config>,
     pub y: Fp2<P::Fp2Config>,
@@ -117,13 +112,8 @@ pub struct G2ProjectiveExtended<P: MNT4Config> {
     pub t: Fp2<P::Fp2Config>,
 }
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: MNT4Config"),
-    Debug(bound = "P: MNT4Config"),
-    PartialEq(bound = "P: MNT4Config"),
-    Eq(bound = "P: MNT4Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct AteDoubleCoefficients<P: MNT4Config> {
     pub c_h: Fp2<P::Fp2Config>,
     pub c_4c: Fp2<P::Fp2Config>,
@@ -131,13 +121,8 @@ pub struct AteDoubleCoefficients<P: MNT4Config> {
     pub c_l: Fp2<P::Fp2Config>,
 }
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: MNT4Config"),
-    Debug(bound = "P: MNT4Config"),
-    PartialEq(bound = "P: MNT4Config"),
-    Eq(bound = "P: MNT4Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct AteAdditionCoefficients<P: MNT4Config> {
     pub c_l1: Fp2<P::Fp2Config>,
     pub c_rz: Fp2<P::Fp2Config>,

--- a/ec/src/models/mnt4/mod.rs
+++ b/ec/src/models/mnt4/mod.rs
@@ -7,7 +7,7 @@ use ark_ff::{
     fp4::{Fp4, Fp4Config},
     AdditiveGroup, CyclotomicMultSubgroup, Field, PrimeField,
 };
-use derivative::Derivative;
+use educe::Educe;
 use itertools::Itertools;
 use num_traits::{One, Zero};
 
@@ -74,8 +74,8 @@ pub trait MNT4Config: 'static + Sized {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct MNT4<P: MNT4Config>(PhantomData<fn() -> P>);
 
 impl<P: MNT4Config> MNT4<P> {

--- a/ec/src/models/mnt6/g1.rs
+++ b/ec/src/models/mnt6/g1.rs
@@ -6,19 +6,13 @@ use crate::{
 use ark_ff::Fp3;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::vec::*;
-use derivative::Derivative;
+use educe::Educe;
 
 pub type G1Affine<P> = Affine<<P as MNT6Config>::G1Config>;
 pub type G1Projective<P> = Projective<<P as MNT6Config>::G1Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Copy(bound = "P: MNT6Config"),
-    Clone(bound = "P: MNT6Config"),
-    Debug(bound = "P: MNT6Config"),
-    PartialEq(bound = "P: MNT6Config"),
-    Eq(bound = "P: MNT6Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct G1Prepared<P: MNT6Config> {
     pub x: P::Fp,
     pub y: P::Fp,

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -7,19 +7,14 @@ use crate::{
 use ark_ff::fields::{Field, Fp3};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{ops::Neg, vec::*};
-use derivative::Derivative;
+use educe::Educe;
 use num_traits::One;
 
 pub type G2Affine<P> = Affine<<P as MNT6Config>::G2Config>;
 pub type G2Projective<P> = Projective<<P as MNT6Config>::G2Config>;
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: MNT6Config"),
-    Debug(bound = "P: MNT6Config"),
-    PartialEq(bound = "P: MNT6Config"),
-    Eq(bound = "P: MNT6Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct G2Prepared<P: MNT6Config> {
     pub x: Fp3<P::Fp3Config>,
     pub y: Fp3<P::Fp3Config>,
@@ -112,13 +107,8 @@ pub struct G2ProjectiveExtended<P: MNT6Config> {
     pub t: Fp3<P::Fp3Config>,
 }
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: MNT6Config"),
-    Debug(bound = "P: MNT6Config"),
-    PartialEq(bound = "P: MNT6Config"),
-    Eq(bound = "P: MNT6Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct AteDoubleCoefficients<P: MNT6Config> {
     pub c_h: Fp3<P::Fp3Config>,
     pub c_4c: Fp3<P::Fp3Config>,
@@ -126,13 +116,8 @@ pub struct AteDoubleCoefficients<P: MNT6Config> {
     pub c_l: Fp3<P::Fp3Config>,
 }
 
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(
-    Clone(bound = "P: MNT6Config"),
-    Debug(bound = "P: MNT6Config"),
-    PartialEq(bound = "P: MNT6Config"),
-    Eq(bound = "P: MNT6Config")
-)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, Debug, PartialEq, Eq)]
 pub struct AteAdditionCoefficients<P: MNT6Config> {
     pub c_l1: Fp3<P::Fp3Config>,
     pub c_rz: Fp3<P::Fp3Config>,

--- a/ec/src/models/mnt6/mod.rs
+++ b/ec/src/models/mnt6/mod.rs
@@ -7,7 +7,7 @@ use ark_ff::{
     fp6_2over3::{Fp6, Fp6Config},
     AdditiveGroup, CyclotomicMultSubgroup, Field, PrimeField,
 };
-use derivative::Derivative;
+use educe::Educe;
 use itertools::Itertools;
 use num_traits::{One, Zero};
 
@@ -75,8 +75,8 @@ pub trait MNT6Config: 'static + Sized {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct MNT6<P: MNT6Config>(PhantomData<fn() -> P>);
 
 impl<P: MNT6Config> MNT6<P> {

--- a/ec/src/models/short_weierstrass/affine.rs
+++ b/ec/src/models/short_weierstrass/affine.rs
@@ -16,7 +16,7 @@ use ark_std::{
 
 use ark_ff::{fields::Field, AdditiveGroup, PrimeField, ToConstraintField, UniformRand};
 
-use derivative::Derivative;
+use educe::Educe;
 use zeroize::Zeroize;
 
 use super::{Projective, SWCurveConfig, SWFlags};
@@ -24,14 +24,8 @@ use crate::AffineRepr;
 
 /// Affine coordinates for a point on an elliptic curve in short Weierstrass
 /// form, over the base field `P::BaseField`.
-#[derive(Derivative)]
-#[derivative(
-    Copy(bound = "P: SWCurveConfig"),
-    Clone(bound = "P: SWCurveConfig"),
-    PartialEq(bound = "P: SWCurveConfig"),
-    Eq(bound = "P: SWCurveConfig"),
-    Hash(bound = "P: SWCurveConfig")
-)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Hash)]
 #[must_use]
 pub struct Affine<P: SWCurveConfig> {
     #[doc(hidden)]

--- a/ec/src/models/short_weierstrass/group.rs
+++ b/ec/src/models/short_weierstrass/group.rs
@@ -20,7 +20,7 @@ use ark_std::{
     vec::*,
     One, Zero,
 };
-use derivative::Derivative;
+use educe::Educe;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use zeroize::Zeroize;
@@ -28,8 +28,8 @@ use zeroize::Zeroize;
 /// Jacobian coordinates for a point on an elliptic curve in short Weierstrass
 /// form, over the base field `P::BaseField`. This struct implements arithmetic
 /// via the Jacobian formulae
-#[derive(Derivative)]
-#[derivative(Copy(bound = "P: SWCurveConfig"), Clone(bound = "P: SWCurveConfig"))]
+#[derive(Educe)]
+#[educe(Copy, Clone)]
 #[must_use]
 pub struct Projective<P: SWCurveConfig> {
     /// `X / Z` projection of the affine `X`

--- a/ec/src/models/twisted_edwards/affine.rs
+++ b/ec/src/models/twisted_edwards/affine.rs
@@ -12,7 +12,7 @@ use ark_std::{
     },
     vec::*,
 };
-use derivative::Derivative;
+use educe::Educe;
 use num_traits::{One, Zero};
 use zeroize::Zeroize;
 
@@ -23,14 +23,8 @@ use crate::AffineRepr;
 
 /// Affine coordinates for a point on a twisted Edwards curve, over the
 /// base field `P::BaseField`.
-#[derive(Derivative)]
-#[derivative(
-    Copy(bound = "P: TECurveConfig"),
-    Clone(bound = "P: TECurveConfig"),
-    PartialEq(bound = "P: TECurveConfig"),
-    Eq(bound = "P: TECurveConfig"),
-    Hash(bound = "P: TECurveConfig")
-)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Hash)]
 #[must_use]
 pub struct Affine<P: TECurveConfig> {
     /// X coordinate of the point represented as a field element

--- a/ec/src/models/twisted_edwards/group.rs
+++ b/ec/src/models/twisted_edwards/group.rs
@@ -17,7 +17,7 @@ use ark_std::{
 
 use ark_ff::{fields::Field, AdditiveGroup, PrimeField, ToConstraintField, UniformRand};
 
-use derivative::Derivative;
+use educe::Educe;
 use zeroize::Zeroize;
 
 #[cfg(feature = "parallel")]
@@ -34,13 +34,8 @@ use crate::{
 ///
 /// This implementation uses the unified addition formulae from that paper (see
 /// Section 3.1).
-#[derive(Derivative)]
-#[derivative(
-    Copy(bound = "P: TECurveConfig"),
-    Clone(bound = "P: TECurveConfig"),
-    Eq(bound = "P: TECurveConfig"),
-    Debug(bound = "P: TECurveConfig")
-)]
+#[derive(Educe)]
+#[educe(Copy, Clone, Eq(bound(P: TECurveConfig)), Debug)]
 #[must_use]
 pub struct Projective<P: TECurveConfig> {
     pub x: P::BaseField,
@@ -408,15 +403,8 @@ impl<P: TECurveConfig> From<Affine<P>> for Projective<P> {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(
-    Copy(bound = "P: MontCurveConfig"),
-    Clone(bound = "P: MontCurveConfig"),
-    PartialEq(bound = "P: MontCurveConfig"),
-    Eq(bound = "P: MontCurveConfig"),
-    Debug(bound = "P: MontCurveConfig"),
-    Hash(bound = "P: MontCurveConfig")
-)]
+#[derive(Educe)]
+#[educe(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct MontgomeryAffine<P: MontCurveConfig> {
     pub x: P::BaseField,
     pub y: P::BaseField,

--- a/ec/src/pairing.rs
+++ b/ec/src/pairing.rs
@@ -14,7 +14,7 @@ use ark_std::{
     vec::*,
     UniformRand, Zero,
 };
-use derivative::Derivative;
+use educe::Educe;
 use zeroize::Zeroize;
 
 use crate::{AffineRepr, CurveGroup, PrimeGroup, VariableBaseMSM};
@@ -119,17 +119,8 @@ pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
 
 /// Represents the target group of a pairing. This struct is a
 /// wrapper around the field that the target group is embedded in.
-#[derive(Derivative)]
-#[derivative(
-    Copy(bound = "P: Pairing"),
-    Clone(bound = "P: Pairing"),
-    Debug(bound = "P: Pairing"),
-    PartialEq(bound = "P: Pairing"),
-    Eq(bound = "P: Pairing"),
-    PartialOrd(bound = "P: Pairing"),
-    Ord(bound = "P: Pairing"),
-    Hash(bound = "P: Pairing")
-)]
+#[derive(Educe)]
+#[educe(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[must_use]
 pub struct PairingOutput<P: Pairing>(pub P::TargetField);
 
@@ -327,16 +318,8 @@ impl<P: Pairing> crate::ScalarMul for PairingOutput<P> {
 impl<P: Pairing> VariableBaseMSM for PairingOutput<P> {}
 
 /// Represents the output of the Miller loop of the pairing.
-#[derive(Derivative)]
-#[derivative(
-    Copy(bound = "P: Pairing"),
-    Clone(bound = "P: Pairing"),
-    Debug(bound = "P: Pairing"),
-    PartialEq(bound = "P: Pairing"),
-    Eq(bound = "P: Pairing"),
-    PartialOrd(bound = "P: Pairing"),
-    Ord(bound = "P: Pairing")
-)]
+#[derive(Educe)]
+#[educe(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[must_use]
 pub struct MillerLoopOutput<P: Pairing>(pub P::TargetField);
 

--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -21,7 +21,7 @@ ark-ff-macros.workspace = true
 ark-std.workspace = true
 ark-serialize.workspace = true
 arrayvec = { version = "0.7", default-features = false }
-derivative = { workspace = true, features = ["use_core"] }
+educe.workspace = true
 num-traits.workspace = true
 paste.workspace = true
 rayon = { workspace = true, optional = true }

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -74,16 +74,8 @@ pub trait CubicExtConfig: 'static + Send + Sync + Sized {
 
 /// An element of a cubic extension field F_p\[X\]/(X^3 - P::NONRESIDUE) is
 /// represented as c0 + c1 * X + c2 * X^2, for c0, c1, c2 in `P::BaseField`.
-#[derive(Derivative)]
-#[derivative(
-    Default(bound = "P: CubicExtConfig"),
-    Hash(bound = "P: CubicExtConfig"),
-    Clone(bound = "P: CubicExtConfig"),
-    Copy(bound = "P: CubicExtConfig"),
-    Debug(bound = "P: CubicExtConfig"),
-    PartialEq(bound = "P: CubicExtConfig"),
-    Eq(bound = "P: CubicExtConfig")
-)]
+#[derive(Educe)]
+#[educe(Default, Hash, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CubicExtField<P: CubicExtConfig> {
     pub c0: P::BaseField,
     pub c1: P::BaseField,

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -101,23 +101,14 @@ pub trait FpConfig<const N: usize>: Send + Sync + 'static + Sized {
 
 /// Represents an element of the prime field F_p, where `p == P::MODULUS`.
 /// This type can represent elements in any field of size at most N * 64 bits.
-#[derive(Derivative)]
-#[derivative(
-    Default(bound = ""),
-    Hash(bound = ""),
-    Clone(bound = ""),
-    Copy(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = "")
-)]
+#[derive(Educe)]
+#[educe(Default, Hash, Clone, Copy, PartialEq, Eq)]
 pub struct Fp<P: FpConfig<N>, const N: usize>(
     /// Contains the element in Montgomery form for efficient multiplication.
     /// To convert an element to a [`BigInt`](struct@BigInt), use `into_bigint` or `into`.
     #[doc(hidden)]
     pub BigInt<N>,
-    #[derivative(Debug = "ignore")]
-    #[doc(hidden)]
-    pub PhantomData<P>,
+    #[doc(hidden)] pub PhantomData<P>,
 );
 
 pub type Fp64<P> = Fp<P, 1>;

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -108,7 +108,8 @@ pub struct Fp<P: FpConfig<N>, const N: usize>(
     /// To convert an element to a [`BigInt`](struct@BigInt), use `into_bigint` or `into`.
     #[doc(hidden)]
     pub BigInt<N>,
-    #[doc(hidden)] pub PhantomData<P>,
+    #[doc(hidden)] 
+    pub PhantomData<P>,
 );
 
 pub type Fp64<P> = Fp<P, 1>;

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -89,16 +89,8 @@ pub trait QuadExtConfig: 'static + Send + Sync + Sized {
 
 /// An element of a quadratic extension field F_p\[X\]/(X^2 - P::NONRESIDUE) is
 /// represented as c0 + c1 * X, for c0, c1 in `P::BaseField`.
-#[derive(Derivative)]
-#[derivative(
-    Default(bound = "P: QuadExtConfig"),
-    Hash(bound = "P: QuadExtConfig"),
-    Clone(bound = "P: QuadExtConfig"),
-    Copy(bound = "P: QuadExtConfig"),
-    Debug(bound = "P: QuadExtConfig"),
-    PartialEq(bound = "P: QuadExtConfig"),
-    Eq(bound = "P: QuadExtConfig")
-)]
+#[derive(Educe)]
+#[educe(Default, Hash, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct QuadExtField<P: QuadExtConfig> {
     /// Coefficient `c0` in the representation of the field element `c = c0 + c1 * X`
     pub c0: P::BaseField,

--- a/ff/src/lib.rs
+++ b/ff/src/lib.rs
@@ -14,7 +14,7 @@
 extern crate ark_std;
 
 #[macro_use]
-extern crate derivative;
+extern crate educe;
 
 #[macro_use]
 pub mod biginteger;

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -20,7 +20,7 @@ ark-ff.workspace = true
 ark-serialize = { workspace = true, features = ["derive"] }
 ark-std.workspace = true
 rayon = { workspace = true, optional = true }
-derivative = { workspace = true, features = [ "use_core" ] }
+educe.workspace = true
 hashbrown.workspace = true
 
 [dev-dependencies]

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -16,7 +16,7 @@
 )]
 
 #[macro_use]
-extern crate derivative;
+extern crate educe;
 
 #[macro_use]
 extern crate ark_std;

--- a/poly/src/polynomial/multivariate/sparse.rs
+++ b/poly/src/polynomial/multivariate/sparse.rs
@@ -17,11 +17,11 @@ use ark_std::{
 use rayon::prelude::*;
 
 /// Stores a sparse multivariate polynomial in coefficient form.
-#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
-#[derivative(Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Educe, CanonicalSerialize, CanonicalDeserialize)]
+#[educe(Clone, PartialEq, Eq, Hash, Default)]
 pub struct SparsePolynomial<F: Field, T: Term> {
     /// The number of variables the polynomial supports
-    #[derivative(PartialEq = "ignore")]
+    #[educe(PartialEq(ignore))]
     pub num_vars: usize,
     /// List of each term along with its coefficient
     pub terms: Vec<(F, T)>,


### PR DESCRIPTION
## Description

This PR corresponds to #831 and replaces all derivative usage with educe, which is a more modern solution that has gained some popularity already. 

closes: #831

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
