### PR TITLE
fix: removing unmaintained "paste" dep and using the "pastey" replacement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ hashbrown = { version = "0.15", default-features = false, features = [ "inline-m
 hex = "0.4"
 itertools = { version = "0.14", default-features = false }
 libtest-mimic = "0.8.1"
-paste = "1.0"
+pastey = "0.1.0"
 rayon = "1"
 serde = "1.0"
 serde_derive = "1.0"

--- a/bench-templates/Cargo.toml
+++ b/bench-templates/Cargo.toml
@@ -24,7 +24,7 @@ ark-std.workspace = true
 ark-ec.workspace = true
 ark-ff.workspace = true
 ark-serialize.workspace = true
-paste.workspace = true
+pastey.workspace = true
 
 [features]
 asm = ["ark-ff/asm"]

--- a/bench-templates/src/lib.rs
+++ b/bench-templates/src/lib.rs
@@ -7,4 +7,4 @@ use macros::*;
 pub extern crate criterion;
 pub use criterion::*;
 
-pub use paste::paste;
+pub use pastey::paste;


### PR DESCRIPTION
## Description

The creator of the crate `paste` has stated in the [`README.md`](https://github.com/dtolnay/paste/blob/master/README.md) that the project is not longer maintained as well as archived the repository. [pastey](https://crates.io/crates/pastey), a fork of paste and is aimed to be a drop-in replacement with additional features for paste crate

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [-] Targeted PR against correct branch (master)
- [-] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [-] Wrote unit tests
- [-] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [-] Re-reviewed `Files changed` in the GitHub PR explorer
