### PR TITLE
bug fix: to_evaluations function for sparse multilinear extension

### DIFF
--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -451,6 +451,23 @@ mod tests {
     }
 
     #[test]
+    fn sparse_to_evaluations_matches_to_dense() {
+        let mut rng = test_rng();
+        const NV: usize = 8; // 2^8 = 256, small and fast
+
+        for _ in 0..25 {
+            // Make a sparse poly with ~sqrt(2^NV) non-zeros at random indices.
+            let sparse = SparseMultilinearExtension::<Fr>::rand(NV, &mut rng);
+            let dense_via_sparse = sparse.to_dense_multilinear_extension().evaluations;
+            let dense_via_to_evals = sparse.to_evaluations();
+            assert_eq!(
+                dense_via_to_evals, dense_via_sparse,
+                "to_evaluations must reproduce the dense vector exactly"
+            );
+        }
+    }
+
+    #[test]
     fn evaluate_edge_cases() {
         // test constant polynomial
         let mut rng = test_rng();


### PR DESCRIPTION
SparseMultilinearExtension::to_evaluations() currently uses:
`self.evaluations
    .iter()
    .map(|(&i, &v)| evaluations[i] = v)
    .next_back();`

This is incorrect because Iterator::map is lazy and the mapped iterator is consumed only once via .next_back(). As a result, only the final key/value in the sparse map gets written into the dense vector; all earlier entries remain zero. 

**Minimal Reproducer**

`
#[test]
fn sparse_to_evaluations_copies_all_nonzeros() {
    use ark_test_curves::bls12_381::Fr;

    // 3 variables → 8 evaluations
    // Non-zeros at indices 1, 3, and 6.
    let v1 = Fr::from(11u64);
    let v3 = Fr::from(33u64);
    let v6 = Fr::from(66u64);

    let sparse = SparseMultilinearExtension::from_evaluations(
        3,
        &[(1usize, v1), (3usize, v3), (6usize, v6)],
    );

    let got = sparse.to_evaluations();

    // Expected dense vector: zeros everywhere except indices 1, 3, and 6.
    let mut expected = vec![Fr::from(0u64); 8];
    expected[1] = v1;
    expected[3] = v3;
    expected[6] = v6;

    assert_eq!(got, expected, "to_evaluations must copy ALL sparse entries");
}
`