### PR TITLE
Use map_or_else for lazy default value in From<Bucket<P>> for Affine<P>

### DIFF
--- a/ec/src/models/short_weierstrass/bucket.rs
+++ b/ec/src/models/short_weierstrass/bucket.rs
@@ -377,7 +377,7 @@ impl<P: SWCurveConfig> From<Affine<P>> for Bucket<P> {
 impl<P: SWCurveConfig> From<Bucket<P>> for Affine<P> {
     #[inline]
     fn from(p: Bucket<P>) -> Self {
-        p.zzz.inverse().map_or(Affine::zero(), |zzz_inv| {
+        p.zzz.inverse().map_or_else(Affine::zero, |zzz_inv| {
             let b = p.zz.square();
             let x = p.x * &b;
             let y = p.y * zzz_inv;


### PR DESCRIPTION
## Description

Replaced map_or(Affine::zero(), ...) with map_or_else(Affine::zero, ...) in the From<Bucket<P>> for Affine<P> implementation.
This ensures that the default value Affine::zero is only computed when needed, improving efficiency and code clarity.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
