### PR TITLE
Double and add mul usage

### DIFF
--- a/ec/src/models/double_odd/mod.rs
+++ b/ec/src/models/double_odd/mod.rs
@@ -11,7 +11,10 @@ pub use affine::*;
 mod group;
 pub use group::*;
 
-use crate::{scalar_mul::{double_and_add, double_and_add_affine}, VariableBaseMSM};
+use crate::{
+    scalar_mul::{double_and_add, double_and_add_affine},
+    VariableBaseMSM,
+};
 
 /// Constants and convenience functions that collectively define the [Double-Odd curve](https://doubleodd.group).
 /// In this model, the curve equation is `y² = x(x² + ax + b)`, (b and (a² - 4b) not squares in field)

--- a/ec/src/models/short_weierstrass/mod.rs
+++ b/ec/src/models/short_weierstrass/mod.rs
@@ -10,9 +10,7 @@ use ark_std::{
 use ark_ff::{fields::Field, AdditiveGroup};
 
 use crate::{
-    scalar_mul::{
-        double_and_add_affine, double_and_add, variable_base::VariableBaseMSM,
-    },
+    scalar_mul::{double_and_add, double_and_add_affine, variable_base::VariableBaseMSM},
     AffineRepr,
 };
 use num_traits::Zero;

--- a/ec/src/models/twisted_edwards/mod.rs
+++ b/ec/src/models/twisted_edwards/mod.rs
@@ -4,7 +4,10 @@ use ark_serialize::{
 };
 use ark_std::io::{Read, Write};
 
-use crate::{scalar_mul::{double_and_add, double_and_add_affine, variable_base::VariableBaseMSM}, AffineRepr};
+use crate::{
+    scalar_mul::{double_and_add, double_and_add_affine, variable_base::VariableBaseMSM},
+    AffineRepr,
+};
 use num_traits::Zero;
 
 use ark_ff::fields::Field;

--- a/ec/src/scalar_mul/mod.rs
+++ b/ec/src/scalar_mul/mod.rs
@@ -3,9 +3,7 @@ pub mod wnaf;
 
 pub mod variable_base;
 
-use crate::{
-    AffineRepr, PrimeGroup,
-};
+use crate::{AffineRepr, PrimeGroup};
 use ark_ff::{AdditiveGroup, BigInteger, PrimeField};
 use ark_std::{
     cfg_iter, cfg_iter_mut,

--- a/test-templates/src/glv.rs
+++ b/test-templates/src/glv.rs
@@ -1,10 +1,10 @@
 use ark_ec::{
-    AffineRepr, CurveGroup, PrimeGroup,
     scalar_mul::{double_and_add, double_and_add_affine, glv::GLVConfig},
     short_weierstrass::{Affine, Projective},
+    AffineRepr, CurveGroup, PrimeGroup,
 };
 use ark_ff::{BigInteger, PrimeField};
-use ark_std::{UniformRand, ops::Mul};
+use ark_std::{ops::Mul, UniformRand};
 
 pub fn glv_scalar_decomposition<P: GLVConfig>() {
     let mut rng = ark_std::test_rng();


### PR DESCRIPTION
- refactor usage of the double-and-add scalar multiplication method 
- add a safer default implementation of `is_in_correct_subgroup_assuming_on_curve` for `SWCurveConfig` and `TECurveConfig`. For further context, see [#948](https://github.com/arkworks-rs/algebra/issues/948).

Closes https://github.com/arkworks-rs/algebra/issues/948