### PR TITLE
feat: make BigUint::serialized_size allocation-free

### DIFF
--- a/serialize/src/impls/int_like.rs
+++ b/serialize/src/impls/int_like.rs
@@ -210,8 +210,14 @@ impl CanonicalSerialize for BigUint {
     }
 
     #[inline]
-    fn serialized_size(&self, compress: Compress) -> usize {
-        self.to_bytes_le().serialized_size(compress)
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        let bits = self.bits();
+        let byte_len = if bits == 0 {
+            1
+        } else {
+            ((bits + 7) / 8) as usize
+        };
+        8 + byte_len
     }
 }
 


### PR DESCRIPTION
Previously, BigUint::serialized_size in serialize/src/impls/int_like.rs computed the size by calling to_bytes_le() and delegating to Vec<u8>’s size calculation. This performed a temporary Vec<u8> allocation solely to obtain the byte length, which is unnecessary and introduces avoidable overhead. The change replaces this with an allocation-free calculation based on BigUint::bits(), preserving the exact on-wire format including the zero edge case. For zero values, to_bytes_le() returns a single byte [0], so we return 8 + 1 for the length-prefixed encoding. For non-zero values, the payload length equals ceil(bits/8), so we compute 8 + ((bits + 7) / 8) directly. The behavior of serialization remains unchanged; only the size computation path is optimized to avoid allocation.