### PR TITLE
Remove dead spill buffer path in generate_impl

### DIFF
--- a/ff-asm/src/lib.rs
+++ b/ff-asm/src/lib.rs
@@ -277,11 +277,6 @@ fn generate_impl(num_limbs: usize, is_mul: bool) -> String {
     ctx.add_declaration("modulus", "&Self::MODULUS.0");
     ctx.add_declaration("mod_inv", "Self::INV");
 
-    if num_limbs > MAX_REGS {
-        ctx.add_buffer(2 * num_limbs);
-        ctx.add_declaration("buf", "&mut spill_buffer");
-    }
-
     let asm_instructions = construct_asm_mul(&ctx, num_limbs);
 
     ctx.add_asm(&asm_instructions);


### PR DESCRIPTION
The spill buffer allocation and buf declaration guarded by num_limbs > MAX_REGS were unreachable and never used. All public call sites hard-gate x86_64 ASM usage to limb counts 2..=6, and the proc-macros themselves emit an empty token stream for num_limbs > 6. Since the asm template does not reference {buf} and this branch cannot be reached, the code was dead and misleading, so it has been removed.