### PR TITLE
refactor: use simplified expression

### DIFF
--- a/ff-macros/src/unroll.rs
+++ b/ff-macros/src/unroll.rs
@@ -110,7 +110,7 @@ fn unroll(expr: &Expr, unroll_by: usize) -> Expr {
         }) = *pat.clone()
         {
             // Don't know how to deal with these so skip and return the original.
-            if !by_ref.is_none() || !mutability.is_none() || !subpat.is_none() {
+            if by_ref.is_some() || mutability.is_some() || subpat.is_some() {
                 return forloop_with_body(new_body);
             }
             let idx = ident; // got the index variable name


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This boolean expression can be simplified.

The whole notice from `cargo clippy`:


```go
warning: this boolean expression can be simplified
   --> ff-macros/src/unroll.rs:113:16
    |
113 |             if !by_ref.is_none() || !mutability.is_none() || !subpat.is_none() {
    |                ^^^^^^^^^^^^^^^^^ help: try: `by_ref.is_some()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool
    = note: `#[warn(clippy::nonminimal_bool)]` on by default

warning: this boolean expression can be simplified
   --> ff-macros/src/unroll.rs:113:37
    |
113 |             if !by_ref.is_none() || !mutability.is_none() || !subpat.is_none() {
    |                                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `mutability.is_some()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool

warning: this boolean expression can be simplified
   --> ff-macros/src/unroll.rs:113:62
    |
113 |             if !by_ref.is_none() || !mutability.is_none() || !subpat.is_none() {
    |                                                              ^^^^^^^^^^^^^^^^^ help: try: `subpat.is_some()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool
```



