### PR TITLE
Dori/bitreverse permutation public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- Consolidated logic into `bitreverse_permutation_in_place` and made it public.
+
 ### Breaking changes
 
 ### Features

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -12,7 +12,7 @@
 
 pub use crate::domain::utils::Elements;
 use crate::domain::{
-    utils::{best_fft, bitreverse},
+    utils::{best_fft, bitreverse_permutation_in_place},
     DomainCoeff, EvaluationDomain,
 };
 use ark_ff::{fields::utils::k_adicity, FftField};
@@ -354,13 +354,7 @@ pub(crate) fn serial_mixed_radix_fft<T: DomainCoeff<F>, F: FftField>(
             m *= q;
         }
     } else {
-        // swapping in place (from Storer's book)
-        for k in 0..n {
-            let rk = bitreverse(k as u32, two_adicity) as usize;
-            if k < rk {
-                a.swap(k, rk);
-            }
-        }
+        bitreverse_permutation_in_place(a, two_adicity);
     }
 
     for _ in 0..two_adicity {

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! `Radix2EvaluationDomain` supports FFTs of size at most `2^F::TWO_ADICITY`.
 
-pub use crate::domain::utils::Elements;
+pub use crate::domain::utils::{bitreverse_permutation_in_place, Elements};
 use crate::domain::{DomainCoeff, EvaluationDomain};
 use ark_ff::FftField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -442,12 +442,7 @@ mod tests {
             assert_eq!(n, 1 << log_n);
 
             // swap coefficients in place
-            for k in 0..n {
-                let rk = crate::domain::utils::bitreverse(k, log_n);
-                if k < rk {
-                    a.swap(rk as usize, k as usize);
-                }
-            }
+            crate::domain::utils::bitreverse_permutation_in_place(a, log_n);
 
             let mut m = 1;
             for _i in 1..=log_n {

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -19,6 +19,18 @@ pub(crate) fn bitreverse(mut n: u32, l: u32) -> u32 {
     r
 }
 
+#[inline]
+pub(crate) fn bitreverse_permutation_in_place<T>(a: &mut [T], width: u32) {
+    // swapping in place (from Storer's book)
+    let n = a.len();
+    for k in 0..n {
+        let rk = bitreverse(k as u32, width) as usize;
+        if k < rk {
+            a.swap(k, rk);
+        }
+    }
+}
+
 pub(crate) fn compute_powers_serial<F: Field>(size: usize, root: F) -> Vec<F> {
     compute_powers_and_mul_by_const_serial(size, root, F::one())
 }

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -20,7 +20,7 @@ pub(crate) fn bitreverse(mut n: u32, l: u32) -> u32 {
 }
 
 #[inline]
-pub(crate) fn bitreverse_permutation_in_place<T>(a: &mut [T], width: u32) {
+pub fn bitreverse_permutation_in_place<T>(a: &mut [T], width: u32) {
     // swapping in place (from Storer's book)
     let n = a.len();
     for k in 0..n {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds `bitreverse_permutation_in_place` - sharing logic previously hard-coded in two places.
Also, makes this utility public, as bit-reversal permutation is useful on it's own.

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [v] Targeted PR against correct branch (master)
- [v] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests - *no, because no logic change.*
- [v] Updated relevant documentation in the code
- [v] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
