### PR TITLE
Implement `CanonicalSerialize` and `CanonicalDeserialize` for signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
+
 ### Improvements
 
 ### Bugfixes

--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -105,6 +105,10 @@ impl_uint!(u8);
 impl_uint!(u16);
 impl_uint!(u32);
 impl_uint!(u64);
+impl_uint!(i8);
+impl_uint!(i16);
+impl_uint!(i32);
+impl_uint!(i64);
 
 impl CanonicalSerialize for usize {
     #[inline]
@@ -147,6 +151,50 @@ impl CanonicalDeserialize for usize {
         let mut bytes = [0u8; core::mem::size_of::<u64>()];
         reader.read_exact(&mut bytes)?;
         Ok(<u64>::from_le_bytes(bytes) as Self)
+    }
+}
+
+impl CanonicalSerialize for isize {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        Ok(writer.write_all(&(*self as i64).to_le_bytes())?)
+    }
+
+    #[inline]
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        core::mem::size_of::<i64>()
+    }
+}
+
+impl Valid for isize {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+
+    #[inline]
+    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self>) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for isize {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let mut bytes = [0u8; core::mem::size_of::<i64>()];
+        reader.read_exact(&mut bytes)?;
+        Ok(<i64>::from_le_bytes(bytes) as Self)
     }
 }
 

--- a/serialize/src/test.rs
+++ b/serialize/src/test.rs
@@ -161,6 +161,20 @@ fn test_uint() {
 }
 
 #[test]
+fn test_int() {
+    test_serialize(192830918isize);
+    test_serialize(-192830918isize);
+    test_serialize(192830918i64);
+    test_serialize(-192830918i64);
+    test_serialize(192830918i32);
+    test_serialize(-192830918i32);
+    test_serialize(22313i16);
+    test_serialize(-22313i16);
+    test_serialize(123i8);
+    test_serialize(-123i8);
+}
+
+#[test]
 fn test_string() {
     test_serialize(String::from("arkworks"));
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR adds implementations of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types (`i8`, `i16`, `i32`, `i64`, and `isize`), reusing the macro that implements these traits for unsigned integers.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [ ] Updated relevant documentation in the code
  - I didn't see any relevant docs to change here
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer