### PR TITLE
Const initialization helper for SmallFp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Features
 
 - (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
-- (`ark-ff`) Add `from_u128` const constructor for `SmallFp` fields
+- [\#1084](https://github.com/arkworks-rs/algebra/pull/1084) (`ark-ff`) Add `from_u128` const constructor for `SmallFp` fields
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Features
 
 - (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
+- (`ark-ff`) Add `from_u128` const constructor for `SmallFp` fields
 
 ### Improvements
 

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -12,7 +12,7 @@ use proc_macro::TokenStream;
 use quote::format_ident;
 use syn::{Expr, ExprLit, Item, ItemFn, Lit, Meta};
 
-mod montgomery;
+pub(crate) mod montgomery;
 mod small_fp;
 mod unroll;
 
@@ -46,9 +46,6 @@ pub fn define_field(input: TokenStream) -> TokenStream {
 
     let name = args.name;
     let config_name = format_ident!("{}Config", name);
-    let modulus = syn::LitStr::new(&args.modulus, proc_macro2::Span::call_site());
-    let generator = syn::LitStr::new(&args.generator, proc_macro2::Span::call_site());
-
     let is_small_modulus = modulus_big < (BigUint::from(1u128) << 127);
 
     if is_small_modulus {
@@ -73,12 +70,23 @@ pub fn define_field(input: TokenStream) -> TokenStream {
     } else {
         let fp_alias = utils::fp_alias_for_limbs(limbs);
 
+        let generator_big = args
+            .generator
+            .parse::<BigUint>()
+            .expect("generator should be a decimal integer string");
+
+        let config_impl = montgomery::mont_config_helper(
+            modulus_big,
+            generator_big,
+            None,
+            None,
+            config_name.clone(),
+        );
+
         quote::quote! {
-            #[derive(ark_ff::MontConfig)]
-            #[modulus = #modulus]
-            #[generator = #generator]
             pub struct #config_name;
             pub type #name = #fp_alias<ark_ff::MontBackend<#config_name, #limbs>>;
+            #config_impl
         }
         .into()
     }

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -50,27 +50,38 @@ pub fn define_field(input: TokenStream) -> TokenStream {
     let generator = syn::LitStr::new(&args.generator, proc_macro2::Span::call_site());
 
     let is_small_modulus = modulus_big < (BigUint::from(1u128) << 127);
-    let derives = if is_small_modulus {
-        quote::quote! { #[derive(ark_ff::SmallFpConfig)] }
-    } else {
-        quote::quote! { #[derive(ark_ff::MontConfig)] }
-    };
 
-    let field_ty = if is_small_modulus {
-        quote::quote! { ark_ff::SmallFp<#config_name> }
+    if is_small_modulus {
+        let modulus_u128: u128 = args
+            .modulus
+            .parse()
+            .expect("modulus should fit in u128 for small field");
+        let generator_u128: u128 = args
+            .generator
+            .parse()
+            .expect("generator should fit in u128 for small field");
+
+        let config_impl =
+            small_fp::small_fp_config_helper(modulus_u128, generator_u128, config_name.clone());
+
+        quote::quote! {
+            pub struct #config_name;
+            pub type #name = ark_ff::SmallFp<#config_name>;
+            #config_impl
+        }
+        .into()
     } else {
         let fp_alias = utils::fp_alias_for_limbs(limbs);
-        quote::quote! { #fp_alias<ark_ff::MontBackend<#config_name, #limbs>> }
-    };
 
-    quote::quote! {
-        #derives
-        #[modulus = #modulus]
-        #[generator = #generator]
-        pub struct #config_name;
-        pub type #name = #field_ty;
+        quote::quote! {
+            #[derive(ark_ff::MontConfig)]
+            #[modulus = #modulus]
+            #[generator = #generator]
+            pub struct #config_name;
+            pub type #name = #fp_alias<ark_ff::MontBackend<#config_name, #limbs>>;
+        }
+        .into()
     }
-    .into()
 }
 
 /// Derive the `MontConfig` trait.

--- a/ff-macros/src/small_fp/mod.rs
+++ b/ff-macros/src/small_fp/mod.rs
@@ -24,7 +24,11 @@ pub(crate) fn small_fp_config_helper(
 
     // Compute R mod P for const Montgomery conversion
     let is_u128 = ty.to_string() == "u128";
-    let k_bits: u32 = if is_u128 { 128 } else { 128 - modulus.leading_zeros() };
+    let k_bits: u32 = if is_u128 {
+        128
+    } else {
+        128 - modulus.leading_zeros()
+    };
     let r_mod_p = if k_bits == 128 {
         0u128.wrapping_sub(modulus) % modulus
     } else {

--- a/ff-macros/src/small_fp/mod.rs
+++ b/ff-macros/src/small_fp/mod.rs
@@ -22,8 +22,17 @@ pub(crate) fn small_fp_config_helper(
         "SmallFpConfig montgomery backend supports only moduli < 2^127. Use MontConfig with BigInt instead of SmallFp."
     );
 
+    // Compute R mod P for const Montgomery conversion
+    let is_u128 = ty.to_string() == "u128";
+    let k_bits: u32 = if is_u128 { 128 } else { 128 - modulus.leading_zeros() };
+    let r_mod_p = if k_bits == 128 {
+        0u128.wrapping_sub(modulus) % modulus
+    } else {
+        (1u128 << k_bits) % modulus
+    };
+
     let backend_impl = montgomery_backend::backend_impl(&ty, modulus, generator);
-    let exit_impl = montgomery_backend::exit_impl();
+    let exit_impl = montgomery_backend::exit_impl(modulus, r_mod_p);
 
     quote! {
         const _: () = {

--- a/ff-macros/src/small_fp/mod.rs
+++ b/ff-macros/src/small_fp/mod.rs
@@ -22,20 +22,7 @@ pub(crate) fn small_fp_config_helper(
         "SmallFpConfig montgomery backend supports only moduli < 2^127. Use MontConfig with BigInt instead of SmallFp."
     );
 
-    // Compute R mod P for const Montgomery conversion
-    let is_u128 = ty.to_string() == "u128";
-    let k_bits: u32 = if is_u128 {
-        128
-    } else {
-        128 - modulus.leading_zeros()
-    };
-    let r_mod_p = if k_bits == 128 {
-        0u128.wrapping_sub(modulus) % modulus
-    } else {
-        (1u128 << k_bits) % modulus
-    };
-
-    let backend_impl = montgomery_backend::backend_impl(&ty, modulus, generator);
+    let (backend_impl, r_mod_p) = montgomery_backend::backend_impl(&ty, modulus, generator);
     let exit_impl = montgomery_backend::exit_impl(modulus, r_mod_p);
 
     quote! {

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -88,7 +88,7 @@ pub(crate) fn backend_impl(
             fn add_assign(a: &mut SmallFp<Self>, b: &SmallFp<Self>) {
                 let (mut val, overflow) = a.value.overflowing_add(b.value);
                 if overflow {
-                    val = Self::T::MAX - Self::MODULUS + 1 + val
+                    val += Self::T::MAX - Self::MODULUS + 1
                 }
                 if val >= Self::MODULUS {
                     val -= Self::MODULUS;

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -8,7 +8,7 @@ pub(crate) fn backend_impl(
     ty: &proc_macro2::TokenStream,
     modulus: u128,
     generator: u128,
-) -> proc_macro2::TokenStream {
+) -> (proc_macro2::TokenStream, u128) {
     assert!(modulus > 1, "modulus must be greater than 1");
     assert!(
         modulus % 2 == 1,
@@ -98,7 +98,7 @@ pub(crate) fn backend_impl(
         }
     };
 
-    quote! {
+    let ts = quote! {
         type T = #ty;
         const MODULUS: Self::T = #modulus as Self::T;
         const MODULUS_U128: u128 = #modulus;
@@ -209,7 +209,9 @@ pub(crate) fn backend_impl(
         #from_bigint_impl
 
         #into_bigint_impl
-    }
+    };
+
+    (ts, r_mod_n)
 }
 
 // Selects the appropriate multiplication algorithm at compile time:

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -504,31 +504,18 @@ pub(crate) fn exit_impl(modulus: u128, r_mod_p: u128) -> proc_macro2::TokenStrea
             const R_MOD_P: u128 = #r_mod_p;
 
             // const-compatible modular multiplication via double-and-add
-            const fn mod_mul(a: u128, b: u128, m: u128) -> u128 {
-                match a.overflowing_mul(b) {
-                    (val, false) => val % m,
-                    (_, true) => {
-                        let mut result = 0u128;
-                        let mut base = a % m;
-                        let mut exp = b;
-                        while exp > 0 {
-                            if exp & 1 == 1 {
-                                result = if result >= m - base {
-                                    result - (m - base)
-                                } else {
-                                    result + base
-                                };
-                            }
-                            base = if base >= m - base {
-                                base - (m - base)
-                            } else {
-                                base + base
-                            };
-                            exp >>= 1;
-                        }
-                        result
+            // Safe from overflow: modulus < 2^127 so a,result < 2^127 and all additions fit u128
+            const fn mod_mul(mut a: u128, mut b: u128, m: u128) -> u128 {
+                a %= m;
+                let mut result = 0u128;
+                while b > 0 {
+                    if b & 1 == 1 {
+                        result = (result + a) % m;
                     }
+                    a = (a + a) % m;
+                    b >>= 1;
                 }
+                result
             }
 
             let val = value % MODULUS;

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -489,96 +489,48 @@ fn mod_inverse_pow2(n: u128, k_bits: u32) -> u128 {
     inv.wrapping_neg() & mask
 }
 
-pub(crate) fn exit_impl(modulus: u128, r2: u128) -> proc_macro2::TokenStream {
+pub(crate) fn exit_impl(modulus: u128, r_mod_p: u128) -> proc_macro2::TokenStream {
     quote! {
         pub fn exit(a: &mut SmallFp<Self>) {
             let one = SmallFp::from_raw(1 as <Self as SmallFpConfig>::T);
             <Self as SmallFpConfig>::mul_assign(a, &one);
         }
 
-        /// Const-compatible Montgomery modular multiplication using u128 arithmetic.
-        /// Computes `a * b mod MODULUS` at compile time via double-and-add.
-        const fn const_mod_mul(a: u128, b: u128, modulus: u128) -> u128 {
-            // If the product fits in u128, just use the remainder operator.
-            // Otherwise fall back to double-and-add.
-            match a.overflowing_mul(b) {
-                (val, false) => val % modulus,
-                (_, true) => {
-                    let mut result = 0u128;
-                    let mut base = a % modulus;
-                    let mut exp = b;
-                    while exp > 0 {
-                        if exp & 1 == 1 {
-                            // result = (result + base) mod modulus
-                            result = if result >= modulus - base {
-                                result - (modulus - base)
-                            } else {
-                                result + base
-                            };
-                        }
-                        // base = (base + base) mod modulus
-                        base = if base >= modulus - base {
-                            base - (modulus - base)
-                        } else {
-                            base + base
-                        };
-                        exp >>= 1;
-                    }
-                    result
-                }
-            }
-        }
-
-        /// Construct a [`SmallFp<Self>`] field element from a sign and a slice of u64 limbs.
-        ///
-        /// This is the `SmallFp` analogue of [`Fp::from_sign_and_limbs`] and is usable
-        /// in `const` contexts. The limbs are interpreted as a little-endian
-        /// integer which is then reduced modulo `MODULUS` and converted to
-        /// Montgomery form.
-        pub const fn from_sign_and_limbs(is_positive: bool, limbs: &[u64]) -> SmallFp<Self> {
-            const MODULUS: u128 = #modulus;
-            const R_MOD_P: u128 = #r2;
-
-            // Build u128 from limbs (little-endian)
-            let mut val: u128 = 0;
-            let mut i = 0;
-            while i < limbs.len() && i < 2 {
-                val |= (limbs[i] as u128) << (64 * i);
-                i += 1;
-            }
-
-            // Reduce mod P
-            val %= MODULUS;
-
-            // Enter Montgomery form: val_mont = val * R mod P  (via const mul)
-            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
-
-            // Handle sign
-            let mont = if is_positive {
-                mont
-            } else if mont == 0 {
-                0
-            } else {
-                MODULUS - mont
-            };
-
-            SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
-        }
-
-        /// Construct a [`SmallFp<Self>`] from a `u128` value in a const context.
-        ///
-        /// This is the simplest way to create compile-time field element
-        /// constants for `SmallFp` fields:
-        ///
-        /// ```ignore
-        /// const SEVEN: Field64 = FConfig64::from_u128(7);
-        /// ```
+        // This is the `SmallFp` analogue of [`MontFp!`] to support const initialization
         pub const fn from_u128(value: u128) -> SmallFp<Self> {
             const MODULUS: u128 = #modulus;
-            const R_MOD_P: u128 = #r2;
+            const R_MOD_P: u128 = #r_mod_p;
+
+            // const-compatible modular multiplication via double-and-add
+            const fn mod_mul(a: u128, b: u128, m: u128) -> u128 {
+                match a.overflowing_mul(b) {
+                    (val, false) => val % m,
+                    (_, true) => {
+                        let mut result = 0u128;
+                        let mut base = a % m;
+                        let mut exp = b;
+                        while exp > 0 {
+                            if exp & 1 == 1 {
+                                result = if result >= m - base {
+                                    result - (m - base)
+                                } else {
+                                    result + base
+                                };
+                            }
+                            base = if base >= m - base {
+                                base - (m - base)
+                            } else {
+                                base + base
+                            };
+                            exp >>= 1;
+                        }
+                        result
+                    }
+                }
+            }
 
             let val = value % MODULUS;
-            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
+            let mont = mod_mul(val, R_MOD_P, MODULUS);
             SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
         }
     }

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -489,11 +489,97 @@ fn mod_inverse_pow2(n: u128, k_bits: u32) -> u128 {
     inv.wrapping_neg() & mask
 }
 
-pub(crate) fn exit_impl() -> proc_macro2::TokenStream {
+pub(crate) fn exit_impl(modulus: u128, r2: u128) -> proc_macro2::TokenStream {
     quote! {
         pub fn exit(a: &mut SmallFp<Self>) {
             let one = SmallFp::from_raw(1 as <Self as SmallFpConfig>::T);
             <Self as SmallFpConfig>::mul_assign(a, &one);
+        }
+
+        /// Const-compatible Montgomery modular multiplication using u128 arithmetic.
+        /// Computes `a * b mod MODULUS` at compile time via double-and-add.
+        const fn const_mod_mul(a: u128, b: u128, modulus: u128) -> u128 {
+            // If the product fits in u128, just use the remainder operator.
+            // Otherwise fall back to double-and-add.
+            match a.overflowing_mul(b) {
+                (val, false) => val % modulus,
+                (_, true) => {
+                    let mut result = 0u128;
+                    let mut base = a % modulus;
+                    let mut exp = b;
+                    while exp > 0 {
+                        if exp & 1 == 1 {
+                            // result = (result + base) mod modulus
+                            result = if result >= modulus - base {
+                                result - (modulus - base)
+                            } else {
+                                result + base
+                            };
+                        }
+                        // base = (base + base) mod modulus
+                        base = if base >= modulus - base {
+                            base - (modulus - base)
+                        } else {
+                            base + base
+                        };
+                        exp >>= 1;
+                    }
+                    result
+                }
+            }
+        }
+
+        /// Construct a [`SmallFp<Self>`] field element from a sign and a slice of u64 limbs.
+        ///
+        /// This is the `SmallFp` analogue of [`Fp::from_sign_and_limbs`] and is usable
+        /// in `const` contexts. The limbs are interpreted as a little-endian
+        /// integer which is then reduced modulo `MODULUS` and converted to
+        /// Montgomery form.
+        pub const fn from_sign_and_limbs(is_positive: bool, limbs: &[u64]) -> SmallFp<Self> {
+            const MODULUS: u128 = #modulus;
+            const R_MOD_P: u128 = #r2;
+
+            // Build u128 from limbs (little-endian)
+            let mut val: u128 = 0;
+            let mut i = 0;
+            while i < limbs.len() && i < 2 {
+                val |= (limbs[i] as u128) << (64 * i);
+                i += 1;
+            }
+
+            // Reduce mod P
+            val %= MODULUS;
+
+            // Enter Montgomery form: val_mont = val * R mod P  (via const mul)
+            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
+
+            // Handle sign
+            let mont = if is_positive {
+                mont
+            } else if mont == 0 {
+                0
+            } else {
+                MODULUS - mont
+            };
+
+            SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
+        }
+
+        /// Construct a [`SmallFp<Self>`] from a `u128` value in a const context.
+        ///
+        /// This is the simplest way to create compile-time field element
+        /// constants for `SmallFp` fields:
+        ///
+        /// ```ignore
+        /// const SEVEN: Field64 = FConfig64::from_u128(7);
+        /// ```
+        pub const fn from_u128(value: u128) -> SmallFp<Self> {
+            const MODULUS: u128 = #modulus;
+            const R_MOD_P: u128 = #r2;
+
+            let val = value % MODULUS;
+            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
+            SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
         }
     }
 }

--- a/ff-macros/src/small_fp/utils.rs
+++ b/ff-macros/src/small_fp/utils.rs
@@ -85,7 +85,7 @@ pub(crate) fn generate_montgomery_bigint_casts(
         quote! {
             fn from_bigint(a: ark_ff::BigInt<2>) -> Option<SmallFp<Self>> {
                 let val = (a.0[0] as u128) + ((a.0[1] as u128) << 64);
-                if val > Self::MODULUS_U128 {
+                if val >= Self::MODULUS_U128 {
                     None
                 } else {
                     let reduced_val = val % Self::MODULUS_U128;

--- a/ff-macros/src/utils.rs
+++ b/ff-macros/src/utils.rs
@@ -87,13 +87,13 @@ pub(crate) fn fp_alias_for_limbs(limbs: usize) -> TokenStream2 {
 }
 
 pub(crate) fn parse_string(input: TokenStream) -> Option<String> {
-    let input: Expr = syn::parse(input).unwrap();
-    let input = if let Expr::Group(syn::ExprGroup { expr, .. }) = input {
-        expr
-    } else {
-        panic!("could not parse");
-    };
-    match *input {
+    let mut input: Expr = syn::parse(input).unwrap();
+    // Unwrap invisible group delimiters that the compiler may (or may not)
+    // insert around tokens forwarded from other proc macros.
+    if let Expr::Group(syn::ExprGroup { expr, .. }) = input {
+        input = *expr;
+    }
+    match input {
         Expr::Lit(expr_lit) => match expr_lit.lit {
             Lit::Str(s) => Some(s.value()),
             _ => None,

--- a/ff-macros/src/utils.rs
+++ b/ff-macros/src/utils.rs
@@ -87,13 +87,13 @@ pub(crate) fn fp_alias_for_limbs(limbs: usize) -> TokenStream2 {
 }
 
 pub(crate) fn parse_string(input: TokenStream) -> Option<String> {
-    let mut input: Expr = syn::parse(input).unwrap();
-    // Unwrap invisible group delimiters that the compiler may (or may not)
-    // insert around tokens forwarded from other proc macros.
-    if let Expr::Group(syn::ExprGroup { expr, .. }) = input {
-        input = *expr;
-    }
-    match input {
+    let input: Expr = syn::parse(input).unwrap();
+    let input = if let Expr::Group(syn::ExprGroup { expr, .. }) = input {
+        expr
+    } else {
+        panic!("could not parse");
+    };
+    match *input {
         Expr::Lit(expr_lit) => match expr_lit.lit {
             Lit::Str(s) => Some(s.value()),
             _ => None,

--- a/test-curves/src/smallfp.rs
+++ b/test-curves/src/smallfp.rs
@@ -46,9 +46,7 @@ mod tests {
 
     mod const_constructors {
         use super::*;
-        use ark_ff::{PrimeField, Zero, One};
-
-        // ---------- from_u128 ----------
+        use ark_ff::{One, Zero};
 
         #[test]
         fn test_from_u128_zero() {
@@ -64,7 +62,17 @@ mod tests {
 
         #[test]
         fn test_from_u128_matches_runtime() {
-            for val in [0u128, 1, 2, 7, 42, 255, 65521, 2013265921, 18446744069414584320] {
+            for val in [
+                0u128,
+                1,
+                2,
+                7,
+                42,
+                255,
+                65521,
+                2013265921,
+                18446744069414584320,
+            ] {
                 let const_elem: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(val);
                 let runtime_elem = SmallFp64Goldilock::from(val);
                 assert_eq!(const_elem, runtime_elem, "from_u128({val}) mismatch");
@@ -72,88 +80,46 @@ mod tests {
         }
 
         #[test]
-        fn test_from_u128_u8_field() {
+        fn test_from_u128_all_backing_types() {
+            // u8 field
             for val in [0u128, 1, 7, 42, 250] {
-                let const_elem: SmallFp8 = SmallFp8Config::from_u128(val);
-                let runtime_elem = SmallFp8::from(val);
-                assert_eq!(const_elem, runtime_elem, "u8 field from_u128({val}) mismatch");
+                assert_eq!(SmallFp8Config::from_u128(val), SmallFp8::from(val));
             }
-        }
-
-        #[test]
-        fn test_from_u128_u32_field() {
+            // u32 field (M31)
             for val in [0u128, 1, 7, 1000000, 2147483646] {
-                let const_elem: SmallFp32M31 = SmallFp32M31Config::from_u128(val);
-                let runtime_elem = SmallFp32M31::from(val);
-                assert_eq!(const_elem, runtime_elem, "u32 M31 field from_u128({val}) mismatch");
+                assert_eq!(SmallFp32M31Config::from_u128(val), SmallFp32M31::from(val));
             }
-        }
-
-        #[test]
-        fn test_from_u128_u128_field() {
-            for val in [0u128, 1, 7, u64::MAX as u128, 143244528689204659050391023439224324688] {
-                let const_elem: SmallFp128 = SmallFp128Config::from_u128(val);
-                let runtime_elem = SmallFp128::from(val);
-                assert_eq!(const_elem, runtime_elem, "u128 field from_u128({val}) mismatch");
+            // u128 field
+            for val in [
+                0u128,
+                1,
+                7,
+                u64::MAX as u128,
+                143244528689204659050391023439224324688,
+            ] {
+                assert_eq!(SmallFp128Config::from_u128(val), SmallFp128::from(val));
             }
         }
 
         #[test]
         fn test_from_u128_reduction() {
-            // Value larger than modulus should be reduced
             let modulus = 18446744069414584321u128; // Goldilocks
             let val = modulus + 7;
             let const_elem: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(val);
             let seven: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
-            assert_eq!(const_elem, seven, "from_u128(P+7) should equal from_u128(7)");
+            assert_eq!(
+                const_elem, seven,
+                "from_u128(P+7) should equal from_u128(7)"
+            );
         }
-
-        // ---------- from_sign_and_limbs ----------
-
-        #[test]
-        fn test_from_sign_and_limbs_positive() {
-            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(true, &[7]);
-            let expected: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
-            assert_eq!(a, expected);
-        }
-
-        #[test]
-        fn test_from_sign_and_limbs_negative() {
-            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
-            let one: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(1);
-            assert_eq!(a, -one, "from_sign_and_limbs(false, [1]) should be -1");
-        }
-
-        #[test]
-        fn test_from_sign_and_limbs_negative_zero() {
-            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[0]);
-            assert!(a.is_zero(), "-0 should be 0");
-        }
-
-        #[test]
-        fn test_from_sign_and_limbs_two_limbs() {
-            // Test with a value that spans two u64 limbs (for u128 field)
-            let val: u128 = (1u128 << 64) + 42;
-            let lo = val as u64;
-            let hi = (val >> 64) as u64;
-            let const_elem: SmallFp128 = SmallFp128Config::from_sign_and_limbs(true, &[lo, hi]);
-            let runtime_elem = SmallFp128::from(val);
-            assert_eq!(const_elem, runtime_elem, "two-limb from_sign_and_limbs mismatch");
-        }
-
-        // ---------- const context ----------
 
         #[test]
         fn test_const_context() {
-            // Verify these are actually usable in const contexts
             const SEVEN: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
-            const NEG_ONE: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
+            const FORTY_TWO: SmallFp128 = SmallFp128Config::from_u128(42);
 
-            let runtime_seven = SmallFp64Goldilock::from(7u128);
-            let runtime_neg_one = -SmallFp64Goldilock::from(1u128);
-
-            assert_eq!(SEVEN, runtime_seven);
-            assert_eq!(NEG_ONE, runtime_neg_one);
+            assert_eq!(SEVEN, SmallFp64Goldilock::from(7u128));
+            assert_eq!(FORTY_TWO, SmallFp128::from(42u128));
         }
     }
 }

--- a/test-curves/src/smallfp.rs
+++ b/test-curves/src/smallfp.rs
@@ -43,4 +43,117 @@ mod tests {
     test_small_field!(f32_mont_babybear; SmallFp32Babybear);
     test_small_field!(f64; SmallFp64Goldilock);
     test_small_field!(f128; SmallFp128);
+
+    mod const_constructors {
+        use super::*;
+        use ark_ff::{PrimeField, Zero, One};
+
+        // ---------- from_u128 ----------
+
+        #[test]
+        fn test_from_u128_zero() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(0);
+            assert!(a.is_zero(), "from_u128(0) should be zero");
+        }
+
+        #[test]
+        fn test_from_u128_one() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(1);
+            assert!(a.is_one(), "from_u128(1) should be one");
+        }
+
+        #[test]
+        fn test_from_u128_matches_runtime() {
+            for val in [0u128, 1, 2, 7, 42, 255, 65521, 2013265921, 18446744069414584320] {
+                let const_elem: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(val);
+                let runtime_elem = SmallFp64Goldilock::from(val);
+                assert_eq!(const_elem, runtime_elem, "from_u128({val}) mismatch");
+            }
+        }
+
+        #[test]
+        fn test_from_u128_u8_field() {
+            for val in [0u128, 1, 7, 42, 250] {
+                let const_elem: SmallFp8 = SmallFp8Config::from_u128(val);
+                let runtime_elem = SmallFp8::from(val);
+                assert_eq!(const_elem, runtime_elem, "u8 field from_u128({val}) mismatch");
+            }
+        }
+
+        #[test]
+        fn test_from_u128_u32_field() {
+            for val in [0u128, 1, 7, 1000000, 2147483646] {
+                let const_elem: SmallFp32M31 = SmallFp32M31Config::from_u128(val);
+                let runtime_elem = SmallFp32M31::from(val);
+                assert_eq!(const_elem, runtime_elem, "u32 M31 field from_u128({val}) mismatch");
+            }
+        }
+
+        #[test]
+        fn test_from_u128_u128_field() {
+            for val in [0u128, 1, 7, u64::MAX as u128, 143244528689204659050391023439224324688] {
+                let const_elem: SmallFp128 = SmallFp128Config::from_u128(val);
+                let runtime_elem = SmallFp128::from(val);
+                assert_eq!(const_elem, runtime_elem, "u128 field from_u128({val}) mismatch");
+            }
+        }
+
+        #[test]
+        fn test_from_u128_reduction() {
+            // Value larger than modulus should be reduced
+            let modulus = 18446744069414584321u128; // Goldilocks
+            let val = modulus + 7;
+            let const_elem: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(val);
+            let seven: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
+            assert_eq!(const_elem, seven, "from_u128(P+7) should equal from_u128(7)");
+        }
+
+        // ---------- from_sign_and_limbs ----------
+
+        #[test]
+        fn test_from_sign_and_limbs_positive() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(true, &[7]);
+            let expected: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
+            assert_eq!(a, expected);
+        }
+
+        #[test]
+        fn test_from_sign_and_limbs_negative() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
+            let one: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(1);
+            assert_eq!(a, -one, "from_sign_and_limbs(false, [1]) should be -1");
+        }
+
+        #[test]
+        fn test_from_sign_and_limbs_negative_zero() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[0]);
+            assert!(a.is_zero(), "-0 should be 0");
+        }
+
+        #[test]
+        fn test_from_sign_and_limbs_two_limbs() {
+            // Test with a value that spans two u64 limbs (for u128 field)
+            let val: u128 = (1u128 << 64) + 42;
+            let lo = val as u64;
+            let hi = (val >> 64) as u64;
+            let const_elem: SmallFp128 = SmallFp128Config::from_sign_and_limbs(true, &[lo, hi]);
+            let runtime_elem = SmallFp128::from(val);
+            assert_eq!(const_elem, runtime_elem, "two-limb from_sign_and_limbs mismatch");
+        }
+
+        // ---------- const context ----------
+
+        #[test]
+        fn test_const_context() {
+            // Verify these are actually usable in const contexts
+            const SEVEN: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
+            const NEG_ONE: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
+
+            let runtime_seven = SmallFp64Goldilock::from(7u128);
+            let runtime_neg_one = -SmallFp64Goldilock::from(1u128);
+
+            assert_eq!(SEVEN, runtime_seven);
+            assert_eq!(NEG_ONE, runtime_neg_one);
+        }
+    }
 }


### PR DESCRIPTION
There was no equivalent const helper for MontFp! so we create NAME::from_u128(1) that is const compatible. This isn't strictly needed but it's far more convenient for users especially when writing extension field config.

Example use: https://github.com/WizardOfMenlo/whir/pull/242/changes#diff-a0fce05055298d8ce81ce601933b6e9349617338f89f53db251b60d5ff884182R95

Small Items:
- also addresses clippy warnings
- also addresses proc macro warnings
- also addresses mapping of modulus to zero when this should probably map to none

closes: #1085

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ x] Targeted PR against correct branch (master)
- [ x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x ] Wrote unit tests
- [x ] Updated relevant documentation in the code
- [ x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ x] Re-reviewed `Files changed` in the GitHub PR explorer
