### PR TITLE
feat: serde-compatible adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 - Consolidated logic into `bitreverse_permutation_in_place` and made it public.
+- (`ark-serialize`) serde-compatible wrapper types.
 
 ### Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde-encoded-bytes = "0.2"
+serde_with = "3.12"
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 blake2 = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ rayon = "1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+serde-encoded-bytes = "0.2"
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 blake2 = { version = "0.10", default-features = false }

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -33,6 +33,7 @@ serde_with = { workspace = true, optional = true, default-features = false }
 sha2.workspace = true
 sha3.workspace = true
 blake2.workspace = true
+serde_json.workspace = true
 ark-test-curves = { workspace = true, default-features = false, features = [
     "bls12_381_curve",
 ] }

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -27,6 +27,7 @@ num-bigint.workspace = true
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde-encoded-bytes = { workspace = true, optional = true, features = ["base64"] }
+serde_with = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
 sha2.workspace = true
@@ -40,6 +41,7 @@ ark-test-curves = { workspace = true, default-features = false, features = [
 [features]
 default = []
 parallel = ["rayon"]
-std = ["ark-std/std"]
+std = ["ark-std/std", "serde_with/std"]
 derive = ["ark-serialize-derive"]
-serde = ["dep:serde", "dep:serde-encoded-bytes"]
+serde = ["dep:serde", "dep:serde-encoded-bytes", "dep:serde_with"]
+serde_with = ["serde", "dep:serde_with"]

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -26,6 +26,7 @@ digest.workspace = true
 num-bigint.workspace = true
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+serde-encoded-bytes = { workspace = true, optional = true, features = ["base64"] }
 
 [dev-dependencies]
 sha2.workspace = true
@@ -41,4 +42,4 @@ default = []
 parallel = ["rayon"]
 std = ["ark-std/std"]
 derive = ["ark-serialize-derive"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde-encoded-bytes"]

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -41,7 +41,7 @@ ark-test-curves = { workspace = true, default-features = false, features = [
 [features]
 default = []
 parallel = ["rayon"]
-std = ["ark-std/std", "serde_with/std"]
+std = ["ark-std/std", "serde_with?/std"]
 derive = ["ark-serialize-derive"]
 serde = ["dep:serde", "dep:serde-encoded-bytes", "dep:serde_with"]
 serde_with = ["serde", "dep:serde_with"]

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -25,6 +25,7 @@ arrayvec.workspace = true
 digest.workspace = true
 num-bigint.workspace = true
 rayon = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 sha2.workspace = true
@@ -40,3 +41,4 @@ default = []
 parallel = ["rayon"]
 std = ["ark-std/std"]
 derive = ["ark-serialize-derive"]
+serde = ["dep:serde"]

--- a/serialize/README.md
+++ b/serialize/README.md
@@ -140,7 +140,7 @@ use serde::{Serialize, Deserialize};
 pub struct Proof(pub G1Affine);
 
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
-#[derive(Serialize,Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(from = "CompressedChecked<Self>", into = "CompressedChecked<Self>")]
 pub struct Signature {
     /// Aggregated BLS signature σ' = H(m)^aSK.

--- a/serialize/README.md
+++ b/serialize/README.md
@@ -126,3 +126,64 @@ impl Valid for MyStruct {
     }
 }
 ```
+
+### `serde`-compatibility
+
+Four wrapper types (`CompressedChecked<T>`, `UncompressedChecked<T>`, `CompressedUnchecked<T>`, `UncompressedUnchecked<T>`) exist with two features: first, a type-level configuration of the de/serialization modes, and support for the [`serde`](https://serde.rs) framework. The easiest way to use these is with the `from` and `into` annotations on a container type already implementing `Canonical*`:
+
+```rust,ignore
+use ark_serialize::{CanonicalSerialize, CanonicalDeserialize, CompressedChecked};
+use ark_test_curves::bls12_381::{G1Affine, G2Affine, Fr};
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct Proof(pub G1Affine);
+
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Serialize,Deserialize)]
+#[serde(from = "CompressedChecked<Self>", into = "CompressedChecked<Self>")]
+pub struct Signature {
+    /// Aggregated BLS signature σ' = H(m)^aSK.
+    pub agg_sig_prime: G2Affine,
+    /// The threshold for the signature.
+    pub threshold: Fr,
+    /// The SNARK proof π.
+    pub proof: Proof,
+}
+
+impl From<CompressedChecked<Signature>> for Signature {
+    fn from(sig: CompressedChecked<Signature>) -> Self {
+        sig.0
+    }
+}
+```
+
+This type can now be used with either serialization framework.
+
+When the container type isn't suitable for `#[serde(from/into)]`, `serde_with` conversions can be used instead of pushing the wrapper types into the field values. This prevents the conversion structures from polluting the real datastructure (eg having to add dummy constructors and strip them out of collections), minimizing the impact of adding serde support.
+
+If `serde_with` is not desired, the less powerful `vec_*` mods provide support just for the common case of sequences. Without this converter, a `CompressedChecked<Vec<T>>` gets serialized as a single blob, as opposed to one blob per element, which is probably more intuitive. The alternative, trying to store `Vec<CompressedCheck<T>>`, causes invasive API pollution.
+
+```rust,ignore
+use ark_serialize::CompressedChecked;
+use serde::Serialize;
+use ark_test_curves::bls12_381::{G1Affine, G2Affine, Fr};
+
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Serialize)]
+pub struct GlobalData {
+    #[serde_as(as = "CompressedChecked<UniversalParams<Curve>>")]
+    pub params: UniversalParams<Curve>,
+    pub degree_max: usize,
+    /// Used for domain separation in lockstitch
+    pub domain: String,
+    #[serde_as(as = "Vec<CompressedChecked<DensePolynomial<F>>>")]
+    pub(crate) lagrange_polynomials: Vec<DensePolynomial<F>>,
+    #[serde(with = "ark_serialize::vec_compressed_checked")]
+    pub(crate) lagrange_coms_g1: Vec<G1Affine>,
+    #[serde(with = "ark_serialize::vec_compressed_checked")]
+    pub(crate) lagrange_coms_g2: Vec<G2Affine>,
+    #[serde(skip)]
+    pub(crate) lockstitch: lockstitch::Protocol,
+}
+```

--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -980,3 +980,31 @@ where
             .collect()
     }
 }
+
+impl<T: CanonicalSerialize> CanonicalSerialize for &T {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        (*self).serialize_with_mode(writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        (*self).serialized_size(compress)
+    }
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for &mut T {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        (**self).serialize_with_mode(writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        (**self).serialized_size(compress)
+    }
+}

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -11,11 +11,14 @@
 mod error;
 mod flags;
 mod impls;
+#[path = "serde.rs"]
+mod serde_;
 
 pub use ark_std::io::{Read, Write};
 
 pub use error::*;
 pub use flags::*;
+pub use serde_::*;
 
 #[cfg(test)]
 mod test;

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 mod flags;
 mod impls;
 
-pub mod serde;
+mod serde;
 
 pub use ark_std::io::{Read, Write};
 

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -11,14 +11,14 @@
 mod error;
 mod flags;
 mod impls;
-#[path = "serde.rs"]
-mod serde_;
+
+pub mod serde;
 
 pub use ark_std::io::{Read, Write};
 
 pub use error::*;
 pub use flags::*;
-pub use serde_::*;
+pub use serde::*;
 
 #[cfg(test)]
 mod test;

--- a/serialize/src/serde.rs
+++ b/serialize/src/serde.rs
@@ -52,20 +52,20 @@ macro_rules! impl_ops {
 }
 
 macro_rules! impl_serde {
-    ($type:ty, $compress:expr, $validate:expr) => {
+    ($type:ty, $constr:ident, $compress:expr, $validate:expr, $vecmod:ident) => {
         #[cfg(feature = "serde")]
-        impl<T> serde::Serialize for $type
+        impl<T> ::serde::Serialize for $type
         where
             T: CanonicalSerialize,
         {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
-                S: serde::Serializer,
+                S: ::serde::Serializer,
             {
                 let mut buf = ark_std::vec![];
                 self.0
                     .serialize_with_mode(&mut buf, $compress)
-                    .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+                    .map_err(|e| ::serde::ser::Error::custom(e.to_string()))?;
                 serde_encoded_bytes::SliceLike::<serde_encoded_bytes::Base64>::serialize(
                     &buf, serializer,
                 )
@@ -73,20 +73,109 @@ macro_rules! impl_serde {
         }
 
         #[cfg(feature = "serde")]
-        impl<'de, T> serde::Deserialize<'de> for $type
+        impl<'de, T> ::serde::Deserialize<'de> for $type
         where
             T: CanonicalDeserialize,
         {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
-                D: serde::Deserializer<'de>,
+                D: ::serde::Deserializer<'de>,
             {
                 let buf: ark_std::vec::Vec<u8> = <serde_encoded_bytes::SliceLike<
                     serde_encoded_bytes::Base64,
                 >>::deserialize(deserializer)?;
                 let t = T::deserialize_with_mode(&buf[..], $compress, $validate)
-                    .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+                    .map_err(|e| ::serde::de::Error::custom(e.to_string()))?;
                 Ok(Self(t))
+            }
+        }
+
+        #[cfg(feature = "serde_with")]
+        impl<T> serde_with::SerializeAs<T> for $type
+        where
+            T: CanonicalSerialize,
+        {
+            fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::Serializer,
+            {
+                use ::serde::Serialize;
+                $constr(value).serialize(serializer)
+            }
+        }
+
+        #[cfg(feature = "serde_with")]
+        impl<'de, T> serde_with::DeserializeAs<'de, T> for $type
+        where
+            T: CanonicalDeserialize,
+        {
+            fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+            where
+                D: ::serde::Deserializer<'de>,
+            {
+                use ::serde::Deserialize;
+                let val: Self = Self::deserialize(deserializer)?;
+                Ok(val.0)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        pub mod $vecmod {
+            use crate::{CanonicalDeserialize, CanonicalSerialize, CompressedChecked};
+            use ::serde::ser::SerializeSeq;
+            use ::serde::{Deserializer, Serializer};
+            use ark_std::fmt;
+            use ark_std::vec::Vec;
+
+            pub fn serialize<S, T>(
+                value: &impl AsRef<[T]>,
+                serializer: S,
+            ) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+                T: CanonicalSerialize,
+            {
+                let values = value.as_ref();
+                let mut seq = serializer.serialize_seq(Some(values.len()))?;
+                for val in values {
+                    seq.serialize_element(&CompressedChecked(val))?;
+                }
+                seq.end()
+            }
+
+            pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+            where
+                D: Deserializer<'de>,
+                T: CanonicalDeserialize,
+            {
+                struct VecCanonicalVisitor<T> {
+                    accum: Vec<T>,
+                }
+                impl<'de, T> serde::de::Visitor<'de> for VecCanonicalVisitor<T>
+                where
+                    T: CanonicalDeserialize,
+                {
+                    type Value = Vec<T>;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        write!(
+                            formatter,
+                            "a sequence of CompressedChecked<{}>",
+                            ark_std::any::type_name::<T>()
+                        )
+                    }
+
+                    fn visit_seq<A>(mut self, mut seq: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: serde::de::SeqAccess<'de>,
+                    {
+                        while let Some(elt) = seq.next_element::<CompressedChecked<T>>()? {
+                            self.accum.push(elt.0);
+                        }
+                        Ok(self.accum)
+                    }
+                }
+                deserializer.deserialize_seq(VecCanonicalVisitor { accum: Vec::new() })
             }
         }
     };
@@ -130,10 +219,34 @@ impl_ops!(UncompressedUnchecked<T>, UncompressedUnchecked);
 impl_ops!(CompressedChecked<T>, CompressedChecked);
 impl_ops!(UncompressedChecked<T>, UncompressedChecked);
 
-impl_serde!(CompressedUnchecked<T>, Compress::Yes, Validate::No);
-impl_serde!(UncompressedUnchecked<T>, Compress::No, Validate::No);
-impl_serde!(CompressedChecked<T>, Compress::Yes, Validate::Yes);
-impl_serde!(UncompressedChecked<T>, Compress::No, Validate::Yes);
+impl_serde!(
+    CompressedUnchecked<T>,
+    CompressedUnchecked,
+    Compress::Yes,
+    Validate::No,
+    vec_compressed_unchecked
+);
+impl_serde!(
+    UncompressedUnchecked<T>,
+    UncompressedUnchecked,
+    Compress::No,
+    Validate::No,
+    vec_uncompressed_unchecked
+);
+impl_serde!(
+    CompressedChecked<T>,
+    CompressedChecked,
+    Compress::Yes,
+    Validate::Yes,
+    vec_compressed_checked
+);
+impl_serde!(
+    UncompressedChecked<T>,
+    UncompressedChecked,
+    Compress::No,
+    Validate::Yes,
+    vec_uncompressed_checked
+);
 
 impl_canonical!(CompressedUnchecked<T>, Compress::Yes, Validate::No);
 impl_canonical!(UncompressedUnchecked<T>, Compress::No, Validate::No);

--- a/serialize/src/serde.rs
+++ b/serialize/src/serde.rs
@@ -66,7 +66,9 @@ macro_rules! impl_serde {
                 self.0
                     .serialize_with_mode(&mut buf, $compress)
                     .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
-                serializer.serialize_bytes(&buf)
+                serde_encoded_bytes::SliceLike::<serde_encoded_bytes::Base64>::serialize(
+                    &buf, serializer,
+                )
             }
         }
 
@@ -79,7 +81,9 @@ macro_rules! impl_serde {
             where
                 D: serde::Deserializer<'de>,
             {
-                let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
+                let buf: ark_std::vec::Vec<u8> = <serde_encoded_bytes::SliceLike<
+                    serde_encoded_bytes::Base64,
+                >>::deserialize(deserializer)?;
                 let t = T::deserialize_with_mode(&buf[..], $compress, $validate)
                     .map_err(|e| serde::de::Error::custom(e.to_string()))?;
                 Ok(Self(t))

--- a/serialize/src/serde.rs
+++ b/serialize/src/serde.rs
@@ -1,4 +1,4 @@
-use ark_std::ops::{Deref,DerefMut};
+use ark_std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "serde")]
 use ark_std::string::ToString;

--- a/serialize/src/serde.rs
+++ b/serialize/src/serde.rs
@@ -1,4 +1,6 @@
 use ark_std::ops::{Deref, DerefMut};
+
+#[cfg(feature = "serde")]
 use ark_std::string::ToString;
 
 use crate::*;
@@ -19,325 +21,120 @@ pub struct CompressedChecked<T>(pub T);
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct UncompressedChecked<T>(pub T);
 
-#[cfg(feature = "serde")]
-impl<T> serde::Serialize for CompressedUnchecked<T>
-where
-    T: CanonicalSerialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut buf = ark_std::vec![];
-        self.0
-            .serialize_with_mode(&mut buf, Compress::Yes)
-            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
-        serializer.serialize_bytes(&buf)
-    }
+macro_rules! impl_deref {
+    ($type:ty) => {
+        impl<T> Deref for $type {
+            type Target = T;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl<T> DerefMut for $type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
 }
 
-#[cfg(feature = "serde")]
-impl<T> serde::Serialize for UncompressedUnchecked<T>
-where
-    T: CanonicalSerialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut buf = ark_std::vec![];
-        self.0
-            .serialize_with_mode(&mut buf, Compress::No)
-            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
-        serializer.serialize_bytes(&buf)
-    }
+macro_rules! impl_serde {
+    ($type:ty, $compress:expr, $validate:expr) => {
+        #[cfg(feature = "serde")]
+        impl<T> serde::Serialize for $type
+        where
+            T: CanonicalSerialize,
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut buf = ark_std::vec![];
+                self.0
+                    .serialize_with_mode(&mut buf, $compress)
+                    .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+                serializer.serialize_bytes(&buf)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de, T> serde::Deserialize<'de> for $type
+        where
+            T: CanonicalDeserialize,
+        {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
+                let t = T::deserialize_with_mode(&buf[..], $compress, $validate)
+                    .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+                Ok(Self(t))
+            }
+        }
+    };
 }
 
-#[cfg(feature = "serde")]
-impl<T> serde::Serialize for CompressedChecked<T>
-where
-    T: CanonicalSerialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut buf = ark_std::vec![];
-        self.0
-            .serialize_with_mode(&mut buf, Compress::Yes)
-            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
-        serializer.serialize_bytes(&buf)
-    }
+macro_rules! impl_canonical {
+    ($type:ty, $compress:expr, $validate:expr) => {
+        impl<T: CanonicalSerialize> CanonicalSerialize for $type {
+            fn serialize_with_mode<W: Write>(
+                &self,
+                writer: W,
+                _compress: Compress,
+            ) -> Result<(), SerializationError> {
+                match $compress {
+                    Compress::Yes => self.0.serialize_compressed(writer),
+                    Compress::No => self.0.serialize_uncompressed(writer),
+                }
+            }
+
+            fn serialized_size(&self, _compress: Compress) -> usize {
+                self.0.serialized_size($compress)
+            }
+        }
+
+        impl<T: CanonicalDeserialize> CanonicalDeserialize for $type {
+            fn deserialize_with_mode<R: Read>(
+                reader: R,
+                _compress: Compress,
+                _validate: Validate,
+            ) -> Result<Self, SerializationError> {
+                Ok(Self(T::deserialize_with_mode(
+                    reader, $compress, $validate,
+                )?))
+            }
+        }
+    };
 }
 
-#[cfg(feature = "serde")]
-impl<T> serde::Serialize for UncompressedChecked<T>
-where
-    T: CanonicalSerialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut buf = ark_std::vec![];
-        self.0
-            .serialize_with_mode(&mut buf, Compress::No)
-            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
-        serializer.serialize_bytes(&buf)
-    }
-}
-#[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for CompressedUnchecked<T>
-where
-    T: CanonicalDeserialize,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
-        let t = T::deserialize_with_mode(&buf[..], Compress::Yes, Validate::No)
-            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
-        Ok(CompressedUnchecked(t))
-    }
+macro_rules! impl_valid {
+    ($type:ty) => {
+        impl<T: Valid> Valid for $type {
+            fn check(&self) -> Result<(), SerializationError> {
+                self.0.check()
+            }
+        }
+    };
 }
 
-#[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for UncompressedUnchecked<T>
-where
-    T: CanonicalDeserialize,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
-        let t = T::deserialize_with_mode(&buf[..], Compress::No, Validate::No)
-            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
-        Ok(UncompressedUnchecked(t))
-    }
-}
+impl_deref!(CompressedUnchecked<T>);
+impl_deref!(UncompressedUnchecked<T>);
+impl_deref!(CompressedChecked<T>);
+impl_deref!(UncompressedChecked<T>);
 
-#[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for CompressedChecked<T>
-where
-    T: CanonicalDeserialize,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
-        let t = T::deserialize_with_mode(&buf[..], Compress::Yes, Validate::Yes)
-            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
-        Ok(CompressedChecked(t))
-    }
-}
+impl_serde!(CompressedUnchecked<T>, Compress::Yes, Validate::No);
+impl_serde!(UncompressedUnchecked<T>, Compress::No, Validate::No);
+impl_serde!(CompressedChecked<T>, Compress::Yes, Validate::Yes);
+impl_serde!(UncompressedChecked<T>, Compress::No, Validate::Yes);
 
-#[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for UncompressedChecked<T>
-where
-    T: CanonicalDeserialize,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
-        let t = T::deserialize_with_mode(&buf[..], Compress::No, Validate::Yes)
-            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
-        Ok(UncompressedChecked(t))
-    }
-}
+impl_canonical!(CompressedUnchecked<T>, Compress::Yes, Validate::No);
+impl_canonical!(UncompressedUnchecked<T>, Compress::No, Validate::No);
+impl_canonical!(CompressedChecked<T>, Compress::Yes, Validate::Yes);
+impl_canonical!(UncompressedChecked<T>, Compress::No, Validate::Yes);
 
-impl<T> Deref for CompressedUnchecked<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> Deref for UncompressedUnchecked<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> Deref for CompressedChecked<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> Deref for UncompressedChecked<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> DerefMut for CompressedUnchecked<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T> DerefMut for UncompressedUnchecked<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T> DerefMut for CompressedChecked<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T> DerefMut for UncompressedChecked<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T: CanonicalSerialize> CanonicalSerialize for CompressedUnchecked<T> {
-    fn serialize_with_mode<W: Write>(
-        &self,
-        writer: W,
-        _compress: Compress,
-    ) -> Result<(), SerializationError> {
-        self.0.serialize_compressed(writer)
-    }
-
-    fn serialized_size(&self, _compress: Compress) -> usize {
-        self.0.serialized_size(Compress::Yes)
-    }
-}
-
-impl<T: CanonicalSerialize> CanonicalSerialize for UncompressedUnchecked<T> {
-    fn serialize_with_mode<W: Write>(
-        &self,
-        writer: W,
-        _compress: Compress,
-    ) -> Result<(), SerializationError> {
-        self.0.serialize_uncompressed(writer)
-    }
-
-    fn serialized_size(&self, _compress: Compress) -> usize {
-        self.0.serialized_size(Compress::No)
-    }
-}
-
-impl<T: CanonicalSerialize> CanonicalSerialize for CompressedChecked<T> {
-    fn serialize_with_mode<W: Write>(
-        &self,
-        writer: W,
-        _compress: Compress,
-    ) -> Result<(), SerializationError> {
-        self.0.serialize_compressed(writer)
-    }
-
-    fn serialized_size(&self, _compress: Compress) -> usize {
-        self.0.serialized_size(Compress::Yes)
-    }
-}
-
-impl<T: CanonicalSerialize> CanonicalSerialize for UncompressedChecked<T> {
-    fn serialize_with_mode<W: Write>(
-        &self,
-        writer: W,
-        _compress: Compress,
-    ) -> Result<(), SerializationError> {
-        self.0.serialize_uncompressed(writer)
-    }
-
-    fn serialized_size(&self, _compress: Compress) -> usize {
-        self.0.serialized_size(Compress::No)
-    }
-}
-
-impl<T: Valid> Valid for CompressedUnchecked<T> {
-    fn check(&self) -> Result<(), SerializationError> {
-        self.0.check()
-    }
-}
-
-impl<T: Valid> Valid for UncompressedUnchecked<T> {
-    fn check(&self) -> Result<(), SerializationError> {
-        self.0.check()
-    }
-}
-
-impl<T: Valid> Valid for CompressedChecked<T> {
-    fn check(&self) -> Result<(), SerializationError> {
-        self.0.check()
-    }
-}
-
-impl<T: Valid> Valid for UncompressedChecked<T> {
-    fn check(&self) -> Result<(), SerializationError> {
-        self.0.check()
-    }
-}
-
-impl<T: CanonicalDeserialize> CanonicalDeserialize for CompressedUnchecked<T> {
-    fn deserialize_with_mode<R: Read>(
-        reader: R,
-        _compress: Compress,
-        _validate: Validate,
-    ) -> Result<Self, SerializationError> {
-        Ok(CompressedUnchecked(T::deserialize_with_mode(
-            reader,
-            Compress::Yes,
-            Validate::No,
-        )?))
-    }
-}
-
-impl<T: CanonicalDeserialize> CanonicalDeserialize for UncompressedUnchecked<T> {
-    fn deserialize_with_mode<R: Read>(
-        reader: R,
-        _compress: Compress,
-        _validate: Validate,
-    ) -> Result<Self, SerializationError> {
-        Ok(UncompressedUnchecked(T::deserialize_with_mode(
-            reader,
-            Compress::No,
-            Validate::No,
-        )?))
-    }
-}
-
-impl<T: CanonicalDeserialize> CanonicalDeserialize for CompressedChecked<T> {
-    fn deserialize_with_mode<R: Read>(
-        reader: R,
-        _compress: Compress,
-        _validate: Validate,
-    ) -> Result<Self, SerializationError> {
-        Ok(CompressedChecked(T::deserialize_with_mode(
-            reader,
-            Compress::Yes,
-            Validate::Yes,
-        )?))
-    }
-}
-
-impl<T: CanonicalDeserialize> CanonicalDeserialize for UncompressedChecked<T> {
-    fn deserialize_with_mode<R: Read>(
-        reader: R,
-        _compress: Compress,
-        _validate: Validate,
-    ) -> Result<Self, SerializationError> {
-        Ok(UncompressedChecked(T::deserialize_with_mode(
-            reader,
-            Compress::No,
-            Validate::Yes,
-        )?))
-    }
-}
+impl_valid!(CompressedUnchecked<T>);
+impl_valid!(UncompressedUnchecked<T>);
+impl_valid!(CompressedChecked<T>);
+impl_valid!(UncompressedChecked<T>);

--- a/serialize/src/serde.rs
+++ b/serialize/src/serde.rs
@@ -42,12 +42,6 @@ macro_rules! impl_ops {
                 $cons(value)
             }
         }
-
-        impl<T: Valid> Valid for $type {
-            fn check(&self) -> Result<(), SerializationError> {
-                self.0.check()
-            }
-        }
     };
 }
 
@@ -197,6 +191,12 @@ macro_rules! impl_canonical {
 
             fn serialized_size(&self, _compress: Compress) -> usize {
                 self.0.serialized_size($compress)
+            }
+        }
+
+        impl<T: Valid> Valid for $type {
+            fn check(&self) -> Result<(), SerializationError> {
+                self.0.check()
             }
         }
 

--- a/serialize/src/serde.rs
+++ b/serialize/src/serde.rs
@@ -1,4 +1,4 @@
-use ark_std::ops::{Deref, DerefMut};
+use ark_std::ops::{Deref,DerefMut};
 
 #[cfg(feature = "serde")]
 use ark_std::string::ToString;
@@ -21,8 +21,8 @@ pub struct CompressedChecked<T>(pub T);
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct UncompressedChecked<T>(pub T);
 
-macro_rules! impl_deref {
-    ($type:ty) => {
+macro_rules! impl_ops {
+    ($type:ty, $cons:expr) => {
         impl<T> Deref for $type {
             type Target = T;
 
@@ -34,6 +34,18 @@ macro_rules! impl_deref {
         impl<T> DerefMut for $type {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.0
+            }
+        }
+
+        impl<T> From<T> for $type {
+            fn from(value: T) -> $type {
+                $cons(value)
+            }
+        }
+
+        impl<T: Valid> Valid for $type {
+            fn check(&self) -> Result<(), SerializationError> {
+                self.0.check()
             }
         }
     };
@@ -109,20 +121,10 @@ macro_rules! impl_canonical {
     };
 }
 
-macro_rules! impl_valid {
-    ($type:ty) => {
-        impl<T: Valid> Valid for $type {
-            fn check(&self) -> Result<(), SerializationError> {
-                self.0.check()
-            }
-        }
-    };
-}
-
-impl_deref!(CompressedUnchecked<T>);
-impl_deref!(UncompressedUnchecked<T>);
-impl_deref!(CompressedChecked<T>);
-impl_deref!(UncompressedChecked<T>);
+impl_ops!(CompressedUnchecked<T>, CompressedUnchecked);
+impl_ops!(UncompressedUnchecked<T>, UncompressedUnchecked);
+impl_ops!(CompressedChecked<T>, CompressedChecked);
+impl_ops!(UncompressedChecked<T>, UncompressedChecked);
 
 impl_serde!(CompressedUnchecked<T>, Compress::Yes, Validate::No);
 impl_serde!(UncompressedUnchecked<T>, Compress::No, Validate::No);
@@ -133,8 +135,3 @@ impl_canonical!(CompressedUnchecked<T>, Compress::Yes, Validate::No);
 impl_canonical!(UncompressedUnchecked<T>, Compress::No, Validate::No);
 impl_canonical!(CompressedChecked<T>, Compress::Yes, Validate::Yes);
 impl_canonical!(UncompressedChecked<T>, Compress::No, Validate::Yes);
-
-impl_valid!(CompressedUnchecked<T>);
-impl_valid!(UncompressedUnchecked<T>);
-impl_valid!(CompressedChecked<T>);
-impl_valid!(UncompressedChecked<T>);

--- a/serialize/src/serde.rs
+++ b/serialize/src/serde.rs
@@ -1,0 +1,343 @@
+use ark_std::ops::{Deref, DerefMut};
+use ark_std::string::ToString;
+
+use crate::*;
+
+/// A serde-compatible wrapper that forces compression and skips validation.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct CompressedUnchecked<T>(pub T);
+
+/// A serde-compatible wrapper that skips compression and skips validation.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct UncompressedUnchecked<T>(pub T);
+
+/// A serde-compatible wrapper that forces compression and validates.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct CompressedChecked<T>(pub T);
+
+/// A serde-compatible wrapper that skips compression and forces validation.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct UncompressedChecked<T>(pub T);
+
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for CompressedUnchecked<T>
+where
+    T: CanonicalSerialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut buf = ark_std::vec![];
+        self.0
+            .serialize_with_mode(&mut buf, Compress::Yes)
+            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+        serializer.serialize_bytes(&buf)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for UncompressedUnchecked<T>
+where
+    T: CanonicalSerialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut buf = ark_std::vec![];
+        self.0
+            .serialize_with_mode(&mut buf, Compress::No)
+            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+        serializer.serialize_bytes(&buf)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for CompressedChecked<T>
+where
+    T: CanonicalSerialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut buf = ark_std::vec![];
+        self.0
+            .serialize_with_mode(&mut buf, Compress::Yes)
+            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+        serializer.serialize_bytes(&buf)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> serde::Serialize for UncompressedChecked<T>
+where
+    T: CanonicalSerialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut buf = ark_std::vec![];
+        self.0
+            .serialize_with_mode(&mut buf, Compress::No)
+            .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+        serializer.serialize_bytes(&buf)
+    }
+}
+#[cfg(feature = "serde")]
+impl<'de, T> serde::Deserialize<'de> for CompressedUnchecked<T>
+where
+    T: CanonicalDeserialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
+        let t = T::deserialize_with_mode(&buf[..], Compress::Yes, Validate::No)
+            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+        Ok(CompressedUnchecked(t))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> serde::Deserialize<'de> for UncompressedUnchecked<T>
+where
+    T: CanonicalDeserialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
+        let t = T::deserialize_with_mode(&buf[..], Compress::No, Validate::No)
+            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+        Ok(UncompressedUnchecked(t))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> serde::Deserialize<'de> for CompressedChecked<T>
+where
+    T: CanonicalDeserialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
+        let t = T::deserialize_with_mode(&buf[..], Compress::Yes, Validate::Yes)
+            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+        Ok(CompressedChecked(t))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T> serde::Deserialize<'de> for UncompressedChecked<T>
+where
+    T: CanonicalDeserialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = <ark_std::vec::Vec<u8>>::deserialize(deserializer)?;
+        let t = T::deserialize_with_mode(&buf[..], Compress::No, Validate::Yes)
+            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+        Ok(UncompressedChecked(t))
+    }
+}
+
+impl<T> Deref for CompressedUnchecked<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Deref for UncompressedUnchecked<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Deref for CompressedChecked<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Deref for UncompressedChecked<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for CompressedUnchecked<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> DerefMut for UncompressedUnchecked<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> DerefMut for CompressedChecked<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> DerefMut for UncompressedChecked<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for CompressedUnchecked<T> {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.0.serialize_compressed(writer)
+    }
+
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        self.0.serialized_size(Compress::Yes)
+    }
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for UncompressedUnchecked<T> {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.0.serialize_uncompressed(writer)
+    }
+
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        self.0.serialized_size(Compress::No)
+    }
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for CompressedChecked<T> {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.0.serialize_compressed(writer)
+    }
+
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        self.0.serialized_size(Compress::Yes)
+    }
+}
+
+impl<T: CanonicalSerialize> CanonicalSerialize for UncompressedChecked<T> {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.0.serialize_uncompressed(writer)
+    }
+
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        self.0.serialized_size(Compress::No)
+    }
+}
+
+impl<T: Valid> Valid for CompressedUnchecked<T> {
+    fn check(&self) -> Result<(), SerializationError> {
+        self.0.check()
+    }
+}
+
+impl<T: Valid> Valid for UncompressedUnchecked<T> {
+    fn check(&self) -> Result<(), SerializationError> {
+        self.0.check()
+    }
+}
+
+impl<T: Valid> Valid for CompressedChecked<T> {
+    fn check(&self) -> Result<(), SerializationError> {
+        self.0.check()
+    }
+}
+
+impl<T: Valid> Valid for UncompressedChecked<T> {
+    fn check(&self) -> Result<(), SerializationError> {
+        self.0.check()
+    }
+}
+
+impl<T: CanonicalDeserialize> CanonicalDeserialize for CompressedUnchecked<T> {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        Ok(CompressedUnchecked(T::deserialize_with_mode(
+            reader,
+            Compress::Yes,
+            Validate::No,
+        )?))
+    }
+}
+
+impl<T: CanonicalDeserialize> CanonicalDeserialize for UncompressedUnchecked<T> {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        Ok(UncompressedUnchecked(T::deserialize_with_mode(
+            reader,
+            Compress::No,
+            Validate::No,
+        )?))
+    }
+}
+
+impl<T: CanonicalDeserialize> CanonicalDeserialize for CompressedChecked<T> {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        Ok(CompressedChecked(T::deserialize_with_mode(
+            reader,
+            Compress::Yes,
+            Validate::Yes,
+        )?))
+    }
+}
+
+impl<T: CanonicalDeserialize> CanonicalDeserialize for UncompressedChecked<T> {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        Ok(UncompressedChecked(T::deserialize_with_mode(
+            reader,
+            Compress::No,
+            Validate::Yes,
+        )?))
+    }
+}

--- a/serialize/src/test.rs
+++ b/serialize/src/test.rs
@@ -57,6 +57,33 @@ impl CanonicalDeserialize for Dummy {
 fn test_serialize<T: PartialEq + core::fmt::Debug + CanonicalSerialize + CanonicalDeserialize>(
     data: T,
 ) {
+    #[cfg(feature = "serde")]
+    let serde_ser = |compress: Compress, validate: Validate| -> Result<String, serde_json::Error> {
+        match (compress, validate) {
+            (Compress::Yes, Validate::Yes) => serde_json::to_string(&CompressedChecked(&data)),
+            (Compress::Yes, Validate::No) => serde_json::to_string(&CompressedUnchecked(&data)),
+            (Compress::No, Validate::Yes) => serde_json::to_string(&UncompressedChecked(&data)),
+            (Compress::No, Validate::No) => serde_json::to_string(&UncompressedUnchecked(&data)),
+        }
+    };
+    #[cfg(feature = "serde")]
+    let serde_de =
+        |compress: Compress, validate: Validate, input: &str| -> Result<T, serde_json::Error> {
+            Ok(match (compress, validate) {
+                (Compress::Yes, Validate::Yes) => {
+                    serde_json::from_str::<CompressedChecked<T>>(input)?.0
+                },
+                (Compress::Yes, Validate::No) => {
+                    serde_json::from_str::<CompressedUnchecked<T>>(input)?.0
+                },
+                (Compress::No, Validate::Yes) => {
+                    serde_json::from_str::<UncompressedChecked<T>>(input)?.0
+                },
+                (Compress::No, Validate::No) => {
+                    serde_json::from_str::<UncompressedUnchecked<T>>(input)?.0
+                },
+            })
+        };
     for compress in [Compress::Yes, Compress::No] {
         for validate in [Validate::Yes, Validate::No] {
             let mut serialized = vec![0; data.serialized_size(compress)];
@@ -64,6 +91,12 @@ fn test_serialize<T: PartialEq + core::fmt::Debug + CanonicalSerialize + Canonic
                 .unwrap();
             let de = T::deserialize_with_mode(&serialized[..], compress, validate).unwrap();
             assert_eq!(data, de);
+            #[cfg(feature = "serde")]
+            {
+                let serde_serialized = serde_ser(compress, validate).unwrap();
+                let serde_de = serde_de(compress, validate, &serde_serialized).unwrap();
+                assert_eq!(data, serde_de);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Adds wrapper types that simplify using CanonicalSerialize/CanonicalDeserialize at the boundaries of `serde` types. serde-encoded-bytes is used to encode either efficient binary data for supported data formats, or else base64 fields when human readable.

The wrapper types derive all of the common traits, as well as implementing CanonicalSerialize/CanonicalDeserialize themselves, with an implementation that ignores the runtime parameters and forces validaation / compression status.

The intention is that crates that use arkworks-using crates can slap one of these wrappers around their fields at an integration interface, or use `serde_with` for semver-compatible porting. I've done a trial integration in one of my projects, and it simplifies things considerably. 

Follow-up on https://github.com/arkworks-rs/algebra/pull/506#issuecomment-1911642960

---

- [ ] Wrote unit tests: no real functionality to test
