### PR TITLE
Replace panic on zero polynomial divisor with None

### DIFF
--- a/poly/src/polynomial/univariate/mod.rs
+++ b/poly/src/polynomial/univariate/mod.rs
@@ -108,7 +108,7 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
         if self.is_zero() {
             Some((DensePolynomial::zero(), DensePolynomial::zero()))
         } else if divisor.is_zero() {
-            panic!("Dividing by zero polynomial")
+            return None;
         } else if self.degree() < divisor.degree() {
             Some((DensePolynomial::zero(), self.clone().into()))
         } else {
@@ -171,7 +171,7 @@ impl<'a, F: FftField> DenseOrSparsePolynomial<'a, F> {
         if self.is_zero() {
             Some(DensePolynomial::zero())
         } else if divisor.is_zero() {
-            panic!("Dividing by zero polynomial")
+            return None;
         } else if self.degree() < divisor.degree() {
             Some(DensePolynomial::zero())
         } else {


### PR DESCRIPTION


Description:
- Summary: Align polynomial division APIs to return None on zero divisor instead of panicking.
- Motivation: Prevent unexpected process crashes and make behavior consistent with Option-returning signatures.
- Changes:
  - poly/src/polynomial/univariate/mod.rs:
    - naive_div: panic! → return None when divisor is zero
    - hensel_div: panic! → return None when divisor is zero
- Impact:
  - Eliminates potential DoS via zero divisor
  - Preserves API semantics; callers using expect(...) retain explicit failure handling
