### PR TITLE
Support 5 mod 8 case in SqrtPrecomputation

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -157,6 +157,13 @@ impl<const N: usize> BigInt<N> {
         (((self.0[0] << 62) >> 62) % 4) as u8
     }
 
+    #[doc(hidden)]
+    pub const fn mod_8(&self) -> u8 {
+        // To compute n % 8, we need to simply look at the
+        // 3 least significant bits of n, and check their value mod 8.
+        (((self.0[0] << 61) >> 61) % 8) as u8
+    }
+
     /// Compute a right shift of `self`
     /// This is equivalent to a (saturating) division by 2.
     #[doc(hidden)]

--- a/ff/src/fields/models/fp/montgomery_backend.rs
+++ b/ff/src/fields/models/fp/montgomery_backend.rs
@@ -93,6 +93,37 @@ pub trait MontConfig<const N: usize>: 'static + Sync + Send + Sized {
         }
     };
 
+    /// (MODULUS + 3) / 8 when MODULUS % 8 == 5. Used for square root precomputations.
+    #[doc(hidden)]
+    const MODULUS_PLUS_THREE_DIV_EIGHT: Option<BigInt<N>> = {
+        match Self::MODULUS.mod_8() == 5 {
+            true => {
+                let (modulus_plus_three, carry) = Self::MODULUS.const_add_with_carry(&BigInt!("3"));
+                let mut result = modulus_plus_three.divide_by_2_round_down();
+                // Since modulus_plus_one is even, dividing by 2 results in a MSB of 0.
+                // Thus we can set MSB to `carry` to get the correct result of (MODULUS + 1) // 2:
+                result.0[N - 1] |= (carry as u64) << 63;
+                result = result.divide_by_2_round_down();
+
+                Some(result.divide_by_2_round_down())
+            },
+            false => None,
+        }
+    };
+
+    /// (MODULUS - 1) / 4 when MODULUS % 8 == 5. Used for square root precomputations.
+    #[doc(hidden)]
+    const MODULUS_MINUS_ONE_DIV_FOUR: Option<BigInt<N>> = {
+        match Self::MODULUS.mod_8() == 5 {
+            true => {
+                let (modulus_plus_three, borrow) = Self::MODULUS.const_sub_with_borrow(&BigInt::one());
+                let mut result = modulus_plus_three.divide_by_2_round_down();
+                Some(result.divide_by_2_round_down())
+            },
+            false => None,
+        }
+    };
+
     /// Sets `a = a + b`.
     #[inline(always)]
     fn add_assign(a: &mut Fp<MontBackend<Self, N>, N>, b: &Fp<MontBackend<Self, N>, N>) {
@@ -548,12 +579,21 @@ pub const fn sqrt_precomputation<const N: usize, T: MontConfig<N>>(
             }),
             None => None,
         },
-        _ => Some(SqrtPrecomputation::TonelliShanks {
-            two_adicity: <MontBackend<T, N>>::TWO_ADICITY,
-            quadratic_nonresidue_to_trace: T::TWO_ADIC_ROOT_OF_UNITY,
-            trace_of_modulus_minus_one_div_two:
+        _ => match T::MODULUS.mod_8() {
+            5 => match (T::MODULUS_PLUS_THREE_DIV_EIGHT.as_ref(), T::MODULUS_MINUS_ONE_DIV_FOUR.as_ref()) {
+                (Some(BigInt(modulus_plus_three_div_eight)), Some(BigInt(modulus_minus_one_div_four))) => Some(SqrtPrecomputation::Case5Mod8 {
+                    modulus_plus_three_div_eight,
+                    modulus_minus_one_div_four,
+                }),
+                _ => None,
+            },
+            _ => Some(SqrtPrecomputation::TonelliShanks {
+                two_adicity: <MontBackend<T, N>>::TWO_ADICITY,
+                quadratic_nonresidue_to_trace: T::TWO_ADIC_ROOT_OF_UNITY,
+                trace_of_modulus_minus_one_div_two:
                 &<Fp<MontBackend<T, N>, N>>::TRACE_MINUS_ONE_DIV_TWO.0,
-        }),
+            }),
+        }
     }
 }
 

--- a/ff/src/fields/sqrt.rs
+++ b/ff/src/fields/sqrt.rs
@@ -154,6 +154,10 @@ impl<F: crate::Field> SqrtPrecomputation<F> {
                 modulus_plus_three_div_eight,
                 modulus_minus_one_div_four,
             } => {
+                if elem.is_zero() {
+                    return Some(F::zero());
+                }
+
                 let result;
 
                 // We have different solutions, if check_value is 1 or -1.


### PR DESCRIPTION
## Description

This pull request optimizes the square root method for cases where the given element equals 5 mod 8. This specific case now runs in constant time, significantly improving performance compared to the Tonelli-Shanks algorithm.