### PR TITLE
Remove invalid documentation link from Cargo.toml

### DIFF
--- a/curves/starkcurve/Cargo.toml
+++ b/curves/starkcurve/Cargo.toml
@@ -5,7 +5,6 @@ authors = [ "CPerezz", "arkworks contributors" ]
 description = "Stark friendly elliptic curve defined over 2^251 + 17 * 2^192 + 1"
 homepage.workspace = true
 repository.workspace = true
-documentation = "https://docs.rs/ark-starkcurve/"
 keywords.workspace = true
 categories.workspace = true
 include.workspace = true


### PR DESCRIPTION
The documentation link in Cargo.toml pointed to a non-existent docs.rs page for ark-starkcurve. Since there is no public documentation available for this crate, the line was removed to avoid confusion and broken links.
If it's necessary, link can be replaced with this one:
https://docs.starkware.co/starkex/crypto/stark-curve.html

