### PR TITLE
fix: update inline assembly documentation to reflect stable Rust support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In addition, the [`curves`](https://github.com/arkworks-rs/algebra/tree/master/c
 
 ## Build guide
 
-The library compiles on the `stable` toolchain of the Rust compiler (v 1.51+). To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
+The library compiles on the `stable` toolchain of the Rust compiler (v 1.51+). For the optimized assembly backend, Rust 1.59+ is required. To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
 
 ```bash
 rustup install stable
@@ -71,7 +71,7 @@ To enable this in the `Cargo.toml` of your own projects, enable the `asm` featur
 ark-ff = { version = "0.4", features = [ "asm" ] }
 ```
 
-Note that because inline assembly support in Rust is currently unstable, using this backend requires using the Nightly compiler at the moment.
+Note that using this backend requires Rust 1.59+ for stable inline assembly support.
 
 ## License
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Update outdated inline assembly documentation

Fixes incorrect documentation stating that inline assembly requires nightly Rust. Inline assembly was stabilized in Rust 1.59.0 (February 2022).

Changes:
- Updated assembly backend note to specify Rust 1.59+ requirement
- Removed outdated nightly compiler requirement
- Added version requirement to build guide

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
