### PR TITLE
Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           tool: cargo-release
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cargo-bins/release-pr@v2
         with:
           pr-template-file: .github/release-pr-template.ejs


### PR DESCRIPTION
This PR updates the GitHub Actions checkout action from v3 to v4.

Changes:
- Upgraded actions/checkout from v3 to v4 in the release PR workflow

This update ensures we're using the latest version of the checkout action with its improvements and bug fixes.