### PR TITLE
Fix incorrect PR link for #141 in CHANGELOG

### DIFF
--- a/curves/CHANGELOG.md
+++ b/curves/CHANGELOG.md
@@ -50,7 +50,7 @@
 - [\#74](https://github.com/arkworks-rs/curves/pull/74) Use Scott's subgroup membership tests for `G1` and `G2` of BLS12-381.
 - [\#103](https://github.com/arkworks-rs/curves/pull/103) Faster cofactor clearing for BLS12-381.
 - [\#107](https://github.com/arkworks-rs/curves/pull/107/) Use 2-NAF of `ATE_LOOP_COUNT` to speed up the Miller loop in MNT curves.
-- [\#141](https://github.com/arkworks-rs/curves/pull/103) Faster cofactor clearing for BLS12-377.
+- [\#141](https://github.com/arkworks-rs/curves/pull/141) Faster cofactor clearing for BLS12-377.
 - [\#138](https://github.com/arkworks-rs/curves/pull/138) Implement WB Hash-to-Curve for bls12-381 and bls12-377
 
 ### Bugfixes


### PR DESCRIPTION
Corrected incorrect PR link for entry #141 in the CHANGELOG. The previous link pointed to PR #103 instead of PR #141. Updated the link to ensure it matches the referenced PR and its description.
Appreciate your hard work!
