### PR TITLE
ff-macros: reject zero unroll factor in unroll_for_loops

### DIFF
--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -84,6 +84,10 @@ pub fn unroll_for_loops(args: TokenStream, input: TokenStream) -> TokenStream {
         _ => panic!("{}", ARG_MSG),
     };
 
+    if unroll_by == 0 {
+        panic!("{}", ARG_MSG);
+    }
+
     let item: Item = syn::parse(input).expect("Failed to parse input.");
 
     if let Item::Fn(item_fn) = item {


### PR DESCRIPTION
Previously, the unroll_for_loops attribute accepted 0 as a valid integer because syn parses it as Lit::Int and we converted it to usize without additional checks. While negatives were already impossible (they parse as a unary minus over an int and are rejected), zero slipped through. This led to generated code in unroll.rs performing division and modulo by the unroll factor, causing a guaranteed runtime panic when unroll_by == 0.
This change adds an explicit guard in ff-macros/src/lib.rs to reject unroll_by == 0 with the same ARG_MSG (“must be a positive integer”), enforcing the documented constraint and converting a runtime panic into a compile-time error. No API changes; existing valid usages (e.g., 6, 12) are unaffected.