### PR TITLE
Fix GenericArray deprecated struct error

### DIFF
--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -29,7 +29,7 @@ mod test;
 #[doc(hidden)]
 pub use ark_serialize_derive::*;
 
-use digest::{generic_array::GenericArray, Digest, OutputSizeUser};
+use digest::{Digest, Output};
 
 /// Serializes the given `CanonicalSerialize` items in sequence. `serialize_to_vec![a, b, c, d, e]`
 /// is identical to the value of `buf` after `(a, b, c, d, e).serialize_compressed(&mut buf)`.
@@ -265,14 +265,14 @@ impl<H: Digest> ark_std::io::Write for HashMarshaller<'_, H> {
 ///
 /// This is a convenience trait that combines the two steps.
 pub trait CanonicalSerializeHashExt: CanonicalSerialize {
-    fn hash<H: Digest>(&self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
+    fn hash<H: Digest>(&self) -> Output<H> {
         let mut hasher = H::new();
         self.serialize_compressed(HashMarshaller(&mut hasher))
             .expect("HashMarshaller::flush should be infaillible!");
         hasher.finalize()
     }
 
-    fn hash_uncompressed<H: Digest>(&self) -> GenericArray<u8, <H as OutputSizeUser>::OutputSize> {
+    fn hash_uncompressed<H: Digest>(&self) -> Output<H> {
         let mut hasher = H::new();
         self.serialize_uncompressed(HashMarshaller(&mut hasher))
             .expect("HashMarshaller::flush should be infaillible!");


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

We get an error in the CI that `GenericArray` is deprecated and this can be safely swapped for `Output`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #1049

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
