### PR TITLE
Improve zero check consistency in Short Weierstrass projective coordinates

### DIFF
--- a/ec/src/models/short_weierstrass/group.rs
+++ b/ec/src/models/short_weierstrass/group.rs
@@ -153,7 +153,8 @@ impl<P: SWCurveConfig> Zero for Projective<P> {
     /// Checks whether `self.z.is_zero()`.
     #[inline]
     fn is_zero(&self) -> bool {
-        self.z == P::BaseField::ZERO
+        // Prefer is_zero() over equality for clarity and potential constant-time behavior.
+        self.z.is_zero()
     }
 }
 


### PR DESCRIPTION


### Description
Replace direct field equality comparison with specialized `is_zero()` method in the `Projective<P>::is_zero()` implementation.

**Before:**
```rust
fn is_zero(&self) -> bool {
    self.z == P::BaseField::ZERO
}
```

**After:**
```rust
fn is_zero(&self) -> bool {
    self.z.is_zero()
}
```

### Benefits
- **Consistency**: Aligns with standard field zero-checking patterns across the codebase
- **Clarity**: Makes the intent of zero comparison explicit
- **Performance**: Leverages optimized field-specific `is_zero()` implementations that may use constant-time operations

