### PR TITLE
Fix performance bug in GLV scalar multiplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove redundant type constraints from `Pairing::G1Prepared`.
 - (`ark-serialize`) Add serde-compatible wrapper types `CompressedChecked<T>`, `CompressedUnchecked<T>`, `UncompressedChecked<T>`, `UncompressedUnchecked<T>`.
 - [\#989](https://github.com/arkworks-rs/algebra/pull/989) (`ark-poly`) Replace bound `F: FftField` with `F: Field` on `GeneralEvaluationDomain`.
+- Improve GLV scalar multiplication performance by skipping leading zeroes.
 
 ### Breaking changes
 

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -109,9 +109,11 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
         let mut res = Projective::zero();
         let mut skip_zeros = true;
         for pair in iter_k1.zip(iter_k2) {
-            if skip_zeros && pair == (false, false) {
+            if skip_zeros {
+                if pair == (false, false) {
+                    continue;
+                }
                 skip_zeros = false;
-                continue;
             }
             res.double_in_place();
             match pair {
@@ -145,9 +147,11 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
         let mut res = Projective::zero();
         let mut skip_zeros = true;
         for pair in iter_k1.zip(iter_k2) {
-            if skip_zeros && pair == (false, false) {
+            if skip_zeros {
+                if pair == (false, false) {
+                    continue;
+                }
                 skip_zeros = false;
-                continue;
             }
             res.double_in_place();
             match pair {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This fixes a performance bug in the GLV scalarmul code. Previously, it only skipped the first leading zero. Now it will skip all leading zeroes. It is a very small fix, it could have also been done by moving `skip_zeros = false` down by 2 lines (out of the conditional), but I felt this was clearer.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
