### PR TITLE
Update CHANGELOG: Fix handling of duplicate terms in SparsePolynomial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugfixes
 
-- (`ark-poly`) Fix handling of duplicate terms in `SparsePolynomial::from_coefficients_vec`. Terms with the same degree are now correctly merged, and zero coefficient terms are removed.
+- [\#915](https://github.com/arkworks-rs/algebra/pull/915) (`ark-poly`) Added `is_valid_coefficients_vec` to `SparsePolynomial::from_coefficients_vec` to remove duplicates and zero coefficients before polynomial creation.
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfixes
 
+- (`ark-poly`) Fix handling of duplicate terms in `SparsePolynomial::from_coefficients_vec`. Terms with the same degree are now correctly merged, and zero coefficient terms are removed.
+
 ## v0.5.0
 
 - [\#772](https://github.com/arkworks-rs/algebra/pull/772) (`ark-ff`) Implementation of `mul` method for `BigInteger`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugfixes
 
-- [\#915](https://github.com/arkworks-rs/algebra/pull/915) (`ark-poly`) Added `is_valid_coefficients_vec` to `SparsePolynomial::from_coefficients_vec` to remove duplicates and zero coefficients before polynomial creation.
+- [\#915](https://github.com/arkworks-rs/algebra/pull/915) (`ark-poly`) Added `is_valid_coefficients_vec` to `SparsePolynomial` to remove duplicates and zero coefficients before polynomial creation.
 
 ## v0.5.0
 

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -241,6 +241,12 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -229,6 +229,12 @@ impl<F: Field> Zero for SparsePolynomial<F> {
     }
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -235,6 +235,12 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -232,20 +232,22 @@ impl<F: Field> Zero for SparsePolynomial<F> {
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified
-    pub fn is_valid_coefficients_vec(coeffs: &[(usize, F)]) -> bool {
+    pub fn is_valid_coefficients_vec(coeffs: &[(usize, F)]) -> Result<(), CoeffVecError> {
         let mut last_degree = None;
         for &(degree, ref coeff) in coeffs {
             if coeff.is_zero() {
-                return false; // Zero coefficients are not allowed
+                // zero term has no effect
+                return Err(CoeffVecError::ZeroCoefficient);
             }
             if let Some(last) = last_degree {
                 if last == degree {
-                    return false; // Duplicate degrees are not allowed
+                    // like terms should be combined
+                    return Err(CoeffVecError::DuplicateDegree);
                 }
             }
             last_degree = Some(degree);
         }
-        true
+        Ok(())
     }
     
     /// Constructs a new polynomial from a list of coefficients.

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -235,24 +235,6 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
-#[derive(Debug)]
-pub enum CoeffVecError {
-    ZeroCoefficient,
-    DuplicateDegree,
-}
-
-#[derive(Debug)]
-pub enum CoeffVecError {
-    ZeroCoefficient,
-    DuplicateDegree,
-}
-
-#[derive(Debug)]
-pub enum CoeffVecError {
-    ZeroCoefficient,
-    DuplicateDegree,
-}
-
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified
@@ -366,7 +348,7 @@ impl<F: Field> From<DensePolynomial<F>> for SparsePolynomial<F> {
 mod tests {
     use crate::{
         polynomial::Polynomial,
-        univariate::{DensePolynomial, SparsePolynomial},
+        univariate::{sparse::CoeffVecError, DensePolynomial, SparsePolynomial},
         EvaluationDomain, GeneralEvaluationDomain,
     };
     use ark_ff::{UniformRand, Zero};
@@ -385,6 +367,30 @@ mod tests {
             }
         }
         SparsePolynomial::from_coefficients_vec(coeffs)
+    }
+
+    #[test]
+    fn test_valid_coefficients() {
+        let coeffs = vec![(1, Fr::from(2)), (2, Fr::from(3)), (3, Fr::from(4))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        assert!(validation.is_ok());
+
+        let poly = SparsePolynomial::from_coefficients_vec(coeffs);
+        assert_eq!(poly.coeffs.len(), 3);
+    }
+
+    #[test]
+    fn test_invalid_zero_coefficient() {
+        let coeffs = vec![(1, Fr::from(0)), (2, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        assert!(matches!(validation, Err(CoeffVecError::ZeroCoefficient)));
+    }
+
+    #[test]
+    fn test_invalid_duplicate_degrees() {
+        let coeffs = vec![(1, Fr::from(2)), (1, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        assert!(matches!(validation, Err(CoeffVecError::DuplicateDegree)));
     }
 
     #[test]

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -247,6 +247,12 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -238,9 +238,11 @@ pub enum CoeffVecError {
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified
-    pub fn is_valid_coefficients_vec(coeffs: &[(usize, F)]) -> Result<(), CoeffVecError> {
+    pub fn is_valid_coefficients_vec(coeffs: &mut [(usize, F)]) -> Result<(), CoeffVecError> {
+        coeffs.sort_by(|a, b| a.0.cmp(&b.0));
+
         let mut last_degree = None;
-        for &(degree, ref coeff) in coeffs {
+        for &mut (degree, ref mut coeff) in coeffs {
             if coeff.is_zero() {
                 // zero term has no effect
                 return Err(CoeffVecError::ZeroCoefficient);
@@ -371,8 +373,8 @@ mod tests {
 
     #[test]
     fn test_valid_coefficients() {
-        let coeffs = vec![(1, Fr::from(2)), (2, Fr::from(3)), (3, Fr::from(4))];
-        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        let mut coeffs = vec![(1, Fr::from(2)), (2, Fr::from(3)), (3, Fr::from(4))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&mut coeffs);
         assert!(validation.is_ok());
 
         let poly = SparsePolynomial::from_coefficients_vec(coeffs);
@@ -381,15 +383,15 @@ mod tests {
 
     #[test]
     fn test_invalid_zero_coefficient() {
-        let coeffs = vec![(1, Fr::from(0)), (2, Fr::from(3))];
-        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        let mut coeffs = vec![(1, Fr::from(0)), (2, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&mut coeffs);
         assert!(matches!(validation, Err(CoeffVecError::ZeroCoefficient)));
     }
 
     #[test]
     fn test_invalid_duplicate_degrees() {
-        let coeffs = vec![(1, Fr::from(2)), (1, Fr::from(3))];
-        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        let mut coeffs = vec![(1, Fr::from(2)), (1, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&mut coeffs);
         assert!(matches!(validation, Err(CoeffVecError::DuplicateDegree)));
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

In the current implementation of `univariate::SparsePolynomial::from_coefficients_vec`, duplicate terms with the same degree are not explicitly handled. As a result, if multiple terms with the same degree are provided, they remain as separate entries in the resulting sparse polynomial. This can lead to inconsistencies in polynomial operations and unnecessary redundancy.

**Current Behavior:**  
Given an input like:  
```rust
vec![
    (0, F::from(2)), 
    (0, F::from(1)), 
    (0, F::from(1)), 
    (3, F::from(5)),
    (3, F::from(3)),
    (4, F::from(0)),
]
```
The resulting polynomial contains duplicate terms without merging them.

**Proposed Improvement:**  
1. **Sort Terms by Degree:** Ensure terms are sorted by degree.  
2. **Merge Duplicate Terms:** For terms with the same degree, sum their coefficients into a single term.  
3. **Remove Zero Coefficient Terms:** Eliminate terms where the coefficient becomes zero after merging.  

**Proposed Implementation Example:**  
```rust
fn from_coefficients_vec(mut coeffs: Vec<(usize, F)>) -> Self {
    // Sort terms by degree
    coeffs.sort_by(|(c1, _), (c2, _)| c1.cmp(c2));

    // Merge duplicate terms
    let mut merged_coeffs: Vec<(usize, F)> = Vec::new();
    for (degree, coeff) in coeffs {
        if let Some((last_degree, last_coeff)) = merged_coeffs.last_mut() {
            if *last_degree == degree {
                *last_coeff += coeff; // Combine coefficients for duplicate degrees
                continue;
            }
        }
        merged_coeffs.push((degree, coeff));
    }

    // Remove zero coefficient terms
    merged_coeffs.retain(|(_, coeff)| !coeff.is_zero());

    // Create the SparsePolynomial
    Self { coeffs: merged_coeffs }
}
```

**Expected Behavior:**  
For the same input:  
```rust
[(0, F::from(4)), (3, F::from(8))]
```
The resulting polynomial will now be consistent and free from redundant terms.

**Why is this change beneficial?**  
- Ensures clarity and consistency in sparse polynomial representations.  
- Prevents redundant terms, which may cause unexpected results in polynomial operations.  
- Aligns with expected mathematical representations of polynomials.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
