### PR TITLE
Fix: must_use on traits has no effect and causes CI to fail

### DIFF
--- a/ec/src/models/short_weierstrass/affine.rs
+++ b/ec/src/models/short_weierstrass/affine.rs
@@ -238,7 +238,6 @@ impl<P: SWCurveConfig> AffineRepr for Affine<P> {
 
     /// Multiplies this element by the cofactor and output the
     /// resulting projective element.
-    #[must_use]
     fn mul_by_cofactor_to_group(&self) -> Self::Group {
         P::mul_affine(self, Self::Config::COFACTOR)
     }

--- a/ec/src/models/twisted_edwards/affine.rs
+++ b/ec/src/models/twisted_edwards/affine.rs
@@ -184,7 +184,6 @@ impl<P: TECurveConfig> AffineRepr for Affine<P> {
 
     /// Multiplies this element by the cofactor and output the
     /// resulting projective element.
-    #[must_use]
     fn mul_by_cofactor_to_group(&self) -> Self::Group {
         P::mul_affine(self, Self::Config::COFACTOR)
     }

--- a/ff/src/fields/models/fp/mod.rs
+++ b/ff/src/fields/models/fp/mod.rs
@@ -677,7 +677,6 @@ impl<P: FpConfig<N>, const N: usize> Display for Fp<P, N> {
 impl<P: FpConfig<N>, const N: usize> Neg for Fp<P, N> {
     type Output = Self;
     #[inline]
-    #[must_use]
     fn neg(mut self) -> Self {
         P::neg_in_place(&mut self);
         self

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -570,7 +570,6 @@ impl<P: QuadExtConfig> From<bool> for QuadExtField<P> {
 impl<P: QuadExtConfig> Neg for QuadExtField<P> {
     type Output = Self;
     #[inline]
-    #[must_use]
     fn neg(mut self) -> Self {
         self.c0.neg_in_place();
         self.c1.neg_in_place();


### PR DESCRIPTION
## Fix: must_use on traits has no effect and causes CI to fail

As of Rust 1.87.0-nightly, #[must_use] on provided trait methods triggers a warning, which becomes an error under cargo check with -D warnings, breaking CI.

Since it had no effect to begin with I think it's safe to remove and we need to do this to resolve CI werrors. 

---

- [x] Targeted PR against correct branch (master)
- [N/A ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [N/A ] Wrote unit tests
- [N/A ] Updated relevant documentation in the code
- [N/A] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [N/A] Re-reviewed `Files changed` in the GitHub PR explorer
