### PR TITLE
feat: add is_zero helper for DensePolynomial

### DIFF
--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -90,6 +90,12 @@ impl<F: Field> DensePolynomial<F> {
             })
             .sum()
     }
+    
+    /// Returns true if the polynomial is identically zero.
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        self.coeffs.iter().all(|c| c.is_zero())
+    }
 }
 
 impl<F: Field> DenseUVPolynomial<F> for DensePolynomial<F> {


### PR DESCRIPTION
Adds a small helper method is_zero to DensePolynomial for improved ergonomics.
No functional or behavioral changes.
