### PR TITLE
Add impl of FftField for Fp2 and Fp3

### DIFF
--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -1,6 +1,7 @@
 use crate::{
     fields::{Field, PrimeField},
-    AdditiveGroup, LegendreSymbol, One, SqrtPrecomputation, ToConstraintField, UniformRand, Zero,
+    AdditiveGroup, FftField, LegendreSymbol, One, SqrtPrecomputation, ToConstraintField,
+    UniformRand, Zero,
 };
 use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
@@ -769,4 +770,29 @@ mod cube_ext_tests {
             );
         }
     }
+}
+
+impl<P: CubicExtConfig> FftField for CubicExtField<P>
+where
+    P::BaseField: FftField,
+{
+    const GENERATOR: Self = Self::new(
+        P::BaseField::GENERATOR,
+        P::BaseField::ZERO,
+        P::BaseField::ZERO,
+    );
+    const TWO_ADICITY: u32 = P::BaseField::TWO_ADICITY;
+    const TWO_ADIC_ROOT_OF_UNITY: Self = Self::new(
+        P::BaseField::TWO_ADIC_ROOT_OF_UNITY,
+        P::BaseField::ZERO,
+        P::BaseField::ZERO,
+    );
+    const SMALL_SUBGROUP_BASE: Option<u32> = P::BaseField::SMALL_SUBGROUP_BASE;
+    const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = P::BaseField::SMALL_SUBGROUP_BASE_ADICITY;
+    const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<Self> =
+        if let Some(x) = P::BaseField::LARGE_SUBGROUP_ROOT_OF_UNITY {
+            Some(Self::new(x, P::BaseField::ZERO, P::BaseField::ZERO))
+        } else {
+            None
+        };
 }

--- a/ff/src/fields/models/fp2.rs
+++ b/ff/src/fields/models/fp2.rs
@@ -1,7 +1,5 @@
-use num_traits::ConstZero;
-
 use super::quadratic_extension::{QuadExtConfig, QuadExtField};
-use crate::{fields::PrimeField, CyclotomicMultSubgroup, FftField, Zero};
+use crate::{fields::PrimeField, CyclotomicMultSubgroup, Zero};
 use core::{marker::PhantomData, ops::Not};
 
 /// Trait that specifies constants and methods for defining degree-two extension fields.
@@ -138,21 +136,4 @@ impl<P: Fp2Config> CyclotomicMultSubgroup for Fp2<P> {
             self
         })
     }
-}
-
-impl<P: Fp2Config> FftField for Fp2<P>
-where
-    P::Fp: FftField + ConstZero,
-{
-    const GENERATOR: Self = Fp2::new(P::Fp::GENERATOR, P::Fp::ZERO);
-    const TWO_ADICITY: u32 = P::Fp::TWO_ADICITY;
-    const TWO_ADIC_ROOT_OF_UNITY: Self = Fp2::new(P::Fp::TWO_ADIC_ROOT_OF_UNITY, P::Fp::ZERO);
-    const SMALL_SUBGROUP_BASE: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE;
-    const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE_ADICITY;
-    const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<Self> =
-        if let Some(x) = P::Fp::LARGE_SUBGROUP_ROOT_OF_UNITY {
-            Some(Fp2::new(x, P::Fp::ZERO))
-        } else {
-            None
-        };
 }

--- a/ff/src/fields/models/fp2.rs
+++ b/ff/src/fields/models/fp2.rs
@@ -1,5 +1,7 @@
+use num_traits::ConstZero;
+
 use super::quadratic_extension::{QuadExtConfig, QuadExtField};
-use crate::{fields::PrimeField, CyclotomicMultSubgroup, Zero};
+use crate::{fields::PrimeField, CyclotomicMultSubgroup, FftField, Zero};
 use core::{marker::PhantomData, ops::Not};
 
 /// Trait that specifies constants and methods for defining degree-two extension fields.
@@ -136,4 +138,21 @@ impl<P: Fp2Config> CyclotomicMultSubgroup for Fp2<P> {
             self
         })
     }
+}
+
+impl<P: Fp2Config> FftField for Fp2<P>
+where
+    P::Fp: FftField + ConstZero,
+{
+    const GENERATOR: Self = Fp2::new(P::Fp::GENERATOR, P::Fp::ZERO);
+    const TWO_ADICITY: u32 = P::Fp::TWO_ADICITY;
+    const TWO_ADIC_ROOT_OF_UNITY: Self = Fp2::new(P::Fp::TWO_ADIC_ROOT_OF_UNITY, P::Fp::ZERO);
+    const SMALL_SUBGROUP_BASE: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE;
+    const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE_ADICITY;
+    const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<Self> =
+        if let Some(x) = P::Fp::LARGE_SUBGROUP_ROOT_OF_UNITY {
+            Some(Fp2::new(x, P::Fp::ZERO))
+        } else {
+            None
+        };
 }

--- a/ff/src/fields/models/fp3.rs
+++ b/ff/src/fields/models/fp3.rs
@@ -1,10 +1,5 @@
-use num_traits::ConstZero;
-
 use super::cubic_extension::{CubicExtConfig, CubicExtField};
-use crate::{
-    fields::{CyclotomicMultSubgroup, MulAssign, PrimeField, SqrtPrecomputation},
-    FftField,
-};
+use crate::fields::{CyclotomicMultSubgroup, MulAssign, PrimeField, SqrtPrecomputation};
 use core::marker::PhantomData;
 
 /// Trait that specifies constants and methods for defining degree-three extension fields.
@@ -105,21 +100,3 @@ impl<P: Fp3Config> Fp3<P> {
 
 // We just use the default algorithms; there don't seem to be any faster ones.
 impl<P: Fp3Config> CyclotomicMultSubgroup for Fp3<P> {}
-
-impl<P: Fp3Config> FftField for Fp3<P>
-where
-    P::Fp: FftField + ConstZero,
-{
-    const GENERATOR: Self = Fp3::new(P::Fp::GENERATOR, P::Fp::ZERO, P::Fp::ZERO);
-    const TWO_ADICITY: u32 = P::Fp::TWO_ADICITY;
-    const TWO_ADIC_ROOT_OF_UNITY: Self =
-        Fp3::new(P::Fp::TWO_ADIC_ROOT_OF_UNITY, P::Fp::ZERO, P::Fp::ZERO);
-    const SMALL_SUBGROUP_BASE: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE;
-    const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE_ADICITY;
-    const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<Self> =
-        if let Some(x) = P::Fp::LARGE_SUBGROUP_ROOT_OF_UNITY {
-            Some(Fp3::new(x, P::Fp::ZERO, P::Fp::ZERO))
-        } else {
-            None
-        };
-}

--- a/ff/src/fields/models/fp3.rs
+++ b/ff/src/fields/models/fp3.rs
@@ -1,5 +1,10 @@
+use num_traits::ConstZero;
+
 use super::cubic_extension::{CubicExtConfig, CubicExtField};
-use crate::fields::{CyclotomicMultSubgroup, MulAssign, PrimeField, SqrtPrecomputation};
+use crate::{
+    fields::{CyclotomicMultSubgroup, MulAssign, PrimeField, SqrtPrecomputation},
+    FftField,
+};
 use core::marker::PhantomData;
 
 /// Trait that specifies constants and methods for defining degree-three extension fields.
@@ -39,7 +44,6 @@ impl<P: Fp3Config> CubicExtConfig for Fp3ConfigWrapper<P> {
     type FrobCoeff = P::Fp;
 
     const DEGREE_OVER_BASE_PRIME_FIELD: usize = 3;
-
     const NONRESIDUE: Self::BaseField = P::NONRESIDUE;
 
     const SQRT_PRECOMP: Option<SqrtPrecomputation<CubicExtField<Self>>> =
@@ -101,3 +105,21 @@ impl<P: Fp3Config> Fp3<P> {
 
 // We just use the default algorithms; there don't seem to be any faster ones.
 impl<P: Fp3Config> CyclotomicMultSubgroup for Fp3<P> {}
+
+impl<P: Fp3Config> FftField for Fp3<P>
+where
+    P::Fp: FftField + ConstZero,
+{
+    const GENERATOR: Self = Fp3::new(P::Fp::GENERATOR, P::Fp::ZERO, P::Fp::ZERO);
+    const TWO_ADICITY: u32 = P::Fp::TWO_ADICITY;
+    const TWO_ADIC_ROOT_OF_UNITY: Self =
+        Fp3::new(P::Fp::TWO_ADIC_ROOT_OF_UNITY, P::Fp::ZERO, P::Fp::ZERO);
+    const SMALL_SUBGROUP_BASE: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE;
+    const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = P::Fp::SMALL_SUBGROUP_BASE_ADICITY;
+    const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<Self> =
+        if let Some(x) = P::Fp::LARGE_SUBGROUP_ROOT_OF_UNITY {
+            Some(Fp3::new(x, P::Fp::ZERO, P::Fp::ZERO))
+        } else {
+            None
+        };
+}

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -1,7 +1,7 @@
 use crate::{
     biginteger::BigInteger,
     fields::{Field, LegendreSymbol, PrimeField},
-    AdditiveGroup, One, SqrtPrecomputation, ToConstraintField, UniformRand, Zero,
+    AdditiveGroup, FftField, One, SqrtPrecomputation, ToConstraintField, UniformRand, Zero,
 };
 use ark_serialize::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
@@ -824,4 +824,22 @@ mod quad_ext_tests {
             );
         }
     }
+}
+
+impl<P: QuadExtConfig> FftField for QuadExtField<P>
+where
+    P::BaseField: FftField,
+{
+    const GENERATOR: Self = Self::new(P::BaseField::GENERATOR, P::BaseField::ZERO);
+    const TWO_ADICITY: u32 = P::BaseField::TWO_ADICITY;
+    const TWO_ADIC_ROOT_OF_UNITY: Self =
+        Self::new(P::BaseField::TWO_ADIC_ROOT_OF_UNITY, P::BaseField::ZERO);
+    const SMALL_SUBGROUP_BASE: Option<u32> = P::BaseField::SMALL_SUBGROUP_BASE;
+    const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = P::BaseField::SMALL_SUBGROUP_BASE_ADICITY;
+    const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<Self> =
+        if let Some(x) = P::BaseField::LARGE_SUBGROUP_ROOT_OF_UNITY {
+            Some(Self::new(x, P::BaseField::ZERO))
+        } else {
+            None
+        };
 }

--- a/poly/benches/fft.rs
+++ b/poly/benches/fft.rs
@@ -12,7 +12,7 @@ use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion
 
 // degree bounds to benchmark on
 // e.g. degree bound of 2^{15}, means we do an FFT for a degree (2^{15} - 1) polynomial
-const BENCHMARK_MIN_DEGREE: usize = 1 << 15;
+const BENCHMARK_MIN_DEGREE: usize = 1 << 4;
 const BENCHMARK_MAX_DEGREE_BLS12_381: usize = 1 << 22;
 const BENCHMARK_MAX_DEGREE_MNT6_753: usize = 1 << 17;
 const BENCHMARK_LOG_INTERVAL_DEGREE: usize = 1;

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -224,11 +224,9 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
         max_threads: usize,
         gap: usize,
     ) {
-        if xi.len() <= 16 {
+        if xi.len() <= MIN_INPUT_SIZE_FOR_PARALLELIZATION {
             xi.chunks_mut(chunk_size).for_each(|cxi| {
                 let (lo, hi) = cxi.split_at_mut(gap);
-                // If the chunk is sufficiently big that parallelism helps,
-                // we parallelize the butterfly operation within the chunk.
                 lo.iter_mut()
                     .zip(hi)
                     .zip(roots.iter().step_by(step))
@@ -240,7 +238,7 @@ impl<F: FftField> Radix2EvaluationDomain<F> {
                 // If the chunk is sufficiently big that parallelism helps,
                 // we parallelize the butterfly operation within the chunk.
 
-                if gap > MIN_GAP_SIZE_FOR_PARALLELISATION && num_chunks < max_threads {
+                if gap > MIN_GAP_SIZE_FOR_PARALLELIZATION && num_chunks < max_threads {
                     cfg_iter_mut!(lo)
                         .zip(hi)
                         .zip(cfg_iter!(roots).step_by(step))
@@ -361,7 +359,13 @@ const MIN_NUM_CHUNKS_FOR_COMPACTION: usize = 1 << 7;
 
 /// The minimum size of a chunk at which parallelization of `butterfly`s is
 /// beneficial. This value was chosen empirically.
-const MIN_GAP_SIZE_FOR_PARALLELISATION: usize = 1 << 10;
+const MIN_GAP_SIZE_FOR_PARALLELIZATION: usize = 1 << 10;
+
+
+/// The minimum size of a chunk at which parallelization of `butterfly`s is
+/// beneficial. This value was chosen empirically.
+const MIN_INPUT_SIZE_FOR_PARALLELIZATION: usize = 1 << 10;
+
 
 // minimum size at which to parallelize.
 #[cfg(feature = "parallel")]

--- a/poly/src/domain/radix2/fft.rs
+++ b/poly/src/domain/radix2/fft.rs
@@ -361,11 +361,9 @@ const MIN_NUM_CHUNKS_FOR_COMPACTION: usize = 1 << 7;
 /// beneficial. This value was chosen empirically.
 const MIN_GAP_SIZE_FOR_PARALLELIZATION: usize = 1 << 10;
 
-
 /// The minimum size of a chunk at which parallelization of `butterfly`s is
 /// beneficial. This value was chosen empirically.
 const MIN_INPUT_SIZE_FOR_PARALLELIZATION: usize = 1 << 10;
-
 
 // minimum size at which to parallelize.
 #[cfg(feature = "parallel")]


### PR DESCRIPTION
This pull request implements `FftField` for quadratic and cubic extension fields, when the base field is itself FFT-Friendly. 