### PR TITLE
chore: use correct spelling for “infallible”

### DIFF
--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -268,14 +268,14 @@ pub trait CanonicalSerializeHashExt: CanonicalSerialize {
     fn hash<H: Digest>(&self) -> Output<H> {
         let mut hasher = H::new();
         self.serialize_compressed(HashMarshaller(&mut hasher))
-            .expect("HashMarshaller::flush should be infaillible!");
+            .expect("HashMarshaller::flush should be infallible!");
         hasher.finalize()
     }
 
     fn hash_uncompressed<H: Digest>(&self) -> Output<H> {
         let mut hasher = H::new();
         self.serialize_uncompressed(HashMarshaller(&mut hasher))
-            .expect("HashMarshaller::flush should be infaillible!");
+            .expect("HashMarshaller::flush should be infallible!");
         hasher.finalize()
     }
 }


### PR DESCRIPTION
## Description

spotted “infaillible” used instead of “infallible”. fixed it to match the usual Rust wording and docs.
ref - https://doc.rust-lang.org/std/result/enum.Result.html#method.expect

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
