### PR TITLE
Grammar and Clarity Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="https://discord.gg/UNtS7QXyPk"><img src="https://img.shields.io/discord/908465643727253524?label=Discord&logo=discord"></a>
 </p>
 
-The arkworks ecosystem consist of Rust libraries for designing and working with *zero knowledge succinct non-interactive arguments (zkSNARKs)*. This repository contains efficient implementations of the key algebraic components underlying zkSNARKs: finite fields, elliptic curves, and polynomials.
+The arkworks ecosystem consists of Rust libraries for designing and working with *zero knowledge succinct non-interactive arguments (zkSNARKs)*. This repository contains efficient implementations of the key algebraic components underlying zkSNARKs: finite fields, elliptic curves, and polynomials.
 
 This library is released under the MIT License and the Apache v2 License (see [License](#license)).
 

--- a/ec/README.md
+++ b/ec/README.md
@@ -98,7 +98,7 @@ use ark_std::{Zero, UniformRand};
 let mut rng = ark_std::test_rng();
 // Let's generate an elliptic curve group element in the `CurveGroup` representation
 let a = G::rand(&mut rng);
-// We can convert it the `AffineRepr` representation...
+// We can convert it to the `AffineRepr` representation...
 let a_aff = a.into_affine();
 // ... and check that the two representations are equal.
 assert_eq!(a_aff, a);


### PR DESCRIPTION

## Changes Made

### In README.md:
Original: "The arkworks ecosystem consist of Rust libraries"
New: "The arkworks ecosystem consists of Rust libraries"
Reason: Fixed subject-verb agreement - "ecosystem" is singular and requires "consists"

### In ec/README.md:
Original: "We can convert it the `AffineRepr` representation"
New: "We can convert it to the `AffineRepr` representation"
Reason: Added missing preposition "to" for grammatical correctness

## Why These Changes Matter

1. Proper grammar and clear writing are important for:
   - Making documentation more professional
   - Improving readability for non-native English speakers
   - Reducing potential confusion or misunderstandings
   - Maintaining high code quality standards

2. These specific fixes:
   - Correct basic grammatical errors
   - Make the technical documentation more precise
   - Improve the overall quality of the project documentation

## Testing

No code changes were made, only documentation updates. No testing required.

## Checklist

- [x] Documentation updates only
- [x] No code changes
- [x] No breaking changes
- [x] Improves readability