### PR TITLE
affine versioned pairing supporting for BitVM

### DIFF
--- a/ec/src/models/bn/g2.rs
+++ b/ec/src/models/bn/g2.rs
@@ -40,6 +40,88 @@ pub struct G2HomProjective<P: BnConfig> {
     z: Fp2<P::Fp2Config>,
 }
 
+impl<P: BnConfig> G2Prepared<P> {
+    fn affine_double_in_place(t: &mut G2Affine<P>, three_div_two: &P::Fp) -> EllCoeff<P> {
+        //  for affine coordinates
+        //  slope: alpha = 3 * x^2 / 2 * y
+        let mut alpha = t.x.square();
+        alpha /= t.y;
+        alpha.mul_assign_by_fp(&three_div_two);
+        let bias = t.y - alpha * t.x;
+
+        // update T
+        // T.x = alpha^2 - 2 * t.x
+        // T.y = -bias - alpha * T.x
+        let tx = alpha.square() - t.x.double();
+        t.y = -bias - alpha * tx;
+        t.x = tx;
+
+        (Fp2::<P::Fp2Config>::ONE, alpha, -bias)
+    }
+
+    fn affine_add_in_place(t: &mut G2Affine<P>, q: &G2Affine<P>) -> EllCoeff<P> {
+        // alpha = (t.y - q.y) / (t.x - q.x)
+        // bias = t.y - alpha * t.x
+        let alpha = (t.y - q.y) / (t.x - q.x);
+        let bias = t.y - alpha * t.x;
+
+        // update T
+        // T.x = alpha^2 - t.x - q.x
+        // T.y = -bias - alpha * T.x
+        let tx = alpha.square() - t.x - q.x;
+        t.y = -bias - alpha * tx;
+        t.x = tx;
+
+        (Fp2::<P::Fp2Config>::ONE, alpha, -bias)
+    }
+
+    /// !!! this method cannot be used directly for users, so we need reuse the `from` trait already exists
+    fn from_affine(q: G2Affine<P>) -> Self {
+        if q.infinity {
+            G2Prepared {
+                ell_coeffs: vec![],
+                infinity: true,
+            }
+        } else {
+            // let two_inv = P::Fp::one().double().inverse().unwrap();
+            let two_inv = P::Fp::one().double().inverse().unwrap();
+            let three_div_two = (P::Fp::one().double() + P::Fp::one()) * two_inv;
+
+            let mut ell_coeffs = vec![];
+            let mut r = q.clone();
+
+            let neg_q = -q;
+
+            for bit in P::ATE_LOOP_COUNT.iter().rev().skip(1) {
+                ell_coeffs.push(Self::affine_double_in_place(&mut r, &three_div_two));
+
+                match bit {
+                    1 => ell_coeffs.push(Self::affine_add_in_place(&mut r, &q)),
+                    -1 => ell_coeffs.push(Self::affine_add_in_place(&mut r, &neg_q)),
+                    _ => continue,
+                }
+            }
+
+            let q1 = mul_by_char::<P>(q);
+            let mut q2 = mul_by_char::<P>(q1);
+
+            if P::X_IS_NEGATIVE {
+                r.y = -r.y;
+            }
+
+            q2.y = -q2.y;
+
+            ell_coeffs.push(Self::affine_add_in_place(&mut r, &q1));
+            ell_coeffs.push(Self::affine_add_in_place(&mut r, &q2));
+
+            Self {
+                ell_coeffs,
+                infinity: false,
+            }
+        }
+    }
+}
+
 impl<P: BnConfig> G2HomProjective<P> {
     pub fn double_in_place(&mut self, two_inv: &P::Fp) -> EllCoeff<P> {
         // Formula for line function when working with
@@ -96,8 +178,24 @@ impl<P: BnConfig> Default for G2Prepared<P> {
     }
 }
 
+/// !!! affine mode is for the purpose of verifying pairings
 impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
     fn from(q: G2Affine<P>) -> Self {
+        if q.infinity {
+            G2Prepared {
+                ell_coeffs: vec![],
+                infinity: true,
+            }
+        } else {
+            Self::from_affine(q)
+        }
+    }
+}
+
+/// !!! projective mode is for the purpose of computing pairings
+impl<P: BnConfig> From<G2Projective<P>> for G2Prepared<P> {
+    fn from(q: G2Projective<P>) -> Self {
+        let q = q.into_affine();
         if q.infinity {
             G2Prepared {
                 ell_coeffs: vec![],
@@ -144,12 +242,6 @@ impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
     }
 }
 
-impl<P: BnConfig> From<G2Projective<P>> for G2Prepared<P> {
-    fn from(q: G2Projective<P>) -> Self {
-        q.into_affine().into()
-    }
-}
-
 impl<'a, P: BnConfig> From<&'a G2Affine<P>> for G2Prepared<P> {
     fn from(other: &'a G2Affine<P>) -> Self {
         (*other).into()
@@ -158,7 +250,7 @@ impl<'a, P: BnConfig> From<&'a G2Affine<P>> for G2Prepared<P> {
 
 impl<'a, P: BnConfig> From<&'a G2Projective<P>> for G2Prepared<P> {
     fn from(q: &'a G2Projective<P>) -> Self {
-        q.into_affine().into()
+        (*q).into()
     }
 }
 

--- a/ec/src/pairing.rs
+++ b/ec/src/pairing.rs
@@ -88,6 +88,14 @@ pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
         b: impl IntoIterator<Item = impl Into<Self::G2Prepared>>,
     ) -> MillerLoopOutput<Self>;
 
+    /// Computes the product of Miller loops for some number of (G1, G2) pairs, where the line functions are in affine mode
+    fn multi_miller_loop_affine(
+        a: impl IntoIterator<Item = impl Into<Self::G1Prepared>>,
+        b: impl IntoIterator<Item = impl Into<Self::G2Prepared>>,
+    ) -> MillerLoopOutput<Self> {
+        unimplemented!()
+    }
+
     /// Computes the Miller loop over `a` and `b`.
     fn miller_loop(
         a: impl Into<Self::G1Prepared>,
@@ -108,12 +116,28 @@ pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
         Self::final_exponentiation(Self::multi_miller_loop(a, b)).unwrap()
     }
 
+    /// Computes a "product" of pairings, where the line functions are in affine mode
+    fn multi_pairing_affine(
+        a: impl IntoIterator<Item = impl Into<Self::G1Prepared>>,
+        b: impl IntoIterator<Item = impl Into<Self::G2Prepared>>,
+    ) -> PairingOutput<Self> {
+        Self::final_exponentiation(Self::multi_miller_loop_affine(a, b)).unwrap()
+    }
+
     /// Performs multiple pairing operations
     fn pairing(
         p: impl Into<Self::G1Prepared>,
         q: impl Into<Self::G2Prepared>,
     ) -> PairingOutput<Self> {
         Self::multi_pairing([p], [q])
+    }
+
+    /// Performs multiple pairing operations, where the line functions are in affine mode
+    fn pairing_affine(
+        p: impl Into<Self::G1Prepared>,
+        q: impl Into<Self::G2Prepared>,
+    ) -> PairingOutput<Self> {
+        Self::multi_pairing_affine([p], [q])
     }
 }
 

--- a/test-templates/src/pairing.rs
+++ b/test-templates/src/pairing.rs
@@ -6,8 +6,9 @@ macro_rules! test_pairing {
             use ark_ec::{pairing::*, CurveGroup, PrimeGroup};
             use ark_ff::{CyclotomicMultSubgroup, Field, PrimeField};
             use ark_std::{test_rng, One, UniformRand, Zero};
+
             #[test]
-            fn test_bilinearity() {
+            fn test_bilinearity_projective() {
                 for _ in 0..100 {
                     let mut rng = test_rng();
                     let a: <$Pairing as Pairing>::G1 = UniformRand::rand(&mut rng);
@@ -36,7 +37,51 @@ macro_rules! test_pairing {
             }
 
             #[test]
-            fn test_multi_pairing() {
+            fn test_bilinearity_affine() {
+                for _ in 0..100 {
+                    let mut rng = test_rng();
+                    let a: <$Pairing as Pairing>::G1 = UniformRand::rand(&mut rng);
+                    let b: <$Pairing as Pairing>::G2 = UniformRand::rand(&mut rng);
+                    let s: <$Pairing as Pairing>::ScalarField = UniformRand::rand(&mut rng);
+
+                    let sa = a * s;
+                    let sb = b * s;
+
+                    let ans1 = <$Pairing>::pairing_affine(sa, b.into_affine());
+                    let ans2 = <$Pairing>::pairing_affine(a, sb.into_affine());
+                    let ans3 = <$Pairing>::pairing_affine(a, b.into_affine()) * s;
+
+                    assert_eq!(ans1, ans2);
+                    assert_eq!(ans2, ans3);
+
+                    assert_ne!(ans1, PairingOutput::zero());
+                    assert_ne!(ans2, PairingOutput::zero());
+                    assert_ne!(ans3, PairingOutput::zero());
+                    let group_order = <<$Pairing as Pairing>::ScalarField>::characteristic();
+
+                    assert_eq!(ans1.mul_bigint(group_order), PairingOutput::zero());
+                    assert_eq!(ans2.mul_bigint(group_order), PairingOutput::zero());
+                    assert_eq!(ans3.mul_bigint(group_order), PairingOutput::zero());
+                }
+            }
+
+            #[test]
+            fn test_multi_pairing_projective() {
+                for _ in 0..ITERATIONS {
+                    let rng = &mut test_rng();
+
+                    let a = <$Pairing as Pairing>::G1::rand(rng);
+                    let b = <$Pairing as Pairing>::G2::rand(rng);
+                    let c = <$Pairing as Pairing>::G1::rand(rng);
+                    let d = <$Pairing as Pairing>::G2::rand(rng);
+                    let ans1 = <$Pairing>::pairing(a, b) + &<$Pairing>::pairing(c, d);
+                    let ans2 = <$Pairing>::multi_pairing(&[a, c], &[b, d]);
+                    assert_eq!(ans1, ans2);
+                }
+            }
+
+            #[test]
+            fn test_multi_pairing_affine() {
                 for _ in 0..ITERATIONS {
                     let rng = &mut test_rng();
 
@@ -44,10 +89,24 @@ macro_rules! test_pairing {
                     let b = <$Pairing as Pairing>::G2::rand(rng).into_affine();
                     let c = <$Pairing as Pairing>::G1::rand(rng).into_affine();
                     let d = <$Pairing as Pairing>::G2::rand(rng).into_affine();
-                    let ans1 = <$Pairing>::pairing(a, b) + &<$Pairing>::pairing(c, d);
-                    let ans2 = <$Pairing>::multi_pairing(&[a, c], &[b, d]);
+                    let ans1 = <$Pairing>::pairing_affine(a, b) + &<$Pairing>::pairing_affine(c, d);
+                    let ans2 = <$Pairing>::multi_pairing_affine(&[a, c], &[b, d]);
                     assert_eq!(ans1, ans2);
                 }
+            }
+
+            #[test]
+            fn test_pairing_affine_vs_projective() {
+                let rng = &mut test_rng();
+
+                let a_proj = <$Pairing as Pairing>::G1::rand(rng);
+                let b_proj = <$Pairing as Pairing>::G2::rand(rng);
+                let a_affine = a_proj.into_affine();
+                let b_affine = b_proj.into_affine();
+
+                let ans1 = <$Pairing>::multi_pairing(&[a_proj], &[b_proj]);
+                let ans2 = <$Pairing>::multi_pairing_affine(&[a_affine], &[b_affine]);
+                assert_eq!(ans1, ans2);
             }
 
             #[test]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR propose is to give caller an another more option to choose when do pairing. In current implementation, the coefficients of divisor line function is computed through projective coordinates as it's more efficient (than affine coordinates) when computing pairings, while it's not when verifying pairings (recursive snark). As Andrija and Liam stated in 5.2 section of [On Proving Pairings](https://eprint.iacr.org/2024/640.pdf). 

So for supporting verifying pairings in [BitVM](https://github.com/BitVM/BitVM), I add one more option method for pairing. 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
