### PR TITLE
chore: Fix typos

### DIFF
--- a/curves/bls12_381/src/curves/g1.rs
+++ b/curves/bls12_381/src/curves/g1.rs
@@ -120,7 +120,7 @@ impl SWCurveConfig for Config {
         let encoding = EncodingFlags {
             is_compressed: compress == ark_serialize::Compress::Yes,
             is_infinity: item.is_zero(),
-            is_lexographically_largest: item.y > -item.y,
+            is_lexicographically_largest: item.y > -item.y,
         };
         let mut p = *item;
         if encoding.is_infinity {

--- a/curves/bls12_381/src/curves/g2.rs
+++ b/curves/bls12_381/src/curves/g2.rs
@@ -147,7 +147,7 @@ impl SWCurveConfig for Config {
         let encoding = EncodingFlags {
             is_compressed: compress == ark_serialize::Compress::Yes,
             is_infinity: item.is_zero(),
-            is_lexographically_largest: item.y > -item.y,
+            is_lexicographically_largest: item.y > -item.y,
         };
         let mut p = *item;
         if encoding.is_infinity {

--- a/curves/bls12_381/src/curves/util.rs
+++ b/curves/bls12_381/src/curves/util.rs
@@ -10,7 +10,7 @@ pub const G2_SERIALIZED_SIZE: usize = 96;
 pub struct EncodingFlags {
     pub is_compressed: bool,
     pub is_infinity: bool,
-    pub is_lexographically_largest: bool,
+    pub is_lexicographically_largest: bool,
 }
 
 impl EncodingFlags {
@@ -22,16 +22,16 @@ impl EncodingFlags {
 
         let is_compressed = compression_flag_set == 1;
         let is_infinity = infinity_flag_set == 1;
-        let is_lexographically_largest = sort_flag_set == 1;
+        let is_lexicographically_largest = sort_flag_set == 1;
 
-        if is_lexographically_largest && (!is_compressed || is_infinity) {
+        if is_lexicographically_largest && (!is_compressed || is_infinity) {
             return Err(SerializationError::InvalidData);
         }
 
         Ok(Self {
             is_compressed,
             is_infinity,
-            is_lexographically_largest,
+            is_lexicographically_largest,
         })
     }
 
@@ -45,7 +45,7 @@ impl EncodingFlags {
             bytes[0] |= 1 << 6;
         }
 
-        if self.is_compressed && !self.is_infinity && self.is_lexographically_largest {
+        if self.is_compressed && !self.is_infinity && self.is_lexicographically_largest {
             bytes[0] |= 1 << 5;
         }
     }
@@ -130,7 +130,7 @@ pub(crate) fn read_g1_compressed<R: ark_serialize::Read>(
     }
 
     let x = deserialize_fq(x_bytes).ok_or(SerializationError::InvalidData)?;
-    let p = G1Affine::get_point_from_x_unchecked(x, flags.is_lexographically_largest)
+    let p = G1Affine::get_point_from_x_unchecked(x, flags.is_lexicographically_largest)
         .ok_or(SerializationError::InvalidData)?;
 
     Ok(p)
@@ -202,7 +202,7 @@ pub(crate) fn read_g2_compressed<R: ark_serialize::Read>(
     let xc0 = deserialize_fq(xc0_bytes).ok_or(SerializationError::InvalidData)?;
     let x = Fq2::new(xc0, xc1);
 
-    let p = G2Affine::get_point_from_x_unchecked(x, flags.is_lexographically_largest)
+    let p = G2Affine::get_point_from_x_unchecked(x, flags.is_lexicographically_largest)
         .ok_or(SerializationError::InvalidData)?;
 
     Ok(p)

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -268,14 +268,14 @@ pub trait CanonicalSerializeHashExt: CanonicalSerialize {
     fn hash<H: Digest>(&self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
         let mut hasher = H::new();
         self.serialize_compressed(HashMarshaller(&mut hasher))
-            .expect("HashMarshaller::flush should be infaillible!");
+            .expect("HashMarshaller::flush should be infallible!");
         hasher.finalize()
     }
 
     fn hash_uncompressed<H: Digest>(&self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
         let mut hasher = H::new();
         self.serialize_uncompressed(HashMarshaller(&mut hasher))
-            .expect("HashMarshaller::flush should be infaillible!");
+            .expect("HashMarshaller::flush should be infallible!");
         hasher.finalize()
     }
 }


### PR DESCRIPTION
## Description

Fix `is_lexographically_largest` to `is_lexicographically_largest`.
Fix `infaillible` to `infallible`.