### PR TITLE
In define_field macro set plausibly useful FFT params for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
 - [\#1084](https://github.com/arkworks-rs/algebra/pull/1084) (`ark-ff`) Add `from_u128` const constructor for `SmallFp` fields
+- [\#1086](https://github.com/arkworks-rs/algebra/pull/1086) (`ark-ff-macros`) Auto-detect small prime subgroup (bases 3, 5, 7) in `define_field!` for both `SmallFp` and `Fp` fields
 
 ### Improvements
 

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -76,7 +76,7 @@ pub fn define_field(input: TokenStream) -> TokenStream {
             .expect("generator should be a decimal integer string");
 
         let (small_subgroup_base, small_subgroup_power) =
-            match utils::detect_small_prime_subgroup(&modulus_big) {
+            match utils::find_conservative_subgroup_base(&modulus_big) {
                 Some((base, power)) => (Some(base), Some(power)),
                 None => (None, None),
             };

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -8,6 +8,7 @@
 #![forbid(unsafe_code)]
 
 use num_bigint::BigUint;
+use num_traits::Zero;
 use proc_macro::TokenStream;
 use quote::format_ident;
 use syn::{Expr, ExprLit, Item, ItemFn, Lit, Meta};
@@ -75,11 +76,28 @@ pub fn define_field(input: TokenStream) -> TokenStream {
             .parse::<BigUint>()
             .expect("generator should be a decimal integer string");
 
+        // Auto-detect small subgroup params (base 3)
+        let mut trace = &modulus_big - BigUint::from(1u32);
+        while trace.bit(0) == false {
+            trace >>= 1u32;
+        }
+        let base = BigUint::from(3u32);
+        let mut power = 0u32;
+        while (&trace % &base).is_zero() {
+            trace /= &base;
+            power += 1;
+        }
+        let (small_subgroup_base, small_subgroup_power) = if power > 0 {
+            (Some(3u32), Some(power))
+        } else {
+            (None, None)
+        };
+
         let config_impl = montgomery::mont_config_helper(
             modulus_big,
             generator_big,
-            None,
-            None,
+            small_subgroup_base,
+            small_subgroup_power,
             config_name.clone(),
         );
 

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -8,7 +8,6 @@
 #![forbid(unsafe_code)]
 
 use num_bigint::BigUint;
-use num_traits::Zero;
 use proc_macro::TokenStream;
 use quote::format_ident;
 use syn::{Expr, ExprLit, Item, ItemFn, Lit, Meta};
@@ -76,24 +75,11 @@ pub fn define_field(input: TokenStream) -> TokenStream {
             .parse::<BigUint>()
             .expect("generator should be a decimal integer string");
 
-        // Detect small prime subgroup: check bases {3, 5, 7}
-        let mut trace = &modulus_big - BigUint::from(1u32);
-        while trace.bit(0) == false {
-            trace >>= 1u32;
-        }
-        let (small_subgroup_base, small_subgroup_power) = [3u32, 5, 7]
-            .iter()
-            .find_map(|&b| {
-                let base = BigUint::from(b);
-                let mut t = trace.clone();
-                let mut power = 0u32;
-                while (&t % &base).is_zero() {
-                    t /= &base;
-                    power += 1;
-                }
-                (power > 0).then_some((Some(b), Some(power)))
-            })
-            .unwrap_or((None, None));
+        let (small_subgroup_base, small_subgroup_power) =
+            match utils::detect_small_prime_subgroup(&modulus_big) {
+                Some((base, power)) => (Some(base), Some(power)),
+                None => (None, None),
+            };
 
         let config_impl = montgomery::mont_config_helper(
             modulus_big,

--- a/ff-macros/src/lib.rs
+++ b/ff-macros/src/lib.rs
@@ -76,22 +76,24 @@ pub fn define_field(input: TokenStream) -> TokenStream {
             .parse::<BigUint>()
             .expect("generator should be a decimal integer string");
 
-        // Auto-detect small subgroup params (base 3)
+        // Detect small prime subgroup: check bases {3, 5, 7}
         let mut trace = &modulus_big - BigUint::from(1u32);
         while trace.bit(0) == false {
             trace >>= 1u32;
         }
-        let base = BigUint::from(3u32);
-        let mut power = 0u32;
-        while (&trace % &base).is_zero() {
-            trace /= &base;
-            power += 1;
-        }
-        let (small_subgroup_base, small_subgroup_power) = if power > 0 {
-            (Some(3u32), Some(power))
-        } else {
-            (None, None)
-        };
+        let (small_subgroup_base, small_subgroup_power) = [3u32, 5, 7]
+            .iter()
+            .find_map(|&b| {
+                let base = BigUint::from(b);
+                let mut t = trace.clone();
+                let mut power = 0u32;
+                while (&t % &base).is_zero() {
+                    t /= &base;
+                    power += 1;
+                }
+                (power > 0).then_some((Some(b), Some(power)))
+            })
+            .unwrap_or((None, None));
 
         let config_impl = montgomery::mont_config_helper(
             modulus_big,

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -3,7 +3,7 @@ use crate::small_fp::utils::{
     compute_large_subgroup_root, compute_two_adic_root_of_unity, compute_two_adicity,
     generate_montgomery_bigint_casts, generate_sqrt_precomputation, mod_mul_const,
 };
-use crate::utils::detect_small_prime_subgroup;
+use crate::utils::find_conservative_subgroup_base;
 
 pub(crate) fn backend_impl(
     ty: &proc_macro2::TokenStream,
@@ -58,7 +58,7 @@ pub(crate) fn backend_impl(
     let neg_one_mont = mod_mul_const(modulus - 1, r_mod_n, modulus);
 
     let modulus_big = num_bigint::BigUint::from(modulus);
-    let mixed_radix_impl = if let Some((base, power)) = detect_small_prime_subgroup(&modulus_big)
+    let mixed_radix_impl = if let Some((base, power)) = find_conservative_subgroup_base(&modulus_big)
     {
         let large_root = compute_large_subgroup_root(modulus, generator, two_adicity, base, power);
         let large_root_mont = mod_mul_const(large_root, r_mod_n, modulus);

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -499,10 +499,7 @@ pub(crate) fn exit_impl(modulus: u128, r_mod_p: u128) -> proc_macro2::TokenStrea
         }
 
         /// Const-compatible Montgomery modular multiplication using u128 arithmetic.
-        /// Computes `a * b mod MODULUS` at compile time via double-and-add.
         const fn const_mod_mul(a: u128, b: u128, modulus: u128) -> u128 {
-            // If the product fits in u128, just use the remainder operator.
-            // Otherwise fall back to double-and-add.
             match a.overflowing_mul(b) {
                 (val, false) => val % modulus,
                 (_, true) => {
@@ -511,14 +508,12 @@ pub(crate) fn exit_impl(modulus: u128, r_mod_p: u128) -> proc_macro2::TokenStrea
                     let mut exp = b;
                     while exp > 0 {
                         if exp & 1 == 1 {
-                            // result = (result + base) mod modulus
                             result = if result >= modulus - base {
                                 result - (modulus - base)
                             } else {
                                 result + base
                             };
                         }
-                        // base = (base + base) mod modulus
                         base = if base >= modulus - base {
                             base - (modulus - base)
                         } else {
@@ -549,13 +544,9 @@ pub(crate) fn exit_impl(modulus: u128, r_mod_p: u128) -> proc_macro2::TokenStrea
                 i += 1;
             }
 
-            // Reduce mod P
             val %= MODULUS;
-
-            // Enter Montgomery form: val_mont = val * R mod P  (via const mul)
             let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
 
-            // Handle sign
             let mont = if is_positive {
                 mont
             } else if mont == 0 {

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -1,9 +1,9 @@
 use super::*;
 use crate::small_fp::utils::{
     compute_large_subgroup_root, compute_two_adic_root_of_unity, compute_two_adicity,
-    detect_small_prime_subgroup, generate_montgomery_bigint_casts, generate_sqrt_precomputation,
-    mod_mul_const,
+    generate_montgomery_bigint_casts, generate_sqrt_precomputation, mod_mul_const,
 };
+use crate::utils::detect_small_prime_subgroup;
 
 pub(crate) fn backend_impl(
     ty: &proc_macro2::TokenStream,
@@ -57,7 +57,8 @@ pub(crate) fn backend_impl(
 
     let neg_one_mont = mod_mul_const(modulus - 1, r_mod_n, modulus);
 
-    let mixed_radix_impl = if let Some((base, power)) = detect_small_prime_subgroup(modulus, two_adicity)
+    let modulus_big = num_bigint::BigUint::from(modulus);
+    let mixed_radix_impl = if let Some((base, power)) = detect_small_prime_subgroup(&modulus_big)
     {
         let large_root = compute_large_subgroup_root(modulus, generator, two_adicity, base, power);
         let large_root_mont = mod_mul_const(large_root, r_mod_n, modulus);

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -498,28 +498,82 @@ pub(crate) fn exit_impl(modulus: u128, r_mod_p: u128) -> proc_macro2::TokenStrea
             <Self as SmallFpConfig>::mul_assign(a, &one);
         }
 
-        // This is the `SmallFp` analogue of [`MontFp!`] to support const initialization
+        /// Const-compatible Montgomery modular multiplication using u128 arithmetic.
+        /// Computes `a * b mod MODULUS` at compile time via double-and-add.
+        const fn const_mod_mul(a: u128, b: u128, modulus: u128) -> u128 {
+            // If the product fits in u128, just use the remainder operator.
+            // Otherwise fall back to double-and-add.
+            match a.overflowing_mul(b) {
+                (val, false) => val % modulus,
+                (_, true) => {
+                    let mut result = 0u128;
+                    let mut base = a % modulus;
+                    let mut exp = b;
+                    while exp > 0 {
+                        if exp & 1 == 1 {
+                            // result = (result + base) mod modulus
+                            result = if result >= modulus - base {
+                                result - (modulus - base)
+                            } else {
+                                result + base
+                            };
+                        }
+                        // base = (base + base) mod modulus
+                        base = if base >= modulus - base {
+                            base - (modulus - base)
+                        } else {
+                            base + base
+                        };
+                        exp >>= 1;
+                    }
+                    result
+                }
+            }
+        }
+
+        /// Construct a [`SmallFp<Self>`] field element from a sign and a slice of u64 limbs.
+        ///
+        /// This is the `SmallFp` analogue of [`Fp::from_sign_and_limbs`] and is usable
+        /// in `const` contexts. The limbs are interpreted as a little-endian
+        /// integer which is then reduced modulo `MODULUS` and converted to
+        /// Montgomery form.
+        pub const fn from_sign_and_limbs(is_positive: bool, limbs: &[u64]) -> SmallFp<Self> {
+            const MODULUS: u128 = #modulus;
+            const R_MOD_P: u128 = #r_mod_p;
+
+            // Build u128 from limbs (little-endian)
+            let mut val: u128 = 0;
+            let mut i = 0;
+            while i < limbs.len() && i < 2 {
+                val |= (limbs[i] as u128) << (64 * i);
+                i += 1;
+            }
+
+            // Reduce mod P
+            val %= MODULUS;
+
+            // Enter Montgomery form: val_mont = val * R mod P  (via const mul)
+            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
+
+            // Handle sign
+            let mont = if is_positive {
+                mont
+            } else if mont == 0 {
+                0
+            } else {
+                MODULUS - mont
+            };
+
+            SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
+        }
+
+        /// Construct a [`SmallFp<Self>`] from a `u128` value in a const context.
         pub const fn from_u128(value: u128) -> SmallFp<Self> {
             const MODULUS: u128 = #modulus;
             const R_MOD_P: u128 = #r_mod_p;
 
-            // const-compatible modular multiplication via double-and-add
-            // Safe from overflow: modulus < 2^127 so a,result < 2^127 and all additions fit u128
-            const fn mod_mul(mut a: u128, mut b: u128, m: u128) -> u128 {
-                a %= m;
-                let mut result = 0u128;
-                while b > 0 {
-                    if b & 1 == 1 {
-                        result = (result + a) % m;
-                    }
-                    a = (a + a) % m;
-                    b >>= 1;
-                }
-                result
-            }
-
             let val = value % MODULUS;
-            let mont = mod_mul(val, R_MOD_P, MODULUS);
+            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
             SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
         }
     }

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -514,73 +514,28 @@ pub(crate) fn exit_impl(modulus: u128, r_mod_p: u128) -> proc_macro2::TokenStrea
             <Self as SmallFpConfig>::mul_assign(a, &one);
         }
 
-        /// Const-compatible Montgomery modular multiplication using u128 arithmetic.
-        const fn const_mod_mul(a: u128, b: u128, modulus: u128) -> u128 {
-            match a.overflowing_mul(b) {
-                (val, false) => val % modulus,
-                (_, true) => {
-                    let mut result = 0u128;
-                    let mut base = a % modulus;
-                    let mut exp = b;
-                    while exp > 0 {
-                        if exp & 1 == 1 {
-                            result = if result >= modulus - base {
-                                result - (modulus - base)
-                            } else {
-                                result + base
-                            };
-                        }
-                        base = if base >= modulus - base {
-                            base - (modulus - base)
-                        } else {
-                            base + base
-                        };
-                        exp >>= 1;
-                    }
-                    result
-                }
-            }
-        }
-
-        /// Construct a [`SmallFp<Self>`] field element from a sign and a slice of u64 limbs.
-        ///
-        /// This is the `SmallFp` analogue of [`Fp::from_sign_and_limbs`] and is usable
-        /// in `const` contexts. The limbs are interpreted as a little-endian
-        /// integer which is then reduced modulo `MODULUS` and converted to
-        /// Montgomery form.
-        pub const fn from_sign_and_limbs(is_positive: bool, limbs: &[u64]) -> SmallFp<Self> {
-            const MODULUS: u128 = #modulus;
-            const R_MOD_P: u128 = #r_mod_p;
-
-            // Build u128 from limbs (little-endian)
-            let mut val: u128 = 0;
-            let mut i = 0;
-            while i < limbs.len() && i < 2 {
-                val |= (limbs[i] as u128) << (64 * i);
-                i += 1;
-            }
-
-            val %= MODULUS;
-            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
-
-            let mont = if is_positive {
-                mont
-            } else if mont == 0 {
-                0
-            } else {
-                MODULUS - mont
-            };
-
-            SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
-        }
-
-        /// Construct a [`SmallFp<Self>`] from a `u128` value in a const context.
+        // This is the `SmallFp` analogue of [`MontFp!`] to support const initialization
         pub const fn from_u128(value: u128) -> SmallFp<Self> {
             const MODULUS: u128 = #modulus;
             const R_MOD_P: u128 = #r_mod_p;
 
+            // const-compatible modular multiplication via double-and-add
+            // Safe from overflow: modulus < 2^127 so a,result < 2^127 and all additions fit u128
+            const fn mod_mul(mut a: u128, mut b: u128, m: u128) -> u128 {
+                a %= m;
+                let mut result = 0u128;
+                while b > 0 {
+                    if b & 1 == 1 {
+                        result = (result + a) % m;
+                    }
+                    a = (a + a) % m;
+                    b >>= 1;
+                }
+                result
+            }
+
             let val = value % MODULUS;
-            let mont = Self::const_mod_mul(val, R_MOD_P, MODULUS);
+            let mont = mod_mul(val, R_MOD_P, MODULUS);
             SmallFp::from_raw(mont as <Self as SmallFpConfig>::T)
         }
     }

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::small_fp::utils::{
-    compute_two_adic_root_of_unity, compute_two_adicity, generate_montgomery_bigint_casts,
-    generate_sqrt_precomputation, mod_mul_const,
+    compute_large_subgroup_root, compute_two_adic_root_of_unity, compute_two_adicity,
+    detect_small_subgroup, generate_montgomery_bigint_casts, generate_sqrt_precomputation,
+    mod_mul_const,
 };
 
 pub(crate) fn backend_impl(
@@ -56,6 +57,19 @@ pub(crate) fn backend_impl(
 
     let neg_one_mont = mod_mul_const(modulus - 1, r_mod_n, modulus);
 
+    let mixed_radix_impl = if let Some((base, power)) = detect_small_subgroup(modulus, two_adicity)
+    {
+        let large_root = compute_large_subgroup_root(modulus, generator, two_adicity, base, power);
+        let large_root_mont = mod_mul_const(large_root, r_mod_n, modulus);
+        quote! {
+            const SMALL_SUBGROUP_BASE: Option<u32> = Some(#base);
+            const SMALL_SUBGROUP_BASE_ADICITY: Option<u32> = Some(#power);
+            const LARGE_SUBGROUP_ROOT_OF_UNITY: Option<SmallFp<Self>> = Some(SmallFp::from_raw(#large_root_mont as Self::T));
+        }
+    } else {
+        quote! {}
+    };
+
     let (from_bigint_impl, into_bigint_impl) = generate_montgomery_bigint_casts();
     let sqrt_precomp_impl = generate_sqrt_precomputation(modulus, two_adicity, Some(r_mod_n));
     let r2 = mod_mul_const(r_mod_n, r_mod_n, modulus);
@@ -109,6 +123,8 @@ pub(crate) fn backend_impl(
 
         const TWO_ADICITY: u32 = #two_adicity;
         const TWO_ADIC_ROOT_OF_UNITY: SmallFp<Self> = SmallFp::from_raw(#two_adic_root_mont as Self::T);
+
+        #mixed_radix_impl
 
         #sqrt_precomp_impl
 

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::small_fp::utils::{
     compute_large_subgroup_root, compute_two_adic_root_of_unity, compute_two_adicity,
-    detect_small_subgroup, generate_montgomery_bigint_casts, generate_sqrt_precomputation,
+    detect_small_prime_subgroup, generate_montgomery_bigint_casts, generate_sqrt_precomputation,
     mod_mul_const,
 };
 
@@ -57,7 +57,7 @@ pub(crate) fn backend_impl(
 
     let neg_one_mont = mod_mul_const(modulus - 1, r_mod_n, modulus);
 
-    let mixed_radix_impl = if let Some((base, power)) = detect_small_subgroup(modulus, two_adicity)
+    let mixed_radix_impl = if let Some((base, power)) = detect_small_prime_subgroup(modulus, two_adicity)
     {
         let large_root = compute_large_subgroup_root(modulus, generator, two_adicity, base, power);
         let large_root_mont = mod_mul_const(large_root, r_mod_n, modulus);

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -58,7 +58,8 @@ pub(crate) fn backend_impl(
     let neg_one_mont = mod_mul_const(modulus - 1, r_mod_n, modulus);
 
     let modulus_big = num_bigint::BigUint::from(modulus);
-    let mixed_radix_impl = if let Some((base, power)) = find_conservative_subgroup_base(&modulus_big)
+    let mixed_radix_impl = if let Some((base, power)) =
+        find_conservative_subgroup_base(&modulus_big)
     {
         let large_root = compute_large_subgroup_root(modulus, generator, two_adicity, base, power);
         let large_root_mont = mod_mul_const(large_root, r_mod_n, modulus);

--- a/ff-macros/src/small_fp/utils.rs
+++ b/ff-macros/src/small_fp/utils.rs
@@ -79,25 +79,27 @@ pub(crate) const fn find_quadratic_non_residue(modulus: u128) -> u128 {
     }
 }
 
-/// Auto-detect small subgroup parameters from the modulus.
-/// Checks if a small prime base (currently 3) divides the odd part of p-1.
-/// Returns `(base, adicity)` if found.
-pub(crate) fn detect_small_subgroup(modulus: u128, two_adicity: u32) -> Option<(u32, u32)> {
-    let mut trace = (modulus - 1) >> two_adicity; // odd part of p-1
+/// Detect a small prime subgroup of the multiplicative group.
+///
+/// Checks whether any small prime base in {3, 5, 7} divides the odd part of
+/// p-1 at least once. Returns the smallest such `(base, adicity)` if found,
+/// or `None` if the odd part has no factors ≤ 7.
+pub(crate) fn detect_small_prime_subgroup(modulus: u128, two_adicity: u32) -> Option<(u32, u32)> {
+    let trace = (modulus - 1) >> two_adicity; // odd part of p-1
 
-    // Check base 3
-    let base: u128 = 3;
-    let mut adicity = 0u32;
-    while trace % base == 0 {
-        trace /= base;
-        adicity += 1;
+    for base in [3u128, 5, 7] {
+        let mut t = trace;
+        let mut adicity = 0u32;
+        while t % base == 0 {
+            t /= base;
+            adicity += 1;
+        }
+        if adicity > 0 {
+            return Some((base as u32, adicity));
+        }
     }
 
-    if adicity > 0 {
-        Some((base as u32, adicity))
-    } else {
-        None
-    }
+    None
 }
 
 /// Compute the large subgroup root of unity:

--- a/ff-macros/src/small_fp/utils.rs
+++ b/ff-macros/src/small_fp/utils.rs
@@ -79,29 +79,6 @@ pub(crate) const fn find_quadratic_non_residue(modulus: u128) -> u128 {
     }
 }
 
-/// Detect a small prime subgroup of the multiplicative group.
-///
-/// Checks whether any small prime base in {3, 5, 7} divides the odd part of
-/// p-1 at least once. Returns the smallest such `(base, adicity)` if found,
-/// or `None` if the odd part has no factors ≤ 7.
-pub(crate) fn detect_small_prime_subgroup(modulus: u128, two_adicity: u32) -> Option<(u32, u32)> {
-    let trace = (modulus - 1) >> two_adicity; // odd part of p-1
-
-    for base in [3u128, 5, 7] {
-        let mut t = trace;
-        let mut adicity = 0u32;
-        while t % base == 0 {
-            t /= base;
-            adicity += 1;
-        }
-        if adicity > 0 {
-            return Some((base as u32, adicity));
-        }
-    }
-
-    None
-}
-
 /// Compute the large subgroup root of unity:
 /// generator^((p-1) / (2^two_adicity * base^power))
 pub(crate) fn compute_large_subgroup_root(

--- a/ff-macros/src/small_fp/utils.rs
+++ b/ff-macros/src/small_fp/utils.rs
@@ -79,6 +79,43 @@ pub(crate) const fn find_quadratic_non_residue(modulus: u128) -> u128 {
     }
 }
 
+/// Auto-detect small subgroup parameters from the modulus.
+/// Checks if a small prime base (currently 3) divides the odd part of p-1.
+/// Returns `(base, adicity)` if found.
+pub(crate) fn detect_small_subgroup(modulus: u128, two_adicity: u32) -> Option<(u32, u32)> {
+    let mut trace = (modulus - 1) >> two_adicity; // odd part of p-1
+
+    // Check base 3
+    let base: u128 = 3;
+    let mut adicity = 0u32;
+    while trace % base == 0 {
+        trace /= base;
+        adicity += 1;
+    }
+
+    if adicity > 0 {
+        Some((base as u32, adicity))
+    } else {
+        None
+    }
+}
+
+/// Compute the large subgroup root of unity:
+/// generator^((p-1) / (2^two_adicity * base^power))
+pub(crate) fn compute_large_subgroup_root(
+    modulus: u128,
+    generator: u128,
+    two_adicity: u32,
+    base: u32,
+    power: u32,
+) -> u128 {
+    let mut remaining = (modulus - 1) >> two_adicity;
+    for _ in 0..power {
+        remaining /= base as u128;
+    }
+    pow_mod_const(generator, remaining, modulus)
+}
+
 pub(crate) fn generate_montgomery_bigint_casts(
 ) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
     (

--- a/ff-macros/src/utils.rs
+++ b/ff-macros/src/utils.rs
@@ -87,13 +87,13 @@ pub(crate) fn fp_alias_for_limbs(limbs: usize) -> TokenStream2 {
 }
 
 pub(crate) fn parse_string(input: TokenStream) -> Option<String> {
-    let input: Expr = syn::parse(input).unwrap();
-    let input = if let Expr::Group(syn::ExprGroup { expr, .. }) = input {
-        expr
-    } else {
-        panic!("could not parse");
-    };
-    match *input {
+    let mut input: Expr = syn::parse(input).unwrap();
+    // Unwrap invisible group delimiters that the compiler may (or may not)
+    // insert around tokens forwarded from other proc macros.
+    if let Expr::Group(syn::ExprGroup { expr, .. }) = input {
+        input = *expr;
+    }
+    match input {
         Expr::Lit(expr_lit) => match expr_lit.lit {
             Lit::Str(s) => Some(s.value()),
             _ => None,

--- a/ff-macros/src/utils.rs
+++ b/ff-macros/src/utils.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use num_bigint::{BigInt, Sign};
-use num_traits::Num;
+use num_bigint::{BigInt, BigUint, Sign};
+use num_traits::{Num, Zero};
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use syn::parse::{Parse, ParseStream};
@@ -100,6 +100,33 @@ pub(crate) fn parse_string(input: TokenStream) -> Option<String> {
         },
         _ => None,
     }
+}
+
+/// Detect a small prime subgroup of the multiplicative group.
+///
+/// Checks whether any small prime base in {3, 5, 7} divides the odd part of
+/// p-1 at least once. Returns the smallest such `(base, adicity)` if found,
+/// or `None` if the odd part has no factors ≤ 7.
+pub(crate) fn detect_small_prime_subgroup(modulus: &BigUint) -> Option<(u32, u32)> {
+    let mut trace = modulus - BigUint::from(1u32);
+    while trace.bit(0) == false {
+        trace >>= 1u32;
+    }
+
+    for b in [3u32, 5, 7] {
+        let base = BigUint::from(b);
+        let mut t = trace.clone();
+        let mut adicity = 0u32;
+        while (&t % &base).is_zero() {
+            t /= &base;
+            adicity += 1;
+        }
+        if adicity > 0 {
+            return Some((b, adicity));
+        }
+    }
+
+    None
 }
 
 pub(crate) fn str_to_limbs(num: &str) -> (bool, Vec<String>) {

--- a/ff-macros/src/utils.rs
+++ b/ff-macros/src/utils.rs
@@ -107,7 +107,7 @@ pub(crate) fn parse_string(input: TokenStream) -> Option<String> {
 /// Checks whether any small prime base in {3, 5, 7} divides the odd part of
 /// p-1 at least once. Returns the smallest such `(base, adicity)` if found,
 /// or `None` if the odd part has no factors ≤ 7.
-pub(crate) fn detect_small_prime_subgroup(modulus: &BigUint) -> Option<(u32, u32)> {
+pub(crate) fn find_conservative_subgroup_base(modulus: &BigUint) -> Option<(u32, u32)> {
     let mut trace = modulus - BigUint::from(1u32);
     while trace.bit(0) == false {
         trace >>= 1u32;

--- a/test-curves/src/smallfp.rs
+++ b/test-curves/src/smallfp.rs
@@ -46,7 +46,7 @@ mod tests {
 
     mod const_constructors {
         use super::*;
-        use ark_ff::{One, Zero};
+        use ark_ff::{One, PrimeField, Zero};
 
         #[test]
         fn test_from_u128_zero() {
@@ -114,12 +114,45 @@ mod tests {
         }
 
         #[test]
+        fn test_from_sign_and_limbs_positive() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(true, &[7]);
+            let expected: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
+            assert_eq!(a, expected);
+        }
+
+        #[test]
+        fn test_from_sign_and_limbs_negative() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
+            let one: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(1);
+            assert_eq!(a, -one, "from_sign_and_limbs(false, [1]) should be -1");
+        }
+
+        #[test]
+        fn test_from_sign_and_limbs_negative_zero() {
+            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[0]);
+            assert!(a.is_zero(), "-0 should be 0");
+        }
+
+        #[test]
+        fn test_from_sign_and_limbs_two_limbs() {
+            let val: u128 = (1u128 << 64) + 42;
+            let lo = val as u64;
+            let hi = (val >> 64) as u64;
+            let const_elem: SmallFp128 = SmallFp128Config::from_sign_and_limbs(true, &[lo, hi]);
+            let runtime_elem = SmallFp128::from(val);
+            assert_eq!(const_elem, runtime_elem, "two-limb from_sign_and_limbs mismatch");
+        }
+
+        #[test]
         fn test_const_context() {
             const SEVEN: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
             const FORTY_TWO: SmallFp128 = SmallFp128Config::from_u128(42);
+            const NEG_ONE: SmallFp64Goldilock =
+                SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
 
             assert_eq!(SEVEN, SmallFp64Goldilock::from(7u128));
             assert_eq!(FORTY_TWO, SmallFp128::from(42u128));
+            assert_eq!(NEG_ONE, -SmallFp64Goldilock::from(1u128));
         }
     }
 }

--- a/test-curves/src/smallfp.rs
+++ b/test-curves/src/smallfp.rs
@@ -46,7 +46,7 @@ mod tests {
 
     mod const_constructors {
         use super::*;
-        use ark_ff::{One, PrimeField, Zero};
+        use ark_ff::{One, Zero};
 
         #[test]
         fn test_from_u128_zero() {
@@ -114,45 +114,12 @@ mod tests {
         }
 
         #[test]
-        fn test_from_sign_and_limbs_positive() {
-            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(true, &[7]);
-            let expected: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
-            assert_eq!(a, expected);
-        }
-
-        #[test]
-        fn test_from_sign_and_limbs_negative() {
-            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
-            let one: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(1);
-            assert_eq!(a, -one, "from_sign_and_limbs(false, [1]) should be -1");
-        }
-
-        #[test]
-        fn test_from_sign_and_limbs_negative_zero() {
-            let a: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[0]);
-            assert!(a.is_zero(), "-0 should be 0");
-        }
-
-        #[test]
-        fn test_from_sign_and_limbs_two_limbs() {
-            let val: u128 = (1u128 << 64) + 42;
-            let lo = val as u64;
-            let hi = (val >> 64) as u64;
-            let const_elem: SmallFp128 = SmallFp128Config::from_sign_and_limbs(true, &[lo, hi]);
-            let runtime_elem = SmallFp128::from(val);
-            assert_eq!(const_elem, runtime_elem, "two-limb from_sign_and_limbs mismatch");
-        }
-
-        #[test]
         fn test_const_context() {
             const SEVEN: SmallFp64Goldilock = SmallFp64GoldilockConfig::from_u128(7);
             const FORTY_TWO: SmallFp128 = SmallFp128Config::from_u128(42);
-            const NEG_ONE: SmallFp64Goldilock =
-                SmallFp64GoldilockConfig::from_sign_and_limbs(false, &[1]);
 
             assert_eq!(SEVEN, SmallFp64Goldilock::from(7u128));
             assert_eq!(FORTY_TWO, SmallFp128::from(42u128));
-            assert_eq!(NEG_ONE, -SmallFp64Goldilock::from(1u128));
         }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

When using the define_field! macro, we were setting FFT params to None irrespective of when nice params do exist. This PR searches for nice seeming params at compile time and sets them None otherwise.

I think this is cool because define_macro! is supposed to be a little bit hand holding for the user.

The traditional macros for both Fp and SmallFp are untouched the user can customize there however they want.

closes: #1087

---

- [ x] Targeted PR against correct branch (master)
- [x ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ x] Re-reviewed `Files changed` in the GitHub PR explorer
