### PR TITLE
Work around for wasm_bindgen::JsError lacking no_std support

### DIFF
--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -27,6 +27,7 @@ rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde-encoded-bytes = { workspace = true, optional = true, features = ["base64"] }
 serde_with = { workspace = true, optional = true, default-features = false }
+wasm-bindgen = { version = "0.2.100", default-features = false, optional = true }
 
 [dev-dependencies]
 sha2.workspace = true
@@ -41,7 +42,9 @@ ark-test-curves = { workspace = true, default-features = false, features = [
 [features]
 default = []
 parallel = ["rayon"]
-std = ["ark-std/std", "serde_with?/std"]
+std = ["ark-std/std", "serde_with?/std", "wasm-bindgen?/std"]
 derive = ["ark-serialize-derive"]
 serde = ["dep:serde", "dep:serde-encoded-bytes", "dep:serde_with"]
 serde_with = ["serde", "dep:serde_with"]
+wasm = ["dep:wasm-bindgen"]
+

--- a/serialize/src/error.rs
+++ b/serialize/src/error.rs
@@ -35,3 +35,19 @@ impl fmt::Display for SerializationError {
         }
     }
 }
+
+
+// Work around current wasm-bindgen limitation:
+// https://github.com/wasm-bindgen/wasm-bindgen/issues/5025
+#[cfg(all(feature="wasm", not(feature = "std")))]
+mod wasm {
+    use super::SerializationError;
+    use wasm_bindgen::JsError;
+    impl From<SerializationError> for JsError {
+        fn from(err: SerializationError) -> JsError {
+            use ark_std::string::ToString;
+            JsError::new(&err.to_string())
+        }
+    }
+}
+


### PR DESCRIPTION
I think wasm_bindgen should fix this error, and if they did then this PR would break, so I'm not sure this PR should be merged, but this PR provides a work around for now, which can be patched in, so maybe worth having in a branch here.

https://github.com/wasm-bindgen/wasm-bindgen/issues/5025

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
