### PR TITLE
Replace deprecated muln and divn methods with << and >> operators in …

### DIFF
--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -995,18 +995,18 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let mut one_mul = B::from(1u64);
-    /// one_mul.muln(5);
+    /// one_mul <<= 5;
     /// assert_eq!(one_mul, B::from(32u64));
     ///
     /// // Edge-Case
     /// let mut zero = B::from(0u64);
-    /// zero.muln(5);
+    /// zero <<= 5;
     /// assert_eq!(zero, B::from(0u64));
     ///
     /// let mut arr: [bool; 64] = [false; 64];
     /// arr[4] = true;
     /// let mut mul = B::from_bits_be(&arr);
-    /// mul.muln(5);
+    /// mul <<= 5;
     /// assert_eq!(mul, B::from(0u64));
     /// ```
     #[deprecated(since = "0.4.2", note = "please use the operator `<<` instead")]
@@ -1105,14 +1105,14 @@ pub trait BigInteger:
     ///
     /// // Basic
     /// let (mut one, mut thirty_two_div) = (B::from(1u64), B::from(32u64));
-    /// thirty_two_div.divn(5);
+    /// thirty_two_div >>= 5;
     /// assert_eq!(one, thirty_two_div);
     ///
     /// // Edge-Case
     /// let mut arr: [bool; 64] = [false; 64];
     /// arr[4] = true;
     /// let mut div = B::from_bits_le(&arr);
-    /// div.divn(5);
+    /// div >>= 5;
     /// assert_eq!(div, B::from(0u64));
     /// ```
     #[deprecated(since = "0.4.2", note = "please use the operator `>>` instead")]


### PR DESCRIPTION

## Description

This PR updates the example documentation for the deprecated BigInteger methods
muln() and divn(), replacing them with the recommended operator-based alternatives
<< and >> respectively.
These methods were marked as deprecated in version 0.4.2 of ark-ff, with notes to use
the operators instead. The update eliminates deprecation warnings when running tests,
improving the developer experience while maintaining the same functionality.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
