### PR TITLE
Relax bound `FftField` on GeneralEvaluationDomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Consolidated logic into `bitreverse_permutation_in_place` and made it public.
 - Remove redundant type constraints from `Pairing::G1Prepared`.
 - (`ark-serialize`) Add serde-compatible wrapper types `CompressedChecked<T>`, `CompressedUnchecked<T>`, `UncompressedChecked<T>`, `UncompressedUnchecked<T>`.
+- [\#989](https://github.com/arkworks-rs/algebra/pull/989) (`ark-poly`) Replace bound `F: FftField` with `F: Field` on `GeneralEvaluationDomain`.
 
 ### Breaking changes
 

--- a/poly/src/domain/general.rs
+++ b/poly/src/domain/general.rs
@@ -10,7 +10,7 @@ pub use crate::domain::utils::Elements;
 use crate::domain::{
     DomainCoeff, EvaluationDomain, MixedRadixEvaluationDomain, Radix2EvaluationDomain,
 };
-use ark_ff::FftField;
+use ark_ff::{FftField, Field};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
 };
@@ -47,7 +47,7 @@ use ark_std::{
 /// let new_evals = large_domain.fft(&coeffs);
 /// ```
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub enum GeneralEvaluationDomain<F: FftField> {
+pub enum GeneralEvaluationDomain<F: Field> {
     /// Radix-2 domain
     Radix2(Radix2EvaluationDomain<F>),
     /// Mixed-radix domain

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -15,7 +15,7 @@ use crate::domain::{
     utils::{best_fft, bitreverse_permutation_in_place},
     DomainCoeff, EvaluationDomain,
 };
-use ark_ff::{fields::utils::k_adicity, FftField};
+use ark_ff::{fields::utils::k_adicity, FftField, Field};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{cmp::min, fmt, vec::*};
 #[cfg(feature = "parallel")]
@@ -26,7 +26,7 @@ use rayon::prelude::*;
 /// Works only for fields that have a multiplicative subgroup of size that is
 /// a power-of-2 and another small subgroup over a different base defined.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct MixedRadixEvaluationDomain<F: FftField> {
+pub struct MixedRadixEvaluationDomain<F: Field> {
     /// The size of the domain.
     pub size: u64,
     /// `log_2(self.size)`.
@@ -48,7 +48,7 @@ pub struct MixedRadixEvaluationDomain<F: FftField> {
     pub offset_pow_size: F,
 }
 
-impl<F: FftField> fmt::Debug for MixedRadixEvaluationDomain<F> {
+impl<F: Field> fmt::Debug for MixedRadixEvaluationDomain<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -6,7 +6,7 @@
 
 pub use crate::domain::utils::{bitreverse_permutation_in_place, Elements};
 use crate::domain::{DomainCoeff, EvaluationDomain};
-use ark_ff::FftField;
+use ark_ff::{FftField, Field};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{fmt, vec::*};
 
@@ -19,7 +19,7 @@ const DEGREE_AWARE_FFT_THRESHOLD_FACTOR: usize = 1 << 2;
 /// only for fields that have a large multiplicative subgroup of size that is
 /// a power-of-2.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Radix2EvaluationDomain<F: FftField> {
+pub struct Radix2EvaluationDomain<F: Field> {
     /// The size of the domain.
     pub size: u64,
     /// `log_2(self.size)`.
@@ -41,7 +41,7 @@ pub struct Radix2EvaluationDomain<F: FftField> {
     pub offset_pow_size: F,
 }
 
-impl<F: FftField> fmt::Debug for Radix2EvaluationDomain<F> {
+impl<F: Field> fmt::Debug for Radix2EvaluationDomain<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Radix-2 multiplicative subgroup of size {}", self.size)
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #984

Replaces bound `F: FftField` with `F: Field` on `GeneralEvaluationDomain`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (Not applicable)
- [ ] Updated relevant documentation in the code (No documentation needs to be updated)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
