### PR TITLE
Fix grammatical errors

### DIFF
--- a/ec/src/models/twisted_edwards/affine.rs
+++ b/ec/src/models/twisted_edwards/affine.rs
@@ -83,7 +83,7 @@ impl<P: TECurveConfig> Affine<P> {
         self.x.is_zero() && self.y.is_one()
     }
 
-    /// Attempts to construct an affine point given an y-coordinate. The
+    /// Attempts to construct an affine point given a y-coordinate. The
     /// point is not guaranteed to be in the prime order subgroup.
     ///
     /// If and only if `greatest` is set will the lexicographically
@@ -104,7 +104,7 @@ impl<P: TECurveConfig> Affine<P> {
         })
     }
 
-    /// Attempts to recover the x-coordinate given an y-coordinate. The
+    /// Attempts to recover the x-coordinate given a y-coordinate. The
     /// resulting point is not guaranteed to be in the prime order subgroup.
     ///
     /// If and only if `greatest` is set will the lexicographically

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -1,6 +1,6 @@
 //! This module contains a `GeneralEvaluationDomain` for
 //! performing various kinds of polynomial arithmetic on top of
-//! a FFT-friendly finite field.
+//! an FFT-friendly finite field.
 //!
 //! It is a wrapper around specific implementations of `EvaluationDomain` that
 //! automatically chooses the most efficient implementation

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -132,7 +132,7 @@ pub(crate) fn parallel_fft<T: DomainCoeff<F>, F: FftField>(
     let new_two_adicity = ark_ff::utils::k_adicity(2, coset_size as u64);
 
     // For each coset, we first build a polynomial of degree |coset size|,
-    // whose evaluations over coset k will agree with the evaluations of a over the coset.
+    // whose evaluations over coset k will agree with the evaluations of an over the coset.
     // Denote the kth such polynomial as poly_k
     tmp.par_iter_mut()
         .enumerate()


### PR DESCRIPTION
This pull request addresses grammatical issues in comments across the codebase, specifically related to the correct usage of articles ("a" vs. "an"). The affected files are:

- `ec/src/models/twisted_edwards/affine.rs`
- `poly/src/domain/general.rs`
- `poly/src/domain/utils.rs`

#### Changes made:
1. Replaced **"an y-coordinate"** with **"a y-coordinate"** in `affine.rs`.
2. Replaced **"a FFT-friendly finite field"** with **"an FFT-friendly finite field"** in `general.rs`.
3. Replaced **"evaluations of a over the coset"** with **"evaluations of an over the coset"** in `utils.rs`.

These changes improve the clarity and grammatical correctness of the code documentation.
