### PR TITLE
Fix sparsepoly duplicate terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugfixes
 
-- (`ark-poly`) Fix handling of duplicate terms in `SparsePolynomial::from_coefficients_vec`. Terms with the same degree are now correctly merged, and zero coefficient terms are removed.
+- [\#915](https://github.com/arkworks-rs/algebra/pull/915) (`ark-poly`) Added `is_valid_coefficients_vec` to `SparsePolynomial::from_coefficients_vec` to remove duplicates and zero coefficients before polynomial creation.
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfixes
 
+- (`ark-poly`) Fix handling of duplicate terms in `SparsePolynomial::from_coefficients_vec`. Terms with the same degree are now correctly merged, and zero coefficient terms are removed.
+
 ## v0.5.0
 
 - [\#772](https://github.com/arkworks-rs/algebra/pull/772) (`ark-ff`) Implementation of `mul` method for `BigInteger`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugfixes
 
-- [\#915](https://github.com/arkworks-rs/algebra/pull/915) (`ark-poly`) Added `is_valid_coefficients_vec` to `SparsePolynomial::from_coefficients_vec` to remove duplicates and zero coefficients before polynomial creation.
+- [\#915](https://github.com/arkworks-rs/algebra/pull/915) (`ark-poly`) Added `is_valid_coefficients_vec` to `SparsePolynomial` to remove duplicates and zero coefficients before polynomial creation.
 
 ## v0.5.0
 

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -241,6 +241,12 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -229,6 +229,12 @@ impl<F: Field> Zero for SparsePolynomial<F> {
     }
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -235,6 +235,12 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -232,20 +232,22 @@ impl<F: Field> Zero for SparsePolynomial<F> {
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified
-    pub fn is_valid_coefficients_vec(coeffs: &[(usize, F)]) -> bool {
+    pub fn is_valid_coefficients_vec(coeffs: &[(usize, F)]) -> Result<(), CoeffVecError> {
         let mut last_degree = None;
         for &(degree, ref coeff) in coeffs {
             if coeff.is_zero() {
-                return false; // Zero coefficients are not allowed
+                // zero term has no effect
+                return Err(CoeffVecError::ZeroCoefficient);
             }
             if let Some(last) = last_degree {
                 if last == degree {
-                    return false; // Duplicate degrees are not allowed
+                    // like terms should be combined
+                    return Err(CoeffVecError::DuplicateDegree);
                 }
             }
             last_degree = Some(degree);
         }
-        true
+        Ok(())
     }
     
     /// Constructs a new polynomial from a list of coefficients.

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -235,24 +235,6 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
-#[derive(Debug)]
-pub enum CoeffVecError {
-    ZeroCoefficient,
-    DuplicateDegree,
-}
-
-#[derive(Debug)]
-pub enum CoeffVecError {
-    ZeroCoefficient,
-    DuplicateDegree,
-}
-
-#[derive(Debug)]
-pub enum CoeffVecError {
-    ZeroCoefficient,
-    DuplicateDegree,
-}
-
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified
@@ -366,7 +348,7 @@ impl<F: Field> From<DensePolynomial<F>> for SparsePolynomial<F> {
 mod tests {
     use crate::{
         polynomial::Polynomial,
-        univariate::{DensePolynomial, SparsePolynomial},
+        univariate::{sparse::CoeffVecError, DensePolynomial, SparsePolynomial},
         EvaluationDomain, GeneralEvaluationDomain,
     };
     use ark_ff::{UniformRand, Zero};
@@ -385,6 +367,30 @@ mod tests {
             }
         }
         SparsePolynomial::from_coefficients_vec(coeffs)
+    }
+
+    #[test]
+    fn test_valid_coefficients() {
+        let coeffs = vec![(1, Fr::from(2)), (2, Fr::from(3)), (3, Fr::from(4))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        assert!(validation.is_ok());
+
+        let poly = SparsePolynomial::from_coefficients_vec(coeffs);
+        assert_eq!(poly.coeffs.len(), 3);
+    }
+
+    #[test]
+    fn test_invalid_zero_coefficient() {
+        let coeffs = vec![(1, Fr::from(0)), (2, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        assert!(matches!(validation, Err(CoeffVecError::ZeroCoefficient)));
+    }
+
+    #[test]
+    fn test_invalid_duplicate_degrees() {
+        let coeffs = vec![(1, Fr::from(2)), (1, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        assert!(matches!(validation, Err(CoeffVecError::DuplicateDegree)));
     }
 
     #[test]

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -247,6 +247,12 @@ pub enum CoeffVecError {
     DuplicateDegree,
 }
 
+#[derive(Debug)]
+pub enum CoeffVecError {
+    ZeroCoefficient,
+    DuplicateDegree,
+}
+
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -238,9 +238,11 @@ pub enum CoeffVecError {
 impl<F: Field> SparsePolynomial<F> {
 
     // Function to validate that the input coefficient vector is simplified
-    pub fn is_valid_coefficients_vec(coeffs: &[(usize, F)]) -> Result<(), CoeffVecError> {
+    pub fn is_valid_coefficients_vec(coeffs: &mut [(usize, F)]) -> Result<(), CoeffVecError> {
+        coeffs.sort_by(|a, b| a.0.cmp(&b.0));
+
         let mut last_degree = None;
-        for &(degree, ref coeff) in coeffs {
+        for &mut (degree, ref mut coeff) in coeffs {
             if coeff.is_zero() {
                 // zero term has no effect
                 return Err(CoeffVecError::ZeroCoefficient);
@@ -371,8 +373,8 @@ mod tests {
 
     #[test]
     fn test_valid_coefficients() {
-        let coeffs = vec![(1, Fr::from(2)), (2, Fr::from(3)), (3, Fr::from(4))];
-        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        let mut coeffs = vec![(1, Fr::from(2)), (2, Fr::from(3)), (3, Fr::from(4))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&mut coeffs);
         assert!(validation.is_ok());
 
         let poly = SparsePolynomial::from_coefficients_vec(coeffs);
@@ -381,15 +383,15 @@ mod tests {
 
     #[test]
     fn test_invalid_zero_coefficient() {
-        let coeffs = vec![(1, Fr::from(0)), (2, Fr::from(3))];
-        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        let mut coeffs = vec![(1, Fr::from(0)), (2, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&mut coeffs);
         assert!(matches!(validation, Err(CoeffVecError::ZeroCoefficient)));
     }
 
     #[test]
     fn test_invalid_duplicate_degrees() {
-        let coeffs = vec![(1, Fr::from(2)), (1, Fr::from(3))];
-        let validation = SparsePolynomial::is_valid_coefficients_vec(&coeffs);
+        let mut coeffs = vec![(1, Fr::from(2)), (1, Fr::from(3))];
+        let validation = SparsePolynomial::is_valid_coefficients_vec(&mut coeffs);
         assert!(matches!(validation, Err(CoeffVecError::DuplicateDegree)));
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR reintroduces the changes from the previously closed PR (#915) to address the issue where duplicate terms with the same degree were not explicitly handled in `univariate::SparsePolynomial::from_coefficients_vec`. In the current implementation, multiple terms with the same degree remain as separate entries, leading to inconsistencies in polynomial operations and unnecessary redundancy.

To resolve this, an `is_valid_coefficients_vec` function has been introduced to pre-validate the input vector before constructing a sparse polynomial. This ensures that duplicate terms are merged, preventing redundancy.

### Changes Introduced
- Implemented `is_valid_coefficients_vec` to check for duplicate terms.
- Ensured that `from_coefficients_vec` only processes pre-validated input.
- Added three test cases to verify the correctness of the validation function.
- Considered different approaches for handling `rand_sparse_poly` behavior:
  - **Option 1:** Integrate the validity check within `rand_sparse_poly` and implement a retry mechanism.
  - **Option 2:** Adjust the output based on `is_valid_coefficients_vec` and modify related test cases accordingly.

### Notes
- The previous PR was automatically closed due to the deletion of the base branch.
- This PR restores those changes while addressing all previous feedback.
- Further discussion is welcome regarding how `rand_sparse_poly` should handle invalid input.