### PR TITLE
 fix(serialize): Allow serialization of unsized types within Rc, Arc, and Cow

### DIFF
--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -337,7 +337,7 @@ impl<T: Send + Sync> CanonicalDeserialize for PhantomData<T> {
     }
 }
 
-impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for Rc<T> {
+impl<T: ?Sized + CanonicalSerialize + ToOwned> CanonicalSerialize for Rc<T> {
     #[inline]
     fn serialize_with_mode<W: Write>(
         &self,
@@ -354,7 +354,7 @@ impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for Rc<T> {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for ark_std::sync::Arc<T> {
+impl<T: ?Sized + CanonicalSerialize + ToOwned> CanonicalSerialize for ark_std::sync::Arc<T> {
     #[inline]
     fn serialize_with_mode<W: Write>(
         &self,
@@ -371,7 +371,7 @@ impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for ark_std::sync::Arc<
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<T: Valid + Sync + Send> Valid for ark_std::sync::Arc<T> {
+impl<T: ?Sized + Valid + Sync + Send> Valid for ark_std::sync::Arc<T> {
     #[inline]
     fn check(&self) -> Result<(), SerializationError> {
         self.as_ref().check()
@@ -389,7 +389,7 @@ impl<T: Valid + Sync + Send> Valid for ark_std::sync::Arc<T> {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<T: CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize
+impl<T: ?Sized + CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize
     for ark_std::sync::Arc<T>
 {
     #[inline]
@@ -404,7 +404,7 @@ impl<T: CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize
     }
 }
 
-impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for Cow<'_, T> {
+impl<T: ?Sized + CanonicalSerialize + ToOwned> CanonicalSerialize for Cow<'_, T> {
     #[inline]
     fn serialize_with_mode<W: Write>(
         &self,
@@ -422,7 +422,7 @@ impl<T: CanonicalSerialize + ToOwned> CanonicalSerialize for Cow<'_, T> {
 
 impl<T> Valid for Cow<'_, T>
 where
-    T: ToOwned + Sync + Valid + Send,
+    T: ?Sized + ToOwned + Sync + Valid + Send,
     <T as ToOwned>::Owned: CanonicalDeserialize + Send,
 {
     #[inline]
@@ -444,7 +444,7 @@ where
 
 impl<T> CanonicalDeserialize for Cow<'_, T>
 where
-    T: ToOwned + Valid + Sync + Send,
+    T: ?Sized + ToOwned + Valid + Sync + Send,
     <T as ToOwned>::Owned: CanonicalDeserialize + Valid + Send,
 {
     #[inline]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR relaxes the implicit `Sized` bound on the `CanonicalSerialize` and `CanonicalDeserialize` blanket implementations for `Rc<T>`, `Arc<T>`, and `Cow<'_, T>`.

Previously, these implementations required `T: Sized`, which prevented serialization/deserialization of types like `Cow<'a, [U]>` even when `U` implemented the necessary traits. This change adds the `?Sized` bound to `T` in the relevant `impl` blocks within `serialize/src/impls.rs`, allowing these types to be used.

closes: #973

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests - *Note: Unit tests covering the `?Sized` cases (e.g., `Cow<'a, [T]>`) should be added.*
- [x] Updated relevant documentation in the code - *Note: No specific documentation updates were required for this change.*
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` - *Note: A changelog entry needs to be added.*
- [x] Re-reviewed `Files changed` in the GitHub PR explorer - *Note: Please double-check the changes in `serialize/src/impls.rs`.*