### PR TITLE
Use portable shebang in install-hook.sh

### DIFF
--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # This script will install the provided directory ../.hooks as the hook
 # directory for the present repo. See there for hooks, including a pre-commit
 # hook that runs rustfmt on files before a commit.


### PR DESCRIPTION

### PR Description
- Replace non‑portable `#!/bin/env bash` with `#!/usr/bin/env bash` in `scripts/install-hook.sh`.
- Improves portability across macOS/Linux where `env` resides under `/usr/bin`.

