### PR TITLE
Mul mle by scalar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [\#772](https://github.com/arkworks-rs/algebra/pull/772) (`ark-ff`) Implementation of `mul` method for `BigInteger`.
 - [\#794](https://github.com/arkworks-rs/algebra/pull/794) (`ark-ff`) Fix `wasm` compilation.
 - [\#837](https://github.com/arkworks-rs/algebra/pull/837) (`ark-serialize`) Fix array deserialization panic.
+- [\#845](https://github.com/arkworks-rs/algebra/pull/845) (`Algebra`) Implementation of `mul` method for `DenseMultilinearExtension<F> * F`.
 
 ### Breaking changes
 

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -11,7 +11,7 @@ use ark_std::{
     fmt::Formatter,
     iter::IntoIterator,
     log2,
-    ops::{Add, AddAssign, Index, Neg, Sub, SubAssign},
+    ops::{Add, AddAssign, Index, Mul, MulAssign, Neg, Sub, SubAssign},
     rand::Rng,
     slice::{Iter, IterMut},
     vec::*,
@@ -331,6 +331,46 @@ impl<'a, F: Field> SubAssign<&'a DenseMultilinearExtension<F>> for DenseMultilin
     }
 }
 
+impl<F: Field> Mul<F> for DenseMultilinearExtension<F> {
+    type Output = DenseMultilinearExtension<F>;
+
+    fn mul(self, scalar: F) -> Self::Output {
+        &self * &scalar
+    }
+}
+
+impl<'a, 'b, F: Field> Mul<&'a F> for &'b DenseMultilinearExtension<F> {
+    type Output = DenseMultilinearExtension<F>;
+
+    fn mul(self, scalar: &'a F) -> Self::Output {
+        if scalar.is_zero() {
+            return DenseMultilinearExtension::zero();
+        } else if scalar.is_one() {
+            return self.clone();
+        }
+        let result: Vec<F> = self.evaluations.iter()
+            .map(|&x| x * scalar)
+            .collect();
+
+        DenseMultilinearExtension {
+            num_vars: self.num_vars,
+            evaluations: result,
+        }
+    }
+}
+
+impl <F: Field> MulAssign<F> for DenseMultilinearExtension<F> {
+    fn mul_assign(&mut self, scalar: F) {
+        *self = &*self * &scalar
+    }
+}
+
+impl <'a, F: Field> MulAssign<&'a F> for DenseMultilinearExtension<F> {
+    fn mul_assign(&mut self, scalar: &'a F) {
+        *self = &*self * scalar
+    }
+}
+
 impl<F: Field> fmt::Debug for DenseMultilinearExtension<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "DenseML(nv = {}, evaluations = [", self.num_vars)?;
@@ -394,7 +434,7 @@ impl<F: Field> Polynomial<F> for DenseMultilinearExtension<F> {
 #[cfg(test)]
 mod tests {
     use crate::{DenseMultilinearExtension, MultilinearExtension, Polynomial};
-    use ark_ff::{Field, Zero};
+    use ark_ff::{Field, One, Zero};
     use ark_std::{ops::Neg, test_rng, vec::*, UniformRand};
     use ark_test_curves::bls12_381::Fr;
 
@@ -471,6 +511,7 @@ mod tests {
         const NV: usize = 10;
         let mut rng = test_rng();
         for _ in 0..20 {
+            let scalar = Fr::rand(&mut rng);
             let point: Vec<_> = (0..NV).map(|_| Fr::rand(&mut rng)).collect();
             let poly1 = DenseMultilinearExtension::rand(NV, &mut rng);
             let poly2 = DenseMultilinearExtension::rand(NV, &mut rng);
@@ -482,6 +523,8 @@ mod tests {
             assert_eq!((&poly1 - &poly2).evaluate(&point), v1 - v2);
             // test negate
             assert_eq!(poly1.clone().neg().evaluate(&point), -v1);
+            // test mul poly by scalar
+            assert_eq!((&poly1 * &scalar).evaluate(&point), v1 * scalar);
             // test add assign
             {
                 let mut poly1 = poly1.clone();
@@ -514,6 +557,16 @@ mod tests {
                     zero += (scalar, &poly1);
                     assert_eq!(zero.evaluate(&point), scalar * v1);
                 }
+            }
+            // test mul_assign for poly * scalar
+            {
+                let mut poly1_cloned = poly1.clone();
+                poly1_cloned *= Fr::one();
+                assert_eq!(poly1_cloned.evaluate(&point), v1);
+                poly1_cloned *= scalar;
+                assert_eq!(poly1_cloned.evaluate(&point), v1 * scalar);
+                poly1_cloned *= Fr::zero();
+                assert_eq!(poly1_cloned, DenseMultilinearExtension::zero());
             }
         }
     }

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -348,9 +348,7 @@ impl<'a, 'b, F: Field> Mul<&'a F> for &'b DenseMultilinearExtension<F> {
         } else if scalar.is_one() {
             return self.clone();
         }
-        let result: Vec<F> = self.evaluations.iter()
-            .map(|&x| x * scalar)
-            .collect();
+        let result: Vec<F> = self.evaluations.iter().map(|&x| x * scalar).collect();
 
         DenseMultilinearExtension {
             num_vars: self.num_vars,
@@ -359,13 +357,13 @@ impl<'a, 'b, F: Field> Mul<&'a F> for &'b DenseMultilinearExtension<F> {
     }
 }
 
-impl <F: Field> MulAssign<F> for DenseMultilinearExtension<F> {
+impl<F: Field> MulAssign<F> for DenseMultilinearExtension<F> {
     fn mul_assign(&mut self, scalar: F) {
         *self = &*self * &scalar
     }
 }
 
-impl <'a, F: Field> MulAssign<&'a F> for DenseMultilinearExtension<F> {
+impl<'a, F: Field> MulAssign<&'a F> for DenseMultilinearExtension<F> {
     fn mul_assign(&mut self, scalar: &'a F) {
         *self = &*self * scalar
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Implements Mul<F> for DenseMultilinearExtension<F> and similar Mul Functions. 

Currently to multiply a DenseMultilinearExtension by a Scalar, one has to iterate over the evaluations field and manually create a new object. Implementing the Mul and MulAssign functions for DenseMultilinearExtension * F will simplify the code for this very fundamental and common operation.

closes: #844 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
