### PR TITLE
Infallible div by vanishing poly

### DIFF
--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -170,12 +170,12 @@ impl<F: FftField> DensePolynomial<F> {
     pub fn divide_by_vanishing_poly<D: EvaluationDomain<F>>(
         &self,
         domain: D,
-    ) -> Option<(DensePolynomial<F>, DensePolynomial<F>)> {
+    ) -> (DensePolynomial<F>, DensePolynomial<F>) {
         let domain_size = domain.size();
 
         if self.coeffs.len() < domain_size {
             // If degree(self) < len(Domain), then the quotient is zero, and the entire polynomial is the remainder
-            Some((DensePolynomial::<F>::zero(), self.clone()))
+            (DensePolynomial::<F>::zero(), self.clone())
         } else {
             // Compute the quotient
             //
@@ -211,7 +211,7 @@ impl<F: FftField> DensePolynomial<F> {
 
             let quotient = DensePolynomial::<F>::from_coefficients_vec(quotient_vec);
             let remainder = DensePolynomial::<F>::from_coefficients_vec(remainder_vec);
-            Some((quotient, remainder))
+            (quotient, remainder)
         }
     }
 }
@@ -899,7 +899,7 @@ mod tests {
             let domain = GeneralEvaluationDomain::new(1 << size).unwrap();
             for degree in 0..12 {
                 let p = DensePolynomial::<Fr>::rand(degree * 100, rng);
-                let (quotient, remainder) = p.divide_by_vanishing_poly(domain).unwrap();
+                let (quotient, remainder) = p.divide_by_vanishing_poly(domain);
                 let p_recovered = quotient.mul_by_vanishing_poly(domain) + remainder;
                 assert_eq!(p, p_recovered);
             }

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -538,8 +538,7 @@ mod tests {
 
                 // Test interpolation works, by checking that interpolated polynomial agrees with the original on the domain
                 let (_q, r) = (dense_poly.clone() + -sparse_evals.interpolate())
-                    .divide_by_vanishing_poly(domain)
-                    .unwrap();
+                    .divide_by_vanishing_poly(domain);
                 assert_eq!(
                     r,
                     DensePolynomial::<Fr>::zero(),
@@ -550,8 +549,7 @@ mod tests {
 
                 // Consistency check that the dense polynomials interpolation is correct.
                 let (_q, r) = (dense_poly.clone() + -dense_evals.interpolate())
-                    .divide_by_vanishing_poly(domain)
-                    .unwrap();
+                    .divide_by_vanishing_poly(domain);
                 assert_eq!(
                     r,
                     DensePolynomial::<Fr>::zero(),


### PR DESCRIPTION
As it can't fail maybe is not worth returning an `Option`. Saves some "dummy" unwraps in downstream

---

This trivially changes the interface, I'm not sure if is really worth mentioning in Changelog