### PR TITLE
fix to_dense_multilinear_extension for nv>30

### DIFF
--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -88,7 +88,7 @@ impl<F: Field> SparseMultilinearExtension<F> {
 
     /// Convert the sparse multilinear polynomial to dense form.
     pub fn to_dense_multilinear_extension(&self) -> DenseMultilinearExtension<F> {
-        let mut evaluations: Vec<_> = (0..(1 << self.num_vars)).map(|_| F::zero()).collect();
+        let mut evaluations: Vec<_> = (0..(1usize << self.num_vars)).map(|_| F::zero()).collect();
         for (&i, &v) in &self.evaluations {
             evaluations[i] = v;
         }

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -451,6 +451,23 @@ mod tests {
     }
 
     #[test]
+    fn sparse_to_evaluations_matches_to_dense() {
+        let mut rng = test_rng();
+        const NV: usize = 8; // 2^8 = 256, small and fast
+
+        for _ in 0..25 {
+            // Make a sparse poly with ~sqrt(2^NV) non-zeros at random indices.
+            let sparse = SparseMultilinearExtension::<Fr>::rand(NV, &mut rng);
+            let dense_via_sparse = sparse.to_dense_multilinear_extension().evaluations;
+            let dense_via_to_evals = sparse.to_evaluations();
+            assert_eq!(
+                dense_via_to_evals, dense_via_sparse,
+                "to_evaluations must reproduce the dense vector exactly"
+            );
+        }
+    }
+
+    #[test]
     fn evaluate_edge_cases() {
         // test constant polynomial
         let mut rng = test_rng();

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -191,11 +191,10 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
     }
 
     fn to_evaluations(&self) -> Vec<F> {
-        let mut evaluations: Vec<_> = (0..1 << self.num_vars).map(|_| F::zero()).collect();
+        let mut evaluations = vec![F::zero(); 1 << self.num_vars];
         self.evaluations
             .iter()
-            .map(|(&i, &v)| evaluations[i] = v)
-            .next_back();
+            .for_each(|(&i, &v)| evaluations[i] = v);
         evaluations
     }
 }


### PR DESCRIPTION
 1 is inferred as i32 1 << 31 on an i32 flips the sign bit hence it's unable to produce random dense multilinear extensions for nv>30. The fix is to replace 1<<nv with 1usize << nv