### PR TITLE
Fix the building of `ark-ff`

### DIFF
--- a/ff/Cargo.toml
+++ b/ff/Cargo.toml
@@ -19,7 +19,7 @@ metadata.release.workspace = true
 ark-ff-asm.workspace = true
 ark-ff-macros.workspace = true
 ark-std.workspace = true
-ark-serialize.workspace = true
+ark-serialize = { features = ["derive"], workspace = true }
 arrayvec.workspace = true
 educe.workspace = true
 num-traits.workspace = true

--- a/serialize-derive/src/deserialize.rs
+++ b/serialize-derive/src/deserialize.rs
@@ -141,7 +141,7 @@ fn impl_deserialize_field(ty: &Type) -> TokenStream {
             quote! { (#(#compressed_fields)*), }
         },
         _ => {
-            quote! { CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?, }
+            quote! { ark_serialize::CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?, }
         },
     }
 }
@@ -194,7 +194,7 @@ pub(super) fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream 
     };
 
     let mut gen = quote! {
-        impl #impl_generics CanonicalDeserialize for #name #ty_generics #where_clause {
+        impl #impl_generics ark_serialize::CanonicalDeserialize for #name #ty_generics #where_clause {
             fn deserialize_with_mode<R: ark_serialize::Read>(
                 mut reader: R,
                 compress: ark_serialize::Compress,

--- a/serialize-derive/src/serialize.rs
+++ b/serialize-derive/src/serialize.rs
@@ -34,9 +34,9 @@ fn impl_serialize_field(
         },
         _ => {
             serialize_body
-                .push(quote! { CanonicalSerialize::serialize_with_mode(&self.#(#idents).*, &mut writer, compress)?; });
+                .push(quote! { ark_serialize::CanonicalSerialize::serialize_with_mode(&self.#(#idents).*, &mut writer, compress)?; });
             serialized_size_body
-                .push(quote! { size += CanonicalSerialize::serialized_size(&self.#(#idents).*, compress); });
+                .push(quote! { size += ark_serialize::CanonicalSerialize::serialized_size(&self.#(#idents).*, compress); });
         },
     }
 }


### PR DESCRIPTION
## Description

Something I noticed while working on https://github.com/arkworks-rs/algebra/pull/1027.

`ark-ff` does not import the `derive` feature of `ark-serialize`, which makes the build fail.

Workspace compilation works because some other dependency is already importing `derive`.

```bash
$ cd ff;
$ cargo check

.
.
.

    = help: the following other types implement trait `CanonicalDeserialize`:
              ()
              (A, B)
              (A, B, C)
              (A, B, C, D)
              (A, B, C, D, E)
              (A,)
              Arc<T>
              BTreeMap<K, V>
            and 28 others
note: required by a bound in `fields::Field::inverse`
   --> ff/src/fields/mod.rs:179:7
    |
179 |     + CanonicalDeserialize
    |       ^^^^^^^^^^^^^^^^^^^^ required by this bound in `Field::inverse`
...
290 |     fn inverse(&self) -> Option<Self>;
    |        ------- required by a bound in this associated function

Some errors have detailed explanations: E0277, E0433.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `ark-ff` (lib) due to 55 previous errors
```

Took the liberty to also include `ark_serialize` prefixes in `ark-serialize-derive`