### PR TITLE
Unify error handling in divide_with_q_and_r: return None instead of panic on zero divisor

### DIFF
--- a/poly/src/polynomial/univariate/mod.rs
+++ b/poly/src/polynomial/univariate/mod.rs
@@ -109,7 +109,7 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
         if self.is_zero() {
             Some((DensePolynomial::zero(), DensePolynomial::zero()))
         } else if divisor.is_zero() {
-            panic!("Dividing by zero polynomial")
+            None
         } else if self.degree() < divisor.degree() {
             Some((DensePolynomial::zero(), self.clone().into()))
         } else {


### PR DESCRIPTION


Description:
- **What**: Replace panic on zero divisor with `None` in `divide_with_q_and_r` (`poly/src/polynomial/univariate/mod.rs`).
- **Why**: The function returns `Option`, so panicking is inconsistent and surprising for library users. Returning `None` aligns with the API contract and avoids unexpected aborts.
