### PR TITLE
fix: remove redundant take() calls on iterators

### DIFF
--- a/poly/src/domain/mod.rs
+++ b/poly/src/domain/mod.rs
@@ -179,7 +179,7 @@ pub trait EvaluationDomain<F: FftField>:
             // Thus we find i by brute force.
             let mut u = vec![F::zero(); size];
             let mut omega_i = offset;
-            for u_i in u.iter_mut().take(size) {
+            for u_i in u.iter_mut() {
                 if omega_i == tau {
                     *u_i = F::one();
                     break;

--- a/poly/src/domain/utils.rs
+++ b/poly/src/domain/utils.rs
@@ -173,7 +173,6 @@ pub(crate) fn parallel_fft<T: DomainCoeff<F>, F: FftField>(
             kth_poly_coeffs
                 .iter_mut()
                 .enumerate()
-                .take(coset_size)
                 .for_each(|(i, coeff)| {
                     for c in 0..num_threads {
                         let idx = i + (c * coset_size);


### PR DESCRIPTION
Remove unnecessary take(size) and take(coset_size) calls where vectors are already created with exact required size. 

Improves performance by eliminating redundant bounds checking.