### PR TITLE
Fix incorrect projective-to-affine coordinate transformation comments

### DIFF
--- a/ec/src/models/short_weierstrass/affine.rs
+++ b/ec/src/models/short_weierstrass/affine.rs
@@ -326,7 +326,7 @@ impl<P: SWCurveConfig, T: Borrow<P::ScalarField>> Mul<T> for Affine<P> {
 }
 
 // The projective point X, Y, Z is represented in the affine
-// coordinates as X/Z^2, Y/Z^3.
+// coordinates as X/Z, Y/Z.
 impl<P: SWCurveConfig> From<Projective<P>> for Affine<P> {
     #[inline]
     fn from(p: Projective<P>) -> Self {


### PR DESCRIPTION
This PR corrects inaccurate comments describing the transformation of projective coordinates (X, Y, Z) to affine form. The previous comments mistakenly stated X/Z², Y/Z³, whereas the correct transformation is X/Z, Y/Z.

