### PR TITLE
Docs improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ To ensure a smooth workflow for all contributors, the following general procedur
     * Be sure to include a relevant changelog entry in the Pending section of CHANGELOG.md (see file for log format)
         * If the change is breaking, we may add migration instructions.
 
-Note that for very small or clear problems (such as typos), or well isolated improvements, it is not required to an open issue to submit a PR.
+Note that for very small or clear problems (such as typos), or well-isolated improvements, it is not required to an open issue to submit a PR.
 But be aware that for more complex problems/features touching multiple parts of the codebase, if a PR is opened before an adequate design discussion has taken place in a GitHub issue, that PR runs a larger likelihood of being rejected.
 
 Looking for a good place to start contributing? How about checking out some good first issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for considering making contributions to `algebra`!
 
-Contributing to this repository can be done in several forms, such as participating in discussion or proposing code changes.
+Contributing to this repository can be done in several forms, such as participating in discussions or proposing code changes.
 To ensure a smooth workflow for all contributors, the following general procedure for contributing has been established:
 
 1) Either open or find an issue you'd like to help with

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="https://discord.gg/UNtS7QXyPk"><img src="https://img.shields.io/discord/908465643727253524?label=Discord&logo=discord"></a>
 </p>
 
-The arkworks ecosystem consist of Rust libraries for designing and working with *zero knowledge succinct non-interactive arguments (zkSNARKs)*. This repository contains efficient implementations of the key algebraic components underlying zkSNARKs: finite fields, elliptic curves, and polynomials.
+The arkworks ecosystem consists of Rust libraries for designing and working with *zero knowledge succinct non-interactive arguments (zkSNARKs)*. This repository contains efficient implementations of the key algebraic components underlying zkSNARKs: finite fields, elliptic curves, and polynomials.
 
 This library is released under the MIT License and the Apache v2 License (see [License](#license)).
 


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.