### PR TITLE
Refactor: Minor Function Renaming and Error Message Clarification

### DIFF
--- a/ec/src/hashing/curve_maps/elligator2.rs
+++ b/ec/src/hashing/curve_maps/elligator2.rs
@@ -257,7 +257,7 @@ mod test {
     /// The point of the test is to get a simple twisted edwards curve and make
     /// simple hash
     #[test]
-    fn hash_arbitary_string_to_curve_elligator2() {
+    fn hash_arbitrary_string_to_curve_elligator2() {
         let test_elligator2_to_curve_hasher = MapToCurveBasedHasher::<
             Projective<TestElligator2MapToCurveConfig>,
             DefaultFieldHasher<Sha256, 128>,

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -218,14 +218,14 @@ pub trait CanonicalSerializeHashExt: CanonicalSerialize {
     fn hash<H: Digest>(&self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
         let mut hasher = H::new();
         self.serialize_compressed(HashMarshaller(&mut hasher))
-            .expect("HashMarshaller::flush should be infaillible!");
+            .expect("HashMarshaller::flush should be infallible!");
         hasher.finalize()
     }
 
     fn hash_uncompressed<H: Digest>(&self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
         let mut hasher = H::new();
         self.serialize_uncompressed(HashMarshaller(&mut hasher))
-            .expect("HashMarshaller::flush should be infaillible!");
+            .expect("HashMarshaller::flush should be infallible!");
         hasher.finalize()
     }
 }


### PR DESCRIPTION


**Description:**  
- Renamed test function for clarity in `elligator2.rs`.
- Improved error message wording in `lib.rs` to enhance code readability and maintainability.