### PR TITLE
fix: remove unnecessary ?Sized constraints in Valid implementations

### DIFF
--- a/serialize/src/impls.rs
+++ b/serialize/src/impls.rs
@@ -371,7 +371,7 @@ impl<T: ?Sized + CanonicalSerialize + ToOwned> CanonicalSerialize for ark_std::s
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<T: ?Sized + Valid + Sync + Send> Valid for ark_std::sync::Arc<T> {
+impl<T: Valid + Sync + Send> Valid for ark_std::sync::Arc<T> {
     #[inline]
     fn check(&self) -> Result<(), SerializationError> {
         self.as_ref().check()
@@ -389,7 +389,7 @@ impl<T: ?Sized + Valid + Sync + Send> Valid for ark_std::sync::Arc<T> {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<T: ?Sized + CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize
+impl<T: CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize
     for ark_std::sync::Arc<T>
 {
     #[inline]
@@ -422,7 +422,7 @@ impl<T: ?Sized + CanonicalSerialize + ToOwned> CanonicalSerialize for Cow<'_, T>
 
 impl<T> Valid for Cow<'_, T>
 where
-    T: ?Sized + ToOwned + Sync + Valid + Send,
+    T: ToOwned + Sync + Valid + Send,
     <T as ToOwned>::Owned: CanonicalDeserialize + Send,
 {
     #[inline]
@@ -444,7 +444,7 @@ where
 
 impl<T> CanonicalDeserialize for Cow<'_, T>
 where
-    T: ?Sized + ToOwned + Valid + Sync + Send,
+    T: ToOwned + Valid + Sync + Send,
     <T as ToOwned>::Owned: CanonicalDeserialize + Valid + Send,
 {
     #[inline]


### PR DESCRIPTION
## Description

This commit fixes compiler warnings related to the use of the ?Sized constraint in the Valid trait and CanonicalDeserialize implementations.

The problem was that trait Valid has an explicit Sized constraint in its definition:
`pub trait Valid: Sized + Sync { .... }`

However, some implementations have used the ?Sized constraint, which makes no sense, 
since Valid already requires Sized. These constraints have been removed in the following places:

1. impl<T: ?Sized + Valid + Sync + Send> Valid for ark_std::sync::Arc<T>
2. impl<T: ?Sized + CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize for ark_std::sync::Arc<T>
3. impl where T: ?Sized + ToOwned + Sync + Valid + Send for Cow<'_, T>
4. impl where T: ?Sized + ToOwned + Valid + Sync + Send for CanonicalDeserialize

This change does not affect functionality, since types that implement the Valid trait already 
must be Sized due to a limitation in the trait definition.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
