### PR TITLE
Improves the performance of VariableBaseMSM when scalars are small

### DIFF
--- a/bench-templates/src/macros/ec.rs
+++ b/bench-templates/src/macros/ec.rs
@@ -299,7 +299,7 @@ macro_rules! ec_bench {
                             .collect();
                         b.iter(|| <$Group>::msm_u32(&v, &s))
                     });
-                    
+
                     c.bench_function(&format!("MSM-i32 for {name}"), |b| {
                         let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(i32::rand(&mut rng)).into_bigint())

--- a/bench-templates/src/macros/ec.rs
+++ b/bench-templates/src/macros/ec.rs
@@ -232,7 +232,7 @@ macro_rules! ec_bench {
                         })
                     });
 
-                    
+
                     c.bench_function(&format!("MSM-bool for {name}"), |b| {
                         let scalars: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(bool::rand(&mut rng)).into_bigint())
@@ -252,7 +252,7 @@ macro_rules! ec_bench {
                             result
                         })
                     });
-                    
+
                     c.bench_function(&format!("MSM-i8 for {name}"), |b| {
                         let scalars: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(i8::rand(&mut rng)).into_bigint())
@@ -272,7 +272,7 @@ macro_rules! ec_bench {
                             result
                         })
                     });
-                    
+
                     c.bench_function(&format!("MSM-i16 for {name}"), |b| {
                         let scalars: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(i16::rand(&mut rng)).into_bigint())
@@ -282,7 +282,7 @@ macro_rules! ec_bench {
                             result
                         })
                     });
-                    
+
                     c.bench_function(&format!("MSM-u32 for {name}"), |b| {
                         let scalars: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(u32::rand(&mut rng)).into_bigint())
@@ -321,7 +321,7 @@ macro_rules! ec_bench {
                             result
                         })
                     });
-                    
+
                     c.bench_function(&format!("MSM-mixed for {name}"), |b| {
                         const S: usize = SAMPLES / 11;
                         let mut s = Vec::with_capacity(S * 11);
@@ -344,7 +344,7 @@ macro_rules! ec_bench {
                         // Positive and negative u64s
                         s.extend((0..S).map(|_| Scalar::from(u64::rand(&mut rng))));
                         s.extend((0..S).map(|_| -Scalar::from(u64::rand(&mut rng))));
-                        
+
                         // Random scalars
                         s.extend((0..S).map(|_| Scalar::rand(&mut rng)));
                         s.shuffle(&mut rng);
@@ -358,7 +358,7 @@ macro_rules! ec_bench {
                         })
                     });
                 }
-                
+
                 $crate::criterion_group!(benches, rand, arithmetic, serialization, msm_131072);
             }
         }

--- a/bench-templates/src/macros/ec.rs
+++ b/bench-templates/src/macros/ec.rs
@@ -219,88 +219,62 @@ macro_rules! ec_bench {
                         .map(|_| <$Group>::rand(&mut rng))
                         .collect();
                     let v = <$Group>::normalize_batch(&v);
-                    let scalars: Vec<_> = (0..SAMPLES)
-                        .map(|_| Scalar::rand(&mut rng).into_bigint())
-                        .collect();
+
                     c.bench_function(&format!("MSM-random for {name}"), |b| {
+                        let scalars: Vec<_> = (0..SAMPLES)
+                            .map(|_| Scalar::rand(&mut rng).into_bigint())
+                            .collect();
                         b.iter(|| {
                             let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
                             result
                         })
                     });
-                }
-                
-                fn msm_131072_bool(c: &mut $crate::criterion::Criterion) {
-                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
-                    use ark_ff::PrimeField;
-                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-                    use ark_std::UniformRand;
 
-                    const SAMPLES: usize = 131072;
-
-                    let name = format!("{}::{}", $curve_name, stringify!($Group));
-                    let mut rng = ark_std::test_rng();
-
-                    let v: Vec<_> = (0..SAMPLES)
-                        .map(|_| <$Group>::rand(&mut rng))
-                        .collect();
-                    let v = <$Group>::normalize_batch(&v);
-                    let scalars: Vec<_> = (0..SAMPLES)
-                        .map(|_| Scalar::from(bool::rand(&mut rng)).into_bigint())
-                        .collect();
+                    
                     c.bench_function(&format!("MSM-bool for {name}"), |b| {
+                        let scalars: Vec<_> = (0..SAMPLES)
+                            .map(|_| Scalar::from(bool::rand(&mut rng)).into_bigint())
+                            .collect();
                         b.iter(|| {
                             let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
                             result
                         })
                     });
-                }
-                
-                fn msm_131072_u8(c: &mut $crate::criterion::Criterion) {
-                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
-                    use ark_ff::PrimeField;
-                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-                    use ark_std::UniformRand;
 
-                    const SAMPLES: usize = 131072;
-
-                    let name = format!("{}::{}", $curve_name, stringify!($Group));
-                    let mut rng = ark_std::test_rng();
-
-                    let v: Vec<_> = (0..SAMPLES)
-                        .map(|_| <$Group>::rand(&mut rng))
-                        .collect();
-                    let v = <$Group>::normalize_batch(&v);
-                    let scalars: Vec<_> = (0..SAMPLES)
-                        .map(|_| Scalar::from(u8::rand(&mut rng)).into_bigint())
-                        .collect();
                     c.bench_function(&format!("MSM-u8 for {name}"), |b| {
+                        let scalars: Vec<_> = (0..SAMPLES)
+                            .map(|_| Scalar::from(u8::rand(&mut rng)).into_bigint())
+                            .collect();
                         b.iter(|| {
                             let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
                             result
                         })
                     });
-                }
-                
-                fn msm_131072_u16(c: &mut $crate::criterion::Criterion) {
-                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
-                    use ark_ff::PrimeField;
-                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-                    use ark_std::UniformRand;
 
-                    const SAMPLES: usize = 131072;
-
-                    let name = format!("{}::{}", $curve_name, stringify!($Group));
-                    let mut rng = ark_std::test_rng();
-
-                    let v: Vec<_> = (0..SAMPLES)
-                        .map(|_| <$Group>::rand(&mut rng))
-                        .collect();
-                    let v = <$Group>::normalize_batch(&v);
-                    let scalars: Vec<_> = (0..SAMPLES)
-                        .map(|_| Scalar::from(u16::rand(&mut rng)).into_bigint())
-                        .collect();
                     c.bench_function(&format!("MSM-u16 for {name}"), |b| {
+                        let scalars: Vec<_> = (0..SAMPLES)
+                            .map(|_| Scalar::from(u16::rand(&mut rng)).into_bigint())
+                            .collect();
+                        b.iter(|| {
+                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
+                            result
+                        })
+                    });
+                    
+                    c.bench_function(&format!("MSM-u32 for {name}"), |b| {
+                        let scalars: Vec<_> = (0..SAMPLES)
+                            .map(|_| Scalar::from(u32::rand(&mut rng)).into_bigint())
+                            .collect();
+                        b.iter(|| {
+                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
+                            result
+                        })
+                    });
+
+                    c.bench_function(&format!("MSM-u64 for {name}"), |b| {
+                        let scalars: Vec<_> = (0..SAMPLES)
+                            .map(|_| Scalar::from(u64::rand(&mut rng)).into_bigint())
+                            .collect();
                         b.iter(|| {
                             let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
                             result
@@ -308,59 +282,7 @@ macro_rules! ec_bench {
                     });
                 }
                 
-                fn msm_131072_u32(c: &mut $crate::criterion::Criterion) {
-                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
-                    use ark_ff::PrimeField;
-                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-                    use ark_std::UniformRand;
-
-                    const SAMPLES: usize = 131072;
-
-                    let name = format!("{}::{}", $curve_name, stringify!($Group));
-                    let mut rng = ark_std::test_rng();
-
-                    let v: Vec<_> = (0..SAMPLES)
-                        .map(|_| <$Group>::rand(&mut rng))
-                        .collect();
-                    let v = <$Group>::normalize_batch(&v);
-                    let scalars: Vec<_> = (0..SAMPLES)
-                        .map(|_| Scalar::from(u32::rand(&mut rng)).into_bigint())
-                        .collect();
-                    c.bench_function(&format!("MSM-u32 for {name}"), |b| {
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
-                    });
-                }
-
-                fn msm_131072_u64(c: &mut $crate::criterion::Criterion) {
-                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
-                    use ark_ff::PrimeField;
-                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-                    use ark_std::UniformRand;
-
-                    const SAMPLES: usize = 131072;
-
-                    let name = format!("{}::{}", $curve_name, stringify!($Group));
-                    let mut rng = ark_std::test_rng();
-
-                    let v: Vec<_> = (0..SAMPLES)
-                        .map(|_| <$Group>::rand(&mut rng))
-                        .collect();
-                    let v = <$Group>::normalize_batch(&v);
-                    let scalars: Vec<_> = (0..SAMPLES)
-                        .map(|_| Scalar::from(u64::rand(&mut rng)).into_bigint())
-                        .collect();
-                    c.bench_function(&format!("MSM-u64 for {name}"), |b| {
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
-                    });
-                }
-
-                $crate::criterion_group!(benches, rand, arithmetic, serialization, msm_131072, msm_131072_bool, msm_131072_u8, msm_131072_u16, msm_131072_u32, msm_131072_u64);
+                $crate::criterion_group!(benches, rand, arithmetic, serialization, msm_131072);
             }
         }
     };

--- a/bench-templates/src/macros/ec.rs
+++ b/bench-templates/src/macros/ec.rs
@@ -204,7 +204,7 @@ macro_rules! ec_bench {
                     );
                 }
 
-                fn msm_131072(c: &mut $crate::criterion::Criterion) {
+                fn msm(c: &mut $crate::criterion::Criterion) {
                     use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
                     use ark_ff::PrimeField;
                     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -223,103 +223,108 @@ macro_rules! ec_bench {
                     let v = <$Group>::normalize_batch(&v);
 
                     c.bench_function(&format!("MSM-random for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::rand(&mut rng).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
 
 
                     c.bench_function(&format!("MSM-bool for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(bool::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
+                    });
+
+                    c.bench_function(&format!("MSM-bool-direct for {name}"), |b| {
+                        let s: Vec<_> = (0..SAMPLES)
+                            .map(|_| bool::rand(&mut rng))
+                            .collect();
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_u1(&v, &s))
                     });
 
                     c.bench_function(&format!("MSM-u8 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(u8::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
+                    });
+
+                    c.bench_function(&format!("MSM-u8-direct for {name}"), |b| {
+                        let s: Vec<_> = (0..SAMPLES)
+                            .map(|_| u8::rand(&mut rng))
+                            .collect();
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_u8(&v, &s))
                     });
 
                     c.bench_function(&format!("MSM-i8 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(i8::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
 
                     c.bench_function(&format!("MSM-u16 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(u16::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
+                    });
+
+                    c.bench_function(&format!("MSM-u16-direct for {name}"), |b| {
+                        let s: Vec<_> = (0..SAMPLES)
+                            .map(|_| u16::rand(&mut rng))
+                            .collect();
+                        b.iter(|| <$Group>::msm_u16(&v, &s))
                     });
 
                     c.bench_function(&format!("MSM-i16 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(i16::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
 
                     c.bench_function(&format!("MSM-u32 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(u32::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
+
+                    c.bench_function(&format!("MSM-u32-direct for {name}"), |b| {
+                        let s: Vec<_> = (0..SAMPLES)
+                            .map(|_| u32::rand(&mut rng))
+                            .collect();
+                        b.iter(|| <$Group>::msm_u32(&v, &s))
+                    });
+                    
                     c.bench_function(&format!("MSM-i32 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(i32::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
 
                     c.bench_function(&format!("MSM-u64 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(u64::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
 
+                    c.bench_function(&format!("MSM-u64-direct for {name}"), |b| {
+                        let s: Vec<_> = (0..SAMPLES)
+                            .map(|_| u64::rand(&mut rng))
+                            .collect();
+                        b.iter(|| <$Group>::msm_u64(&v, &s))
+                    });
                     c.bench_function(&format!("MSM-i64 for {name}"), |b| {
-                        let scalars: Vec<_> = (0..SAMPLES)
+                        let s: Vec<_> = (0..SAMPLES)
                             .map(|_| Scalar::from(i64::rand(&mut rng)).into_bigint())
                             .collect();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
 
                     c.bench_function(&format!("MSM-mixed for {name}"), |b| {
@@ -345,21 +350,18 @@ macro_rules! ec_bench {
                         s.extend((0..S).map(|_| Scalar::from(u64::rand(&mut rng))));
                         s.extend((0..S).map(|_| -Scalar::from(u64::rand(&mut rng))));
 
-                        // Random scalars
+                        // Random s
                         s.extend((0..S).map(|_| Scalar::rand(&mut rng)));
                         s.shuffle(&mut rng);
-                        let scalars = s
+                        let s = s
                             .into_iter()
                             .map(|s| s.into_bigint())
                             .collect::<Vec<_>>();
-                        b.iter(|| {
-                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
-                            result
-                        })
+                        b.iter(|| <$Group as VariableBaseMSM>::msm_bigint(&v, &s))
                     });
                 }
 
-                $crate::criterion_group!(benches, rand, arithmetic, serialization, msm_131072);
+                $crate::criterion_group!(benches, rand, arithmetic, serialization, msm);
             }
         }
     };

--- a/bench-templates/src/macros/ec.rs
+++ b/bench-templates/src/macros/ec.rs
@@ -222,7 +222,111 @@ macro_rules! ec_bench {
                     let scalars: Vec<_> = (0..SAMPLES)
                         .map(|_| Scalar::rand(&mut rng).into_bigint())
                         .collect();
-                    c.bench_function(&format!("MSM for {name}"), |b| {
+                    c.bench_function(&format!("MSM-random for {name}"), |b| {
+                        b.iter(|| {
+                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
+                            result
+                        })
+                    });
+                }
+                
+                fn msm_131072_bool(c: &mut $crate::criterion::Criterion) {
+                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
+                    use ark_ff::PrimeField;
+                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+                    use ark_std::UniformRand;
+
+                    const SAMPLES: usize = 131072;
+
+                    let name = format!("{}::{}", $curve_name, stringify!($Group));
+                    let mut rng = ark_std::test_rng();
+
+                    let v: Vec<_> = (0..SAMPLES)
+                        .map(|_| <$Group>::rand(&mut rng))
+                        .collect();
+                    let v = <$Group>::normalize_batch(&v);
+                    let scalars: Vec<_> = (0..SAMPLES)
+                        .map(|_| Scalar::from(bool::rand(&mut rng)).into_bigint())
+                        .collect();
+                    c.bench_function(&format!("MSM-bool for {name}"), |b| {
+                        b.iter(|| {
+                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
+                            result
+                        })
+                    });
+                }
+                
+                fn msm_131072_u8(c: &mut $crate::criterion::Criterion) {
+                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
+                    use ark_ff::PrimeField;
+                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+                    use ark_std::UniformRand;
+
+                    const SAMPLES: usize = 131072;
+
+                    let name = format!("{}::{}", $curve_name, stringify!($Group));
+                    let mut rng = ark_std::test_rng();
+
+                    let v: Vec<_> = (0..SAMPLES)
+                        .map(|_| <$Group>::rand(&mut rng))
+                        .collect();
+                    let v = <$Group>::normalize_batch(&v);
+                    let scalars: Vec<_> = (0..SAMPLES)
+                        .map(|_| Scalar::from(u8::rand(&mut rng)).into_bigint())
+                        .collect();
+                    c.bench_function(&format!("MSM-u8 for {name}"), |b| {
+                        b.iter(|| {
+                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
+                            result
+                        })
+                    });
+                }
+                
+                fn msm_131072_u16(c: &mut $crate::criterion::Criterion) {
+                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
+                    use ark_ff::PrimeField;
+                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+                    use ark_std::UniformRand;
+
+                    const SAMPLES: usize = 131072;
+
+                    let name = format!("{}::{}", $curve_name, stringify!($Group));
+                    let mut rng = ark_std::test_rng();
+
+                    let v: Vec<_> = (0..SAMPLES)
+                        .map(|_| <$Group>::rand(&mut rng))
+                        .collect();
+                    let v = <$Group>::normalize_batch(&v);
+                    let scalars: Vec<_> = (0..SAMPLES)
+                        .map(|_| Scalar::from(u16::rand(&mut rng)).into_bigint())
+                        .collect();
+                    c.bench_function(&format!("MSM-u16 for {name}"), |b| {
+                        b.iter(|| {
+                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
+                            result
+                        })
+                    });
+                }
+                
+                fn msm_131072_u32(c: &mut $crate::criterion::Criterion) {
+                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
+                    use ark_ff::PrimeField;
+                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+                    use ark_std::UniformRand;
+
+                    const SAMPLES: usize = 131072;
+
+                    let name = format!("{}::{}", $curve_name, stringify!($Group));
+                    let mut rng = ark_std::test_rng();
+
+                    let v: Vec<_> = (0..SAMPLES)
+                        .map(|_| <$Group>::rand(&mut rng))
+                        .collect();
+                    let v = <$Group>::normalize_batch(&v);
+                    let scalars: Vec<_> = (0..SAMPLES)
+                        .map(|_| Scalar::from(u32::rand(&mut rng)).into_bigint())
+                        .collect();
+                    c.bench_function(&format!("MSM-u32 for {name}"), |b| {
                         b.iter(|| {
                             let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
                             result
@@ -230,7 +334,33 @@ macro_rules! ec_bench {
                     });
                 }
 
-                $crate::criterion_group!(benches, rand, arithmetic, serialization, msm_131072,);
+                fn msm_131072_u64(c: &mut $crate::criterion::Criterion) {
+                    use ark_ec::{scalar_mul::variable_base::VariableBaseMSM, CurveGroup};
+                    use ark_ff::PrimeField;
+                    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+                    use ark_std::UniformRand;
+
+                    const SAMPLES: usize = 131072;
+
+                    let name = format!("{}::{}", $curve_name, stringify!($Group));
+                    let mut rng = ark_std::test_rng();
+
+                    let v: Vec<_> = (0..SAMPLES)
+                        .map(|_| <$Group>::rand(&mut rng))
+                        .collect();
+                    let v = <$Group>::normalize_batch(&v);
+                    let scalars: Vec<_> = (0..SAMPLES)
+                        .map(|_| Scalar::from(u64::rand(&mut rng)).into_bigint())
+                        .collect();
+                    c.bench_function(&format!("MSM-u64 for {name}"), |b| {
+                        b.iter(|| {
+                            let result: $Group = VariableBaseMSM::msm_bigint(&v, &scalars);
+                            result
+                        })
+                    });
+                }
+
+                $crate::criterion_group!(benches, rand, arithmetic, serialization, msm_131072, msm_131072_bool, msm_131072_u8, msm_131072_u16, msm_131072_u32, msm_131072_u64);
             }
         }
     };

--- a/bench-templates/src/macros/ec.rs
+++ b/bench-templates/src/macros/ec.rs
@@ -209,8 +209,9 @@ macro_rules! ec_bench {
                     use ark_ff::PrimeField;
                     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
                     use ark_std::UniformRand;
+                    let mut c = c.benchmark_group("MSM");
 
-                    const SAMPLES: usize = 131072;
+                    const SAMPLES: usize = 1 << 20;
 
                     let name = format!("{}::{}", $curve_name, stringify!($Group));
                     let mut rng = ark_std::test_rng();
@@ -280,6 +281,7 @@ macro_rules! ec_bench {
                             result
                         })
                     });
+                    c.sample_size(10);
                 }
                 
                 $crate::criterion_group!(benches, rand, arithmetic, serialization, msm_131072);

--- a/ec/src/hashing/curve_maps/elligator2.rs
+++ b/ec/src/hashing/curve_maps/elligator2.rs
@@ -279,7 +279,7 @@ mod test {
     fn map_field_to_curve_elligator2() {
         Elligator2Map::<TestElligator2MapToCurveConfig>::check_parameters().unwrap();
 
-        let mut map_range: Vec<Affine<TestElligator2MapToCurveConfig>> = vec![];
+        let mut map_range: Vec<Affine<TestElligator2MapToCurveConfig>> = Vec::new();
         // We are mapping all elements of the field to the curve, verifying that
         // map is not constant on that set.
         for current_field_element in 0..101 {

--- a/ec/src/hashing/curve_maps/swu.rs
+++ b/ec/src/hashing/curve_maps/swu.rs
@@ -266,7 +266,7 @@ mod test {
     fn map_field_to_curve_swu() {
         SWUMap::<TestSWUMapToCurveConfig>::check_parameters().unwrap();
 
-        let mut map_range: Vec<Affine<TestSWUMapToCurveConfig>> = vec![];
+        let mut map_range: Vec<Affine<TestSWUMapToCurveConfig>> = Vec::with_capacity(128);
         for current_field_element in 0..127 {
             let element = F127::from(current_field_element as u64);
             map_range.push(SWUMap::map_to_curve(element).unwrap());

--- a/ec/src/scalar_mul/variable_base/mod.rs
+++ b/ec/src/scalar_mul/variable_base/mod.rs
@@ -529,6 +529,7 @@ fn msm_bigint_wnaf_parallel<V: VariableBaseMSM>(
             })
 }
 
+#[cfg(feature = "parallel")]
 const THREADS_PER_CHUNK: usize = 2;
 
 /// Computes an MSM using the windowed non-adjacent form (WNAF) algorithm.

--- a/ec/src/scalar_mul/variable_base/mod.rs
+++ b/ec/src/scalar_mul/variable_base/mod.rs
@@ -1,11 +1,11 @@
 use ark_ff::prelude::*;
 use ark_std::{
     borrow::Borrow,
-    cfg_into_iter,
+    cfg_chunks, cfg_into_iter, cfg_iter,
     iterable::Iterable,
     ops::{AddAssign, SubAssign},
     vec,
-    vec::*,
+    vec::Vec,
 };
 
 #[cfg(feature = "parallel")]
@@ -60,7 +60,7 @@ pub trait VariableBaseMSM: ScalarMul + for<'a> AddAssign<&'a Self::Bucket> {
         let bigints = cfg_into_iter!(scalars)
             .map(|s| s.into_bigint())
             .collect::<Vec<_>>();
-        Self::msm_bigint(bases, &bigints)
+        Self::msm_bigint(bases, bigints.as_slice())
     }
 
     /// Performs multi-scalar multiplication.
@@ -82,10 +82,15 @@ pub trait VariableBaseMSM: ScalarMul + for<'a> AddAssign<&'a Self::Bucket> {
         bigints: &[<Self::ScalarField as PrimeField>::BigInt],
     ) -> Self {
         if Self::NEGATION_IS_CHEAP {
-            msm_bigint_wnaf(bases, bigints)
+            msm_signed(bases, bigints)
         } else {
-            msm_bigint(bases, bigints)
+            msm_unsigned(bases, bigints)
         }
+    }
+
+    /// Performs multi-scalar multiplication when the scalars are known to be boolean.
+    fn msm_bool(bases: &[Self::MulBase], scalars: &[bool]) -> Self {
+        msm_binary(bases, scalars)
     }
 
     /// Streaming multi-scalar multiplication algorithm with hard-coded chunk
@@ -124,12 +129,342 @@ pub trait VariableBaseMSM: ScalarMul + for<'a> AddAssign<&'a Self::Bucket> {
     }
 }
 
+#[inline]
+fn get_group<const N: usize, A: Send + Sync, B: Send + Sync>(
+    grouped: &[u64],
+    f: impl Fn(usize) -> (A, B) + Send + Sync,
+) -> (Vec<A>, Vec<B>) {
+    let extract_index = |i| ((i << N) >> N) as usize;
+    cfg_iter!(grouped)
+        .map(|&i| f(extract_index(i)))
+        .unzip::<_, _, Vec<_>, Vec<_>>()
+}
+
+#[inline]
+fn uget_group<A: Send + Sync, B: Send + Sync>(
+    grouped: &[u64],
+    f: impl Fn(usize) -> (A, B) + Send + Sync,
+) -> (Vec<A>, Vec<B>) {
+    get_group::<3, _, _>(grouped, f)
+}
+
+#[inline]
+fn iget_group<A: Send + Sync, B: Send + Sync>(
+    grouped: &[u64],
+    f: impl Fn(usize) -> (A, B) + Send + Sync,
+) -> (Vec<A>, Vec<B>) {
+    get_group::<4, _, _>(grouped, f)
+}
+
+/// Computes multi-scalar multiplication where the scalars
+/// are positive.
+/// Should be used when the negation is expensive, i.e. when
+/// `V::NEGATION_IS_CHEAP` is `false`.
+fn msm_unsigned<V: VariableBaseMSM>(
+    bases: &[V::MulBase],
+    scalars: &[<V::ScalarField as PrimeField>::BigInt],
+) -> V {
+    // Partition scalars according to whether
+    // 1. they are in the range {0, 1};
+    // 3. they are in the range [0, 255];
+    // 4. they are small-sized (< 16 bits);
+    // 4. they are intermediate-sized (< 32 bits);
+    // 6. they are medium-sized (< 64 bits);
+    // 7. the rest.
+
+    let size = bases.len().min(scalars.len());
+    let bases = &bases[..size];
+    let scalars = &scalars[..size];
+
+    let mut grouped = cfg_iter!(scalars)
+        .enumerate()
+        .filter(|(_, scalar)| !scalar.is_zero())
+        .map(|(i, scalar)| {
+            let num_bits = scalar.num_bits();
+            let group = if num_bits <= 1 {
+                1u8
+            } else if num_bits <= 8 {
+                3u8
+            } else if num_bits <= 16 {
+                4u8
+            } else if num_bits <= 32 {
+                5u8
+            } else if num_bits <= 64 {
+                6u8
+            } else {
+                7u8
+            };
+            // group is at most 7, so we can fit it in 3 bits.
+            (i as u64) ^ ((group as u64) << 61)
+        })
+        .collect::<Vec<_>>();
+    let extract_group = |i| (i >> 61) as u8;
+    #[cfg(feature = "parallel")]
+    grouped.par_sort_unstable_by_key(|i| extract_group(*i));
+    #[cfg(not(feature = "parallel"))]
+    grouped.sort_unstable_by_key(|i| extract_group(*i));
+
+    let s1 = 0;
+    let s3 = s1 + grouped[s1..].partition_point(|i| extract_group(*i) < 3);
+    let s4 = s3 + grouped[s3..].partition_point(|i| extract_group(*i) < 4);
+    let s5 = s4 + grouped[s4..].partition_point(|i| extract_group(*i) < 5);
+    let s6 = s5 + grouped[s5..].partition_point(|i| extract_group(*i) < 6);
+    let s7 = s6 + grouped[s6..].partition_point(|i| extract_group(*i) < 7);
+
+    let (b1, s1) = uget_group(&grouped[s1..s3], |i| {
+        (bases[i], scalars[i].as_ref()[0] == 1)
+    });
+    let (b3, s3) = uget_group(&grouped[s3..s4], |i| {
+        (bases[i], scalars[i].as_ref()[0] as u8)
+    });
+    let (b4, s4) = uget_group(&grouped[s4..s5], |i| {
+        (bases[i], scalars[i].as_ref()[0] as u16)
+    });
+    let (b5, s5) = uget_group(&grouped[s5..s6], |i| {
+        (bases[i], scalars[i].as_ref()[0] as u32)
+    });
+    let (b6, s6) = uget_group(&grouped[s6..s7], |i| {
+        (bases[i], scalars[i].as_ref()[0] as u64)
+    });
+    let (b7, s7) = uget_group(&grouped[s7..], |i| (bases[i], scalars[i]));
+
+    let result: V = msm_binary::<V>(&b1, &s1)
+        + msm_u8::<V>(&b3, &s3)
+        + msm_u16::<V>(&b4, &s4)
+        + msm_u32::<V>(&b5, &s5)
+        + msm_u64::<V>(&b6, &s6)
+        + msm_bigint::<V>(&b7, &s7, V::ScalarField::MODULUS_BIT_SIZE as usize);
+    result.into()
+}
+
+#[inline(always)]
+fn sub<B: BigInteger>(m: &B, scalar: &B) -> u64 {
+    let mut negated = *m;
+    negated.sub_with_borrow(scalar);
+    negated.as_ref()[0]
+}
+
+/// Computes multi-scalar multiplication where the scalars
+/// can be negative, zero, or positive.
+/// Should be used when the negation is cheap, i.e. when
+/// `V::NEGATION_IS_CHEAP` is `true`.
+fn msm_signed<V: VariableBaseMSM>(
+    bases: &[V::MulBase],
+    scalars: &[<V::ScalarField as PrimeField>::BigInt],
+) -> V {
+    // Partition scalars according to whether
+    // 1. they are in the range {-1, 0, 1};
+    // 2. they are in the range [-127, 127];
+    // 3. they are in the range [0, 255];
+    // 4. they are small-sized (< 16 bits);
+    // 4. they are intermediate-sized (< 32 bits);
+    // 6. they are medium-sized (< 64 bits);
+    // 7. the rest.
+
+    let size = bases.len().min(scalars.len());
+    let bases = &bases[..size];
+    let scalars = &scalars[..size];
+
+    let mut grouped = cfg_iter!(scalars)
+        .enumerate()
+        .filter(|(_, scalar)| !scalar.is_zero())
+        .map(|(i, scalar)| {
+            let mut p_minus_scalar = V::ScalarField::MODULUS;
+            p_minus_scalar.sub_with_borrow(scalar);
+            let num_bits = scalar.num_bits();
+            let neg_num_bits = p_minus_scalar.num_bits();
+            let group = if num_bits <= 1 {
+                0u8
+            } else if neg_num_bits <= 1 {
+                1u8
+            } else if num_bits <= 8 {
+                2u8
+            } else if neg_num_bits <= 8 {
+                3u8
+            } else if num_bits <= 16 {
+                4u8
+            } else if neg_num_bits <= 16 {
+                5u8
+            } else if num_bits <= 32 {
+                6u8
+            } else if neg_num_bits <= 32 {
+                7u8
+            } else if num_bits <= 64 {
+                8u8
+            } else if neg_num_bits <= 64 {
+                9u8
+            } else {
+                10u8
+            };
+            // group is at most 10, so we can fit it in 4 bits.
+            // hence, we can use the first 60 bits for the index,
+            // and the last 4 bits for the group.
+            (((i as u64) << 4) >> 4) ^ ((group as u64) << 60)
+        })
+        .collect::<Vec<_>>();
+    let extract_group = |i| (i >> 60) as u8;
+
+    #[cfg(feature = "parallel")]
+    grouped.par_sort_unstable_by_key(|i| extract_group(*i));
+    #[cfg(not(feature = "parallel"))]
+    grouped.sort_unstable_by_key(|i| extract_group(*i));
+
+    let su1 = 0;
+    let si1 = su1 + grouped[su1..].partition_point(|i| extract_group(*i) < 1);
+    let su8 = si1 + grouped[si1..].partition_point(|i| extract_group(*i) < 2);
+    let si8 = su8 + grouped[su8..].partition_point(|i| extract_group(*i) < 3);
+    let su16 = si8 + grouped[si8..].partition_point(|i| extract_group(*i) < 4);
+    let si16 = su16 + grouped[su16..].partition_point(|i| extract_group(*i) < 5);
+    let su32 = si16 + grouped[si16..].partition_point(|i| extract_group(*i) < 6);
+    let si32 = su32 + grouped[su32..].partition_point(|i| extract_group(*i) < 7);
+    let su64 = si32 + grouped[si32..].partition_point(|i| extract_group(*i) < 8);
+    let si64 = su64 + grouped[su64..].partition_point(|i| extract_group(*i) < 9);
+    let sf = si64 + grouped[si64..].partition_point(|i| extract_group(*i) < 10);
+
+    let m = V::ScalarField::MODULUS;
+    let mut result: V;
+
+    // Handle the scalars in the range {-1, 0, 1}.
+    let (ub, us) = iget_group(&grouped[su1..si1], |i| {
+        (bases[i], scalars[i].as_ref()[0] == 1)
+    });
+    let (ib, is) = iget_group(&grouped[si1..su8], |i| {
+        (bases[i], sub(&m, &scalars[i]) == 1)
+    });
+    result = msm_binary::<V>(&ub, &us) - msm_binary::<V>(&ib, &is);
+
+    // Handle positive and negative u8 scalars.
+    let (ub, us) = iget_group(&grouped[su8..si8], |i| {
+        (bases[i], scalars[i].as_ref()[0] as u8)
+    });
+    let (ib, is) = iget_group(&grouped[si8..su16], |i| {
+        (bases[i], sub(&m, &scalars[i]) as u8)
+    });
+    result += msm_u8::<V>(&ub, &us) - msm_u8::<V>(&ib, &is);
+
+    // Handle positive and negative u16 scalars.
+    let (ub, us) = iget_group(&grouped[su16..si16], |i| {
+        (bases[i], scalars[i].as_ref()[0] as u16)
+    });
+    let (ib, is) = iget_group(&grouped[si16..su32], |i| {
+        (bases[i], sub(&m, &scalars[i]) as u16)
+    });
+    result += msm_u16::<V>(&ub, &us) - msm_u16::<V>(&ib, &is);
+
+    // Handle positive and negative u32 scalars.
+    let (ub, us) = iget_group(&grouped[su32..si32], |i| {
+        (bases[i], scalars[i].as_ref()[0] as u32)
+    });
+    let (ib, is) = iget_group(&grouped[si32..su64], |i| {
+        (bases[i], sub(&m, &scalars[i]) as u32)
+    });
+    result += msm_u32::<V>(&ub, &us) - msm_u32::<V>(&ib, &is);
+
+    // Handle positive and negative u64 scalars.
+    let (ub, us) = iget_group(&grouped[su64..si64], |i| (bases[i], scalars[i].as_ref()[0]));
+    let (ib, is) = iget_group(&grouped[si64..sf], |i| (bases[i], sub(&m, &scalars[i])));
+    result += msm_u64::<V>(&ub, &us) - msm_u64::<V>(&ib, &is);
+
+    // Handle the rest of the scalars.
+    let (bf, sf) = iget_group(&grouped[sf..], |i| (bases[i], scalars[i]));
+    result += msm_bigint_wnaf::<V>(&bf, &sf);
+
+    result.into()
+}
+
+fn preamble<A, B>(bases: &mut &[A], scalars: &mut &[B]) -> Option<usize> {
+    let size = bases.len().min(scalars.len());
+    if size == 0 {
+        return None;
+    }
+    #[cfg(feature = "parallel")]
+    let chunk_size = {
+        let chunk_size = size / rayon::current_num_threads();
+        if chunk_size == 0 {
+            size
+        } else {
+            chunk_size
+        }
+    };
+    #[cfg(not(feature = "parallel"))]
+    let chunk_size = size;
+
+    *bases = &bases[..size];
+    *scalars = &scalars[..size];
+    Some(chunk_size)
+}
+
+/// Computes multi-scalar multiplication where the scalars
+/// lie in the range {-1, 0, 1}.
+fn msm_binary<V: VariableBaseMSM>(mut bases: &[V::MulBase], mut scalars: &[bool]) -> V {
+    let chunk_size = match preamble(&mut bases, &mut scalars) {
+        Some(chunk_size) => chunk_size,
+        None => return V::zero(),
+    };
+
+    // We only need to process the non-zero scalars.
+    cfg_chunks!(bases, chunk_size)
+        .zip(cfg_chunks!(scalars, chunk_size))
+        .map(|(bases, scalars)| {
+            let mut res = V::ZERO_BUCKET;
+            for (base, _) in bases.iter().zip(scalars).filter(|(_, &s)| s) {
+                res += base;
+            }
+            res.into()
+        })
+        .sum()
+}
+
+fn msm_u8<V: VariableBaseMSM>(mut bases: &[V::MulBase], mut scalars: &[u8]) -> V {
+    let chunk_size = match preamble(&mut bases, &mut scalars) {
+        Some(chunk_size) => chunk_size,
+        None => return V::zero(),
+    };
+    cfg_chunks!(bases, chunk_size)
+        .zip(cfg_chunks!(scalars, chunk_size))
+        .map(|(bases, scalars)| msm_serial::<V>(bases, scalars))
+        .sum()
+}
+
+fn msm_u16<V: VariableBaseMSM>(mut bases: &[V::MulBase], mut scalars: &[u16]) -> V {
+    let chunk_size = match preamble(&mut bases, &mut scalars) {
+        Some(chunk_size) => chunk_size,
+        None => return V::zero(),
+    };
+    cfg_chunks!(bases, chunk_size)
+        .zip(cfg_chunks!(scalars, chunk_size))
+        .map(|(bases, scalars)| msm_serial::<V>(bases, scalars))
+        .sum()
+}
+
+fn msm_u32<V: VariableBaseMSM>(mut bases: &[V::MulBase], mut scalars: &[u32]) -> V {
+    let chunk_size = match preamble(&mut bases, &mut scalars) {
+        Some(chunk_size) => chunk_size,
+        None => return V::zero(),
+    };
+    cfg_chunks!(bases, chunk_size)
+        .zip(cfg_chunks!(scalars, chunk_size))
+        .map(|(bases, scalars)| msm_serial::<V>(bases, scalars))
+        .sum()
+}
+
+fn msm_u64<V: VariableBaseMSM>(mut bases: &[V::MulBase], mut scalars: &[u64]) -> V {
+    let chunk_size = match preamble(&mut bases, &mut scalars) {
+        Some(chunk_size) => chunk_size,
+        None => return V::zero(),
+    };
+    cfg_chunks!(bases, chunk_size)
+        .zip(cfg_chunks!(scalars, chunk_size))
+        .map(|(bases, scalars)| msm_serial::<V>(bases, scalars))
+        .sum()
+}
+
 // Compute msm using windowed non-adjacent form
 fn msm_bigint_wnaf<V: VariableBaseMSM>(
     bases: &[V::MulBase],
     bigints: &[<V::ScalarField as PrimeField>::BigInt],
 ) -> V {
-    let size = ark_std::cmp::min(bases.len(), bigints.len());
+    let size = bases.len().min(bigints.len());
     let scalars = &bigints[..size];
     let bases = &bases[..size];
 
@@ -166,6 +501,7 @@ fn msm_bigint_wnaf<V: VariableBaseMSM>(
                 }
             }
 
+            // prefix sum
             let mut running_sum = V::ZERO_BUCKET;
             let mut res = V::ZERO_BUCKET;
             buckets.into_iter().rev().for_each(|b| {
@@ -195,12 +531,14 @@ fn msm_bigint_wnaf<V: VariableBaseMSM>(
 
 /// Optimized implementation of multi-scalar multiplication.
 fn msm_bigint<V: VariableBaseMSM>(
-    bases: &[V::MulBase],
-    bigints: &[<V::ScalarField as PrimeField>::BigInt],
+    mut bases: &[V::MulBase],
+    mut scalars: &[<V::ScalarField as PrimeField>::BigInt],
+    num_bits: usize,
 ) -> V {
-    let size = ark_std::cmp::min(bases.len(), bigints.len());
-    let scalars = &bigints[..size];
-    let bases = &bases[..size];
+    if preamble(&mut bases, &mut scalars).is_none() {
+        return V::zero();
+    }
+    let size = scalars.len();
     let scalars_and_bases_iter = scalars.iter().zip(bases).filter(|(s, _)| !s.is_zero());
 
     let c = if size < 32 {
@@ -209,16 +547,15 @@ fn msm_bigint<V: VariableBaseMSM>(
         super::ln_without_floats(size) + 2
     };
 
-    let num_bits = V::ScalarField::MODULUS_BIT_SIZE as usize;
     let one = V::ScalarField::one().into_bigint();
 
     let zero = V::ZERO_BUCKET;
-    let window_starts: Vec<_> = (0..num_bits).step_by(c).collect();
 
     // Each window is of size `c`.
     // We divide up the bits 0..num_bits into windows of size `c`, and
     // in parallel process each such window.
-    let window_sums: Vec<_> = ark_std::cfg_into_iter!(window_starts)
+    let window_sums: Vec<_> = ark_std::cfg_into_iter!(0..num_bits)
+        .step_by(c)
         .map(|w_start| {
             let mut res = zero;
             // We don't need the "zero" bucket, so we only have 2^c - 1 buckets.
@@ -274,7 +611,103 @@ fn msm_bigint<V: VariableBaseMSM>(
         .collect();
 
     // We store the sum for the lowest window.
-    let lowest = (*window_sums.first().unwrap()).into();
+    let lowest = window_sums.first().copied().map_or(V::ZERO, Into::into);
+
+    // We're traversing windows from high to low.
+    lowest
+        + &window_sums[1..]
+            .iter()
+            .rev()
+            .fold(V::zero(), |mut total, sum_i| {
+                total += sum_i;
+                for _ in 0..c {
+                    total.double_in_place();
+                }
+                total
+            })
+}
+
+fn msm_serial<V: VariableBaseMSM>(
+    bases: &[V::MulBase],
+    scalars: &[impl Into<u64> + Copy + Send + Sync],
+) -> V {
+    let c = if bases.len() < 32 {
+        3
+    } else {
+        super::ln_without_floats(bases.len()) + 2
+    };
+
+    let zero = V::ZERO_BUCKET;
+
+    // Each window is of size `c`.
+    // We divide up the bits 0..num_bits into windows of size `c`, and
+    // in parallel process each such window.
+    let two_to_c = 1 << c;
+    let window_sums: Vec<_> = (0..(core::mem::size_of::<u64>() * 8))
+        .step_by(c)
+        .map(|w_start| {
+            let mut res = zero;
+            // We don't need the "zero" bucket, so we only have 2^c - 1 buckets.
+            let mut buckets = vec![zero; two_to_c - 1];
+            // This clone is cheap, because the iterator contains just a
+            // pointer and an index into the original vectors.
+            scalars
+                .iter()
+                .zip(bases)
+                .filter_map(|(&s, b)| {
+                    let s = s.into();
+                    (s != 0).then_some((s, b))
+                })
+                .for_each(|(scalar, base)| {
+                    if scalar == 1 {
+                        // We only process unit scalars once in the first window.
+                        if w_start == 0 {
+                            res += base;
+                        }
+                    } else {
+                        let mut scalar = scalar;
+
+                        // We right-shift by w_start, thus getting rid of the
+                        // lower bits.
+                        scalar >>= w_start as u32;
+
+                        // We mod the remaining bits by 2^{window size}, thus taking `c` bits.
+                        scalar %= two_to_c as u64;
+
+                        // If the scalar is non-zero, we update the corresponding
+                        // bucket.
+                        // (Recall that `buckets` doesn't have a zero bucket.)
+                        if scalar != 0 {
+                            buckets[(scalar - 1) as usize] += base;
+                        }
+                    }
+                });
+
+            // Compute sum_{i in 0..num_buckets} (sum_{j in i..num_buckets} bucket[j])
+            // This is computed below for b buckets, using 2b curve additions.
+            //
+            // We could first normalize `buckets` and then use mixed-addition
+            // here, but that's slower for the kinds of groups we care about
+            // (Short Weierstrass curves and Twisted Edwards curves).
+            // In the case of Short Weierstrass curves,
+            // mixed addition saves ~4 field multiplications per addition.
+            // However normalization (with the inversion batched) takes ~6
+            // field multiplications per element,
+            // hence batch normalization is a slowdown.
+
+            // `running_sum` = sum_{j in i..num_buckets} bucket[j],
+            // where we iterate backward from i = num_buckets to 0.
+            let mut running_sum = V::ZERO_BUCKET;
+            buckets.into_iter().rev().for_each(|b| {
+                running_sum += &b;
+                res += &running_sum;
+            });
+            res
+        })
+        .collect();
+
+    // We store the sum for the lowest window.
+    let lowest = window_sums.first().copied().map_or(V::ZERO, Into::into);
 
     // We're traversing windows from high to low.
     lowest

--- a/ec/src/scalar_mul/variable_base/mod.rs
+++ b/ec/src/scalar_mul/variable_base/mod.rs
@@ -89,8 +89,33 @@ pub trait VariableBaseMSM: ScalarMul + for<'a> AddAssign<&'a Self::Bucket> {
     }
 
     /// Performs multi-scalar multiplication when the scalars are known to be boolean.
-    fn msm_bool(bases: &[Self::MulBase], scalars: &[bool]) -> Self {
+    /// The default implementation is faster than [`Self::msm_bigint`].
+    fn msm_u1(bases: &[Self::MulBase], scalars: &[bool]) -> Self {
         msm_binary(bases, scalars)
+    }
+
+    /// Performs multi-scalar multiplication when the scalars are known to be `u8`-sized.
+    /// The default implementation is faster than [`Self::msm_bigint`].
+    fn msm_u8(bases: &[Self::MulBase], scalars: &[u8]) -> Self {
+        msm_u8(bases, scalars)
+    }
+
+    /// Performs multi-scalar multiplication when the scalars are known to be `u16`-sized.
+    /// The default implementation is faster than [`Self::msm_bigint`].
+    fn msm_u16(bases: &[Self::MulBase], scalars: &[u16]) -> Self {
+        msm_u16(bases, scalars)
+    }
+
+    /// Performs multi-scalar multiplication when the scalars are known to be `u32`-sized.
+    /// The default implementation is faster than [`Self::msm_bigint`].
+    fn msm_u32(bases: &[Self::MulBase], scalars: &[u32]) -> Self {
+        msm_u32(bases, scalars)
+    }
+
+    /// Performs multi-scalar multiplication when the scalars are known to be `u64`-sized.
+    /// The default implementation is faster than [`Self::msm_bigint`].
+    fn msm_u64(bases: &[Self::MulBase], scalars: &[u64]) -> Self {
+        msm_u64(bases, scalars)
     }
 
     /// Streaming multi-scalar multiplication algorithm with hard-coded chunk

--- a/ff/src/bits.rs
+++ b/ff/src/bits.rs
@@ -84,7 +84,7 @@ impl<Slice: AsRef<[u64]>> Iterator for BitIteratorLE<Slice> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ark_std::vec::Vec;
+    use ark_std::{vec, vec::Vec};
 
     #[test]
     fn test_bit_iterator_be() {

--- a/ff/src/const_helpers.rs
+++ b/ff/src/const_helpers.rs
@@ -358,7 +358,7 @@ mod tests {
     fn test_ser_buffer_write_and_read() {
         type Ser = SerBuffer<2>;
         let buf = Ser::zeroed();
-        let mut data = vec![];
+        let mut data = ark_std::vec::Vec::new();
         buf.write_up_to(&mut data, 16)
             .expect("Failed to write buffer");
 

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -518,6 +518,7 @@ mod no_std_tests {
 
     #[test]
     fn test_from_be_bytes_mod_order() {
+        use ark_std::vec;
         // Each test vector is a byte array,
         // and its tested by parsing it with from_bytes_mod_order, and the num-bigint
         // library. The bytes are currently generated from scripts/test_vectors.py.

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -694,7 +694,7 @@ where
 #[cfg(test)]
 mod cube_ext_tests {
     use super::*;
-    use ark_std::test_rng;
+    use ark_std::{test_rng, vec};
     use ark_test_curves::{
         ark_ff::Field,
         bls12_381::{Fq, Fq2, Fq6},

--- a/ff/src/fields/models/quadratic_extension.rs
+++ b/ff/src/fields/models/quadratic_extension.rs
@@ -822,10 +822,9 @@ mod quad_ext_tests {
 
     #[test]
     fn test_from_base_prime_field_element() {
-        let ext_degree = Fq2::extension_degree() as usize;
         let max_num_elems_to_test = 10;
         for _ in 0..max_num_elems_to_test {
-            let mut random_coeffs = vec![Fq::zero(); ext_degree];
+            let mut random_coeffs = [Fq::zero(); 2];
             let random_coeff = Fq::rand(&mut test_rng());
             let res = Fq2::from_base_prime_field(random_coeff);
             random_coeffs[0] = random_coeff;

--- a/poly/src/domain/mixed_radix.rs
+++ b/poly/src/domain/mixed_radix.rs
@@ -522,7 +522,7 @@ mod tests {
         use super::serial_mixed_radix_fft;
         use crate::domain::utils::parallel_fft;
         use ark_ff::PrimeField;
-        use ark_std::{test_rng, vec::*};
+        use ark_std::{test_rng, vec::Vec};
         use ark_test_curves::bn384_small_two_adicity::Fq as Fr;
         use core::cmp::min;
 
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn test_fft_ifft_identity() {
         let domain = MixedRadixEvaluationDomain::<Fr>::new(8).unwrap();
-        let mut coeffs = vec![
+        let mut coeffs = ark_std::vec![
             Fr::from(1),
             Fr::from(2),
             Fr::from(3),

--- a/poly/src/domain/radix2/mod.rs
+++ b/poly/src/domain/radix2/mod.rs
@@ -171,7 +171,7 @@ mod tests {
         EvaluationDomain, Radix2EvaluationDomain,
     };
     use ark_ff::{FftField, Field, One, UniformRand, Zero};
-    use ark_std::{collections::BTreeSet, rand::Rng, test_rng};
+    use ark_std::{collections::BTreeSet, rand::Rng, test_rng, vec};
     use ark_test_curves::bls12_381::Fr;
 
     #[test]

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -407,7 +407,7 @@ mod tests {
     };
     use ark_ff::{One, Zero};
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-    use ark_std::{ops::Neg, test_rng, vec::*, UniformRand};
+    use ark_std::{ops::Neg, test_rng, vec, vec::*, UniformRand};
     use ark_test_curves::bls12_381::Fr;
     /// Some sanity test to ensure random sparse polynomial make sense.
     #[test]

--- a/poly/src/polynomial/multivariate/mod.rs
+++ b/poly/src/polynomial/multivariate/mod.rs
@@ -174,6 +174,7 @@ impl Ord for SparseTerm {
 mod tests {
     use super::*;
     use ark_ff::{Fp64, MontBackend, MontConfig};
+    use ark_std::vec;
 
     #[derive(MontConfig)]
     #[modulus = "5"]

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -330,7 +330,7 @@ mod tests {
         EvaluationDomain, GeneralEvaluationDomain,
     };
     use ark_ff::{UniformRand, Zero};
-    use ark_std::{cmp::max, ops::Mul, rand::Rng, test_rng};
+    use ark_std::{cmp::max, ops::Mul, rand::Rng, test_rng, vec};
     use ark_test_curves::bls12_381::Fr;
 
     // probability of rand sparse polynomial having a particular coefficient be 0

--- a/poly/src/test.rs
+++ b/poly/src/test.rs
@@ -1,6 +1,6 @@
 use crate::domain::*;
 use ark_ff::{PrimeField, UniformRand};
-use ark_std::test_rng;
+use ark_std::{test_rng, vec};
 use ark_test_curves::{
     bls12_381::{Fr, G1Projective},
     bn384_small_two_adicity::Fr as BNFr,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 
 match_block_trailing_comma = true
 
@@ -6,4 +6,3 @@ reorder_imports = true
 
 use_field_init_shorthand = true
 use_try_shorthand = true
-

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -196,6 +196,11 @@ macro_rules! __test_group {
         fn test_var_base_msm_mixed_scalars() {
             $crate::msm::test_var_base_msm_mixed_scalars::<$group>();
         }
+        
+        #[test]
+        fn test_var_base_msm_specialized() {
+            $crate::msm::test_var_base_msm_specialized::<$group>();
+        }
 
         #[test]
         fn test_chunked_pippenger() {

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -191,7 +191,7 @@ macro_rules! __test_group {
         fn test_var_base_msm() {
             $crate::msm::test_var_base_msm::<$group>();
         }
-        
+
         #[test]
         fn test_var_base_msm_mixed_scalars() {
             $crate::msm::test_var_base_msm_mixed_scalars::<$group>();

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -196,7 +196,7 @@ macro_rules! __test_group {
         fn test_var_base_msm_mixed_scalars() {
             $crate::msm::test_var_base_msm_mixed_scalars::<$group>();
         }
-        
+
         #[test]
         fn test_var_base_msm_specialized() {
             $crate::msm::test_var_base_msm_specialized::<$group>();

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -191,6 +191,11 @@ macro_rules! __test_group {
         fn test_var_base_msm() {
             $crate::msm::test_var_base_msm::<$group>();
         }
+        
+        #[test]
+        fn test_var_base_msm_mixed_scalars() {
+            $crate::msm::test_var_base_msm_mixed_scalars::<$group>();
+        }
 
         #[test]
         fn test_chunked_pippenger() {

--- a/test-templates/src/msm.rs
+++ b/test-templates/src/msm.rs
@@ -74,35 +74,35 @@ pub fn test_var_base_msm_mixed_scalars<G: VariableBaseMSM>() {
 pub fn test_var_base_msm_specialized<G: VariableBaseMSM>() {
     const SAMPLES: usize = (1 << 10) * 5;
 
-    let mut rng = ark_std::test_rng();
-    let g = (0..SAMPLES).map(|_| G::rand(&mut rng)).collect::<Vec<_>>();
+    let rng = &mut ark_std::test_rng();
+    let g = (0..SAMPLES).map(|_| G::rand(rng)).collect::<Vec<_>>();
     let g = G::batch_convert_to_mul_base(&g);
 
-    let v = (0..SAMPLES).map(|_| bool::rand(&mut rng)).collect::<Vec<_>>();
+    let v = (0..SAMPLES).map(|_| bool::rand(rng)).collect::<Vec<_>>();
     let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
     let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
     let fast = G::msm_u1(g.as_slice(), v.as_slice());
     assert_eq!(naive, fast);
-    
-    let v = (0..SAMPLES).map(|_| u8::rand(&mut rng)).collect::<Vec<_>>();
+
+    let v = (0..SAMPLES).map(|_| u8::rand(rng)).collect::<Vec<_>>();
     let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
     let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
     let fast = G::msm_u8(g.as_slice(), v.as_slice());
     assert_eq!(naive, fast);
 
-    let v = (0..SAMPLES).map(|_| u16::rand(&mut rng)).collect::<Vec<_>>();
+    let v = (0..SAMPLES).map(|_| u16::rand(rng)).collect::<Vec<_>>();
     let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
     let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
     let fast = G::msm_u16(g.as_slice(), v.as_slice());
     assert_eq!(naive, fast);
 
-    let v = (0..SAMPLES).map(|_| u32::rand(&mut rng)).collect::<Vec<_>>();
+    let v = (0..SAMPLES).map(|_| u32::rand(rng)).collect::<Vec<_>>();
     let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
     let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
     let fast = G::msm_u32(g.as_slice(), v.as_slice());
     assert_eq!(naive, fast);
 
-    let v = (0..SAMPLES).map(|_| u64::rand(&mut rng)).collect::<Vec<_>>();
+    let v = (0..SAMPLES).map(|_| u64::rand(rng)).collect::<Vec<_>>();
     let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
     let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
     let fast = G::msm_u64(g.as_slice(), v.as_slice());

--- a/test-templates/src/msm.rs
+++ b/test-templates/src/msm.rs
@@ -57,7 +57,7 @@ pub fn test_var_base_msm_mixed_scalars<G: VariableBaseMSM>() {
     // Positive and negative u64s
     v.extend((0..SAMPLES).map(|_| F::<G>::from(u64::rand(&mut rng))));
     v.extend((0..SAMPLES).map(|_| -F::<G>::from(u64::rand(&mut rng))));
-    
+
     // Random scalars
     v.extend((0..SAMPLES).map(|_| F::<G>::from(G::ScalarField::rand(&mut rng))));
     v.shuffle(&mut rng);

--- a/test-templates/src/msm.rs
+++ b/test-templates/src/msm.rs
@@ -71,6 +71,44 @@ pub fn test_var_base_msm_mixed_scalars<G: VariableBaseMSM>() {
     assert_eq!(naive, fast);
 }
 
+pub fn test_var_base_msm_specialized<G: VariableBaseMSM>() {
+    const SAMPLES: usize = (1 << 10) * 5;
+
+    let mut rng = ark_std::test_rng();
+    let g = (0..SAMPLES).map(|_| G::rand(&mut rng)).collect::<Vec<_>>();
+    let g = G::batch_convert_to_mul_base(&g);
+
+    let v = (0..SAMPLES).map(|_| bool::rand(&mut rng)).collect::<Vec<_>>();
+    let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
+    let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
+    let fast = G::msm_u1(g.as_slice(), v.as_slice());
+    assert_eq!(naive, fast);
+    
+    let v = (0..SAMPLES).map(|_| u8::rand(&mut rng)).collect::<Vec<_>>();
+    let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
+    let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
+    let fast = G::msm_u8(g.as_slice(), v.as_slice());
+    assert_eq!(naive, fast);
+
+    let v = (0..SAMPLES).map(|_| u16::rand(&mut rng)).collect::<Vec<_>>();
+    let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
+    let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
+    let fast = G::msm_u16(g.as_slice(), v.as_slice());
+    assert_eq!(naive, fast);
+
+    let v = (0..SAMPLES).map(|_| u32::rand(&mut rng)).collect::<Vec<_>>();
+    let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
+    let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
+    let fast = G::msm_u32(g.as_slice(), v.as_slice());
+    assert_eq!(naive, fast);
+
+    let v = (0..SAMPLES).map(|_| u64::rand(&mut rng)).collect::<Vec<_>>();
+    let v_fe = v.iter().map(|&b| F::<G>::from(b)).collect::<Vec<_>>();
+    let naive = naive_var_base_msm::<G>(g.as_slice(), v_fe.as_slice());
+    let fast = G::msm_u64(g.as_slice(), v.as_slice());
+    assert_eq!(naive, fast);
+}
+
 pub fn test_chunked_pippenger<G: VariableBaseMSM>() {
     const SAMPLES: usize = 1 << 10;
 

--- a/test-templates/src/msm.rs
+++ b/test-templates/src/msm.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     ScalarMul,
 };
 use ark_ff::{PrimeField, UniformRand};
-use ark_std::vec::*;
+use ark_std::{rand::seq::SliceRandom, vec::*};
 
 fn naive_var_base_msm<G: ScalarMul>(bases: &[G::MulBase], scalars: &[G::ScalarField]) -> G {
     let mut acc = G::zero();
@@ -23,6 +23,46 @@ pub fn test_var_base_msm<G: VariableBaseMSM>() {
         .map(|_| G::ScalarField::rand(&mut rng))
         .collect::<Vec<_>>();
     let g = (0..SAMPLES).map(|_| G::rand(&mut rng)).collect::<Vec<_>>();
+    let g = G::batch_convert_to_mul_base(&g);
+
+    let naive = naive_var_base_msm::<G>(g.as_slice(), v.as_slice());
+    let fast = G::msm(g.as_slice(), v.as_slice()).unwrap();
+
+    assert_eq!(naive, fast);
+}
+
+type F<G> = <G as ark_ec::PrimeGroup>::ScalarField;
+
+pub fn test_var_base_msm_mixed_scalars<G: VariableBaseMSM>() {
+    const SAMPLES: usize = 1 << 10;
+
+    let mut rng = ark_std::test_rng();
+    let mut v = Vec::<F<G>>::with_capacity(SAMPLES * 11);
+    // Positive and negative u1s
+    v.extend((0..SAMPLES).map(|_| F::<G>::from(bool::rand(&mut rng))));
+    v.extend((0..SAMPLES).map(|_| -F::<G>::from(bool::rand(&mut rng))));
+
+    // Positive and negative u8s
+    v.extend((0..SAMPLES).map(|_| F::<G>::from(u8::rand(&mut rng))));
+    v.extend((0..SAMPLES).map(|_| -F::<G>::from(u8::rand(&mut rng))));
+
+    // Positive and negative u16s
+    v.extend((0..SAMPLES).map(|_| F::<G>::from(u16::rand(&mut rng))));
+    v.extend((0..SAMPLES).map(|_| -F::<G>::from(u16::rand(&mut rng))));
+
+    // Positive and negative u32s
+    v.extend((0..SAMPLES).map(|_| F::<G>::from(u32::rand(&mut rng))));
+    v.extend((0..SAMPLES).map(|_| -F::<G>::from(u32::rand(&mut rng))));
+
+    // Positive and negative u64s
+    v.extend((0..SAMPLES).map(|_| F::<G>::from(u64::rand(&mut rng))));
+    v.extend((0..SAMPLES).map(|_| -F::<G>::from(u64::rand(&mut rng))));
+    
+    // Random scalars
+    v.extend((0..SAMPLES).map(|_| F::<G>::from(G::ScalarField::rand(&mut rng))));
+    v.shuffle(&mut rng);
+
+    let g = (0..v.len()).map(|_| G::rand(&mut rng)).collect::<Vec<_>>();
     let g = G::batch_convert_to_mul_base(&g);
 
     let naive = naive_var_base_msm::<G>(g.as_slice(), v.as_slice());


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Greatly improves performance when the size of the scalars is known to be small.
Inspired by [`jolt`'s MSMs](https://github.com/a16z/jolt/blob/e8c245607a4ab881f40713bae7cc4119dc117ae4/jolt-core/src/msm/mod.rs), except the version in this PR automatically partitions scalars and bases according to scalar size, and uses the best MSM for each partition.

```
MSM/MSM-random for BN254::G1
                        time:   [594.29 ms 595.72 ms 597.40 ms]
                        change: [+0.5766% +1.1131% +1.5745%] (p = 0.00 < 0.05)
                        Change within noise threshold.
MSM/MSM-bool for BN254::G1
                        time:   [15.240 ms 15.341 ms 15.427 ms]
                        change: [−86.632% −86.501% −86.377%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u8 for BN254::G1
                        time:   [29.244 ms 29.361 ms 29.497 ms]
                        change: [−84.803% −84.722% −84.645%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i8 for BN254::G1
                        time:   [32.387 ms 33.462 ms 34.364 ms]
                        change: [−89.208% −88.956% −88.652%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u16 for BN254::G1
                        time:   [51.980 ms 52.116 ms 52.218 ms]
                        change: [−76.408% −76.274% −76.141%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i16 for BN254::G1
                        time:   [54.833 ms 55.824 ms 56.835 ms]
                        change: [−82.000% −81.774% −81.554%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u32 for BN254::G1
                        time:   [79.570 ms 79.736 ms 79.889 ms]
                        change: [−64.927% −64.787% −64.639%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i32 for BN254::G1
                        time:   [86.232 ms 86.877 ms 87.974 ms]
                        change: [−71.781% −71.583% −71.367%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u64 for BN254::G1
                        time:   [130.77 ms 130.95 ms 131.18 ms]
                        change: [−43.628% −43.224% −42.792%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i64 for BN254::G1
                        time:   [144.81 ms 145.62 ms 146.09 ms]
                        change: [−61.201% −59.247% −57.091%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-mixed for BN254::G1
                        time:   [135.97 ms 136.29 ms 136.59 ms]
                        change: [−58.709% −58.510% −58.313%] (p = 0.00 < 0.05)
                        Performance has improved.
```

```
MSM/MSM-random for BN254::G2
                        time:   [1.6892 s 1.6924 s 1.6960 s]
                        change: [+0.3237% +0.5644% +0.8446%] (p = 0.00 < 0.05)
                        Change within noise threshold.
MSM/MSM-bool for BN254::G2
                        time:   [39.202 ms 39.288 ms 39.365 ms]
                        change: [−86.115% −86.063% −86.009%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u8 for BN254::G2
                        time:   [76.824 ms 76.965 ms 77.132 ms]
                        change: [−85.368% −85.325% −85.270%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i8 for BN254::G2
                        time:   [81.739 ms 82.361 ms 83.092 ms]
                        change: [−90.137% −90.043% −89.954%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u16 for BN254::G2
                        time:   [143.33 ms 143.95 ms 144.34 ms]
                        change: [−75.856% −75.567% −75.279%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i16 for BN254::G2
                        time:   [149.28 ms 150.47 ms 151.19 ms]
                        change: [−82.237% −82.099% −81.963%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u32 for BN254::G2
                        time:   [224.01 ms 224.53 ms 225.08 ms]
                        change: [−63.798% −63.557% −63.315%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i32 for BN254::G2
                        time:   [241.36 ms 242.28 ms 243.26 ms]
                        change: [−71.275% −71.153% −71.029%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-u64 for BN254::G2
                        time:   [374.23 ms 374.84 ms 375.46 ms]
                        change: [−38.459% −38.175% −37.881%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-i64 for BN254::G2
                        time:   [409.37 ms 410.56 ms 411.59 ms]
                        change: [−63.278% −60.759% −57.586%] (p = 0.00 < 0.05)
                        Performance has improved.
MSM/MSM-mixed for BN254::G2
                        time:   [366.64 ms 369.24 ms 373.68 ms]
                        change: [−58.802% −58.470% −57.970%] (p = 0.00 < 0.05)
                        Performance has improved.
  
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
