### PR TITLE
`DensePolynomial`: add `to_coefficients_vec`

### DIFF
--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -251,6 +251,11 @@ impl<F: FftField> DensePolynomial<F> {
         let poly: DenseOrSparsePolynomial<'_, F> = self.into();
         DenseOrSparsePolynomial::<F>::evaluate_over_domain(poly, domain)
     }
+
+    /// Consumes `self` and returns a coefficients vec.
+    pub fn to_coefficients_vec(self) -> Vec<F> {
+        self.coeffs
+    }
 }
 
 impl<F: Field> fmt::Debug for DensePolynomial<F> {


### PR DESCRIPTION
This PR adds a `to_coefficients_vec` to `DensePolynomial`, so that external users can convert vec to `DensePolynomial` with `from_coefficients_vec`, and after computations finally converts `DensePolynomial` back to vec with `to_coefficients_vec` without copy.