### PR TITLE
Make SparsePolynomial.coeffs field public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [\#989](https://github.com/arkworks-rs/algebra/pull/989) (`ark-poly`) Replace bound `F: FftField` with `F: Field` on `GeneralEvaluationDomain`.
 - (`ark-poly`) Add fast polynomial division
 - (`ark-ec`) Improve GLV scalar multiplication performance by skipping leading zeroes.
+- (`ark-poly`) Make `SparsePolynomial.coeffs` field public
 
 ### Breaking changes
 

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -25,7 +25,7 @@ pub struct SparsePolynomial<F: Field> {
     /// The coefficient a_i of `x^i` is stored as (i, a_i) in `self.coeffs`.
     /// the entries in `self.coeffs` *must*  be sorted in increasing order of
     /// `i`.
-    coeffs: Vec<(usize, F)>,
+    pub coeffs: Vec<(usize, F)>,
 }
 
 impl<F: Field> fmt::Debug for SparsePolynomial<F> {


### PR DESCRIPTION
## Description
Make SparsePolynomial.coeffs field public. This modification is needed for https://github.com/arkworks-rs/poly-commit/issues/169

Contributes to closing: https://github.com/arkworks-rs/poly-commit/issues/169

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (Not needed)
- [ ] Updated relevant documentation in the code (Not needed)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
