### PR TITLE
Remove redundant constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 - Consolidated logic into `bitreverse_permutation_in_place` and made it public.
+- Remove redundant type constraints from `Pairing::G1Prepared`.
 
 ### Breaking changes
 
@@ -54,7 +55,7 @@
 
 - [\#736](https://github.com/arkworks-rs/algebra/pull/736) (`ark-ff`) Deprecate `divn()`, and use `core::ops::{Shr, ShrAssign}` instead.
 - [\#739](https://github.com/arkworks-rs/algebra/pull/739) (`ark-ff`) Deprecate `muln()`, and use `core::ops::{Shl, ShlAssign}` instead.
-- [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for short Weierstrass curves of cofactor one.  
+- [\#771](https://github.com/arkworks-rs/algebra/pull/771) (`ark-ec`) Omit expensive  scalar multiplication in `is_in_correct_subgroup_assuming_on_curve()` for short Weierstrass curves of cofactor one.
 - [\#817](https://github.com/arkworks-rs/algebra/pull/817) (`ark-ec`) Relax the visibility for G2 ell coeffs and related algorithms.
 
 ### Bugfixes

--- a/ec/src/pairing.rs
+++ b/ec/src/pairing.rs
@@ -51,8 +51,6 @@ pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
         + Debug
         + CanonicalSerialize
         + CanonicalDeserialize
-        + for<'a> From<&'a Self::G1>
-        + for<'a> From<&'a Self::G1Affine>
         + From<Self::G1>
         + From<Self::G1Affine>;
 
@@ -83,8 +81,6 @@ pub trait Pairing: Sized + 'static + Copy + Debug + Sync + Send + Eq {
         + Debug
         + CanonicalSerialize
         + CanonicalDeserialize
-        + for<'a> From<&'a Self::G2>
-        + for<'a> From<&'a Self::G2Affine>
         + From<Self::G2>
         + From<Self::G2Affine>;
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Associated types `ark_ec::pairing::Pairing::G1Prepared ` and `ark_ec::pairing::Pairing::G2Prepared` have the redundant constraints
```
for<'a> From<&'a Self::G1>
for<'a> From<&'a Self::G1Affine>
```
First, these are redundant because `G1` and `G1Affine` (similarly `G2`) implement the Copy trait. Second, we may not care for the benefits of `G1Prepared` and `G2Prepared` at all and we simply want a Pairing instance for `G1` and `G2`. 
A sensible thing to do then is to define

```
type G1 = G1;
type G1Prepared = G1;
```

The redundant constraints forbid this in this case, as `G1Prepared` is more constrained than `G1`. This commit fixes this.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
