### PR TITLE
Issue 752

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
 
 ### Improvements
+- [\#752](https://github.com/arkworks-rs/algebra/pull/752) Fix duplicate KaTeX header
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
 
 ### Improvements
+
 - [\#752](https://github.com/arkworks-rs/algebra/pull/752) Fix duplicate KaTeX header
 
 ### Bugfixes

--- a/doc/katex-header.html
+++ b/doc/katex-header.html
@@ -1,31 +1,47 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css"
+    integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
 
 <!-- The loading of KaTeX is deferred to speed up page rendering -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js" integrity="sha384-X/XCfMm41VSsqRNQgDerQczD69XqmjOOOwYQvr/uuC+j4OPoNhVgjdGFwhvN02Ja" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js"
+    integrity="sha384-X/XCfMm41VSsqRNQgDerQczD69XqmjOOOwYQvr/uuC+j4OPoNhVgjdGFwhvN02Ja" crossorigin="anonymous">
+</script>
 
 <!-- To automatically render math in text elements, include the auto-render extension: -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"
-    onload="renderMathInElement(document.body);"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js"
+    integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"
+    onload="renderMathInElement(document.body, window.katex_options);"></script>
+
+<!-- Define global KaTeX options before loading scripts -->
+<script>
+    window.katex_options = {
+        macros: {
+            "\\defeq": ":=",
+            "\\FF": "\\mathbb{F}",
+            "\\GG": "\\mathbb{G}",
+            "\\prover": "\\mathsf{P}",
+            "\\verifier": "\\mathsf{V}",
+        },
+        delimiters: [
+            {left: "$$", right: "$$", display: true},
+            {left: "$", right: "$", display: false},
+        ],
+    };
+</script>
 
 <script>
-document.addEventListener("DOMContentLoaded", function() {
-renderMathInElement(document.body, {
-    macros: {
-    "\\defeq": ":=",
-    "\\FF": "\\mathbb{F}",
-    "\\GG": "\\mathbb{G}",
-    "\\prover": "\\mathsf{P}",
-    "\\verifier": "\\mathsf{V}",
-    },
-    delimiters: [
-        {left: "$$", right: "$$", display: true},
-        {left: "$", right: "$", display: false},
-    ],
-});
-});
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, window.katex_options);
+    });
 </script>
-<style>
-.katex { font-size: 1em !important; }
-pre.rust, .docblock code, .docblock-short code { font-size: 0.85em !important; }
-</style>
 
+<style>
+    .katex {
+        font-size: 1em !important;
+    }
+
+    pre.rust,
+    .docblock code,
+    .docblock-short code {
+        font-size: 0.85em !important;
+    }
+</style>

--- a/ec/doc/katex-header.html
+++ b/ec/doc/katex-header.html
@@ -1,1 +1,0 @@
-../../doc/katex-header.html

--- a/ff/doc/katex-header.html
+++ b/ff/doc/katex-header.html
@@ -1,1 +1,0 @@
-../../doc/katex-header.html


### PR DESCRIPTION
## Description

### Changes
1. **Removed Duplicate Files**:
	- Found identical header also in `ec/doc`
    - Removed duplicate `katex-header.html` files from both `/ff/doc/` and `/ec/doc/`
    - Kept only the centralized version at the workspace level
2. **Fixed Macro Rendering Issues**:
    - After removing duplicates, I discovered browser console errors related to custom LaTeX macros
    - Cause: The `onload` rendering of math expressions occurred before macro definitions were available
    - To resolve this I restructured the `katex-header.html` file to define the `window.katex_options` object before loading the auto-render script
    - Reformated `katex-header.html` for better readability

### Verification:
- Clean rebuild with `cargo clean --doc && make doc`
- Added test LaTeX expressions to `index.html` in `ark_ff` and `ark_ec` documentation to verify proper rendering
- Checked browser console for KaTeX parse errors

---

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests: *did not write tests for docs generations instead verified by generating docs and confirming expressions render correctly*
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer