### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -36,7 +36,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -63,7 +63,7 @@ jobs:
           - nightly
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
@@ -115,7 +115,7 @@ jobs:
           - nightly
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
@@ -179,7 +179,7 @@ jobs:
     outputs:
       dir: ${{ steps.set-dirs.outputs.dir }} # generate output name dir by using inner step output
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - id: set-dirs # Give it an id to handle to get step outputs in the outputs key above
         run: |
           # shellcheck disable=SC2086
@@ -202,7 +202,7 @@ jobs:
           - dir: ./cp6_782
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Run tests
         run: |
           cd ${{matrix.dir}}
@@ -215,7 +215,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if source code updated
         uses: dorny/paths-filter@v2.11.1
@@ -253,7 +253,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if source code updated
         uses: dorny/paths-filter@v2.11.1
@@ -290,7 +290,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if source code updated
         uses: dorny/paths-filter@v2.11.1
@@ -328,7 +328,7 @@ jobs:
       RUSTFLAGS: -Dwarnings
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust nightly
         uses: actions-rs/toolchain@v1
@@ -360,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Description

Bumps checkout to v6 for future-proofing against Node 24 runner updates.
Requires runner v2.327.1+. Workflows compile the same.

Ref: [https://github.com/actions/checkout/releases/tag/v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
