### PR TITLE
Skip unrolling labeled for-loops to preserve labeled control-flow semantics

### DIFF
--- a/ff-macros/src/unroll.rs
+++ b/ff-macros/src/unroll.rs
@@ -101,6 +101,12 @@ fn unroll(expr: &Expr, unroll_by: usize) -> Expr {
             })
         };
 
+        // If the original loop has a label, skip unrolling to preserve
+        // the semantics of labeled control flow (especially `continue 'label`).
+        if label.is_some() {
+            return forloop_with_body(new_body);
+        }
+
         if let Pat::Ident(PatIdent {
             by_ref,
             mutability,


### PR DESCRIPTION
This change avoids unrolling any for-loop that has a label. In the previous implementation, the original loop label was moved onto an enclosing Expr::Block. That preserved break 'label but broke or changed the semantics of continue 'label, which is only valid for loops, not blocks. By skipping unrolling for labeled loops, we guarantee that both break 'label and continue 'label retain their original behavior. This is a safe, minimal fix that prevents subtle control-flow bugs without affecting unlabeled loops.