### PR TITLE
Decorate unsafe code block with allow unused_unsafe

### DIFF
--- a/ff/src/biginteger/arithmetic.rs
+++ b/ff/src/biginteger/arithmetic.rs
@@ -14,8 +14,7 @@ pub const fn adc(a: &mut u64, b: u64, carry: u64) -> u64 {
 #[doc(hidden)]
 pub fn adc_for_add_with_carry(a: &mut u64, b: u64, carry: u8) -> u8 {
     #[cfg(all(target_arch = "x86_64", feature = "asm"))]
-    #[allow(unused_unsafe)]
-    #[allow(unsafe_code)]
+    #[allow(unused_unsafe, unsafe_code)]
     unsafe {
         use core::arch::x86_64::_addcarry_u64;
         _addcarry_u64(carry, *a, b, a)
@@ -49,8 +48,7 @@ pub(crate) const fn sbb(a: &mut u64, b: u64, borrow: u64) -> u64 {
 #[doc(hidden)]
 pub fn sbb_for_sub_with_borrow(a: &mut u64, b: u64, borrow: u8) -> u8 {
     #[cfg(target_arch = "x86_64")]
-    #[allow(unused_unsafe)]
-    #[allow(unsafe_code)]
+    #[allow(unused_unsafe, unsafe_code)]
     unsafe {
         use core::arch::x86_64::_subborrow_u64;
         _subborrow_u64(borrow, *a, b, a)

--- a/ff/src/biginteger/mod.rs
+++ b/ff/src/biginteger/mod.rs
@@ -358,8 +358,7 @@ impl<const N: usize> BigInteger for BigInt<N> {
     #[inline]
     fn mul2(&mut self) -> bool {
         #[cfg(target_arch = "x86_64")]
-        #[allow(unused_unsafe)]
-        #[allow(unsafe_code)]
+        #[allow(unused_unsafe, unsafe_code)]
         {
             let mut carry = 0;
 


### PR DESCRIPTION
## Description

The CI has started giving an error that the unsafe block is not needed. However, the unsafe block cannot be removed and thus needs to be decorated with allow unused_unsafe.

closes: #1060

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
