### PR TITLE
Release 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,8 +145,8 @@ ark-serialize = { version = "0.6.0", path = "./serialize", default-features = fa
 ark-serialize-derive = { version = "0.6.0", path = "./serialize-derive" }
 ark-std = { version = "0.6.0", default-features = false }
 
-ark-algebra-bench-templates = { version = "0.6.0", path = "./bench-templates", default-features = false }
-ark-algebra-test-templates = { version = "0.6.0", path = "./test-templates", default-features = false }
+ark-algebra-bench-templates = { path = "./bench-templates", default-features = false }
+ark-algebra-test-templates = { path = "./test-templates", default-features = false }
 ark-test-curves = { path = "./test-curves", default-features = false }
 
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["curves/**"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["arkworks contributors"]
 homepage = "https://arkworks.rs"
 repository = "https://github.com/arkworks-rs/algebra"
@@ -136,18 +136,18 @@ significant_drop_tightening = "allow"
 too_long_first_doc_paragraph = "allow"
 
 [workspace.dependencies]
-ark-ec = { version = "0.5.0", path = "./ec", default-features = false }
-ark-ff = { version = "0.5.0", path = "./ff", default-features = false }
-ark-ff-asm = { version = "0.5.0", path = "./ff-asm" }
-ark-ff-macros = { version = "0.5.0", path = "./ff-macros" }
-ark-poly = { version = "0.5.0", path = "./poly", default-features = false }
-ark-serialize = { version = "0.5.0", path = "./serialize", default-features = false }
-ark-serialize-derive = { version = "0.5.0", path = "./serialize-derive" }
-ark-std = { version = "0.5.0", default-features = false }
+ark-ec = { version = "0.6.0", path = "./ec", default-features = false }
+ark-ff = { version = "0.6.0", path = "./ff", default-features = false }
+ark-ff-asm = { version = "0.6.0", path = "./ff-asm" }
+ark-ff-macros = { version = "0.6.0", path = "./ff-macros" }
+ark-poly = { version = "0.6.0", path = "./poly", default-features = false }
+ark-serialize = { version = "0.6.0", path = "./serialize", default-features = false }
+ark-serialize-derive = { version = "0.6.0", path = "./serialize-derive" }
+ark-std = { version = "0.6.0", default-features = false }
 
-ark-algebra-bench-templates = { version = "0.5.0", path = "./bench-templates", default-features = false }
-ark-algebra-test-templates = { version = "0.5.0", path = "./test-templates", default-features = false }
-ark-test-curves = { version = "0.5.0", path = "./test-curves", default-features = false }
+ark-algebra-bench-templates = { version = "0.6.0", path = "./bench-templates", default-features = false }
+ark-algebra-test-templates = { version = "0.6.0", path = "./test-templates", default-features = false }
+ark-test-curves = { version = "0.6.0", path = "./test-curves", default-features = false }
 
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ ark-std = { version = "0.6.0", default-features = false }
 
 ark-algebra-bench-templates = { version = "0.6.0", path = "./bench-templates", default-features = false }
 ark-algebra-test-templates = { version = "0.6.0", path = "./test-templates", default-features = false }
-ark-test-curves = { version = "0.6.0", path = "./test-curves", default-features = false }
+ark-test-curves = { path = "./test-curves", default-features = false }
 
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = [ "arkworks contributors" ]
 homepage = "https://arkworks.rs"
 repository = "https://github.com/arkworks-rs/algebra"
@@ -59,29 +59,29 @@ edition = "2021"
 rust-version = "1.75"
 
 [workspace.dependencies]
-ark-ec = { version = "0.5.0", path = "../ec", default-features = false }
-ark-ff = { version = "0.5.0", path = "../ff", default-features = false }
-ark-ff-asm = { version = "0.5.0", path = "../ff-asm" }
-ark-poly = { version = "0.5.0", path = "../poly", default-features = false }
-ark-serialize = { version = "0.5.0", path = "../serialize", default-features = false }
-ark-algebra-test-templates = { version = "0.5.0", path = "../test-templates", default-features = false }
-ark-algebra-bench-templates =  { version = "0.5.0", path = "../bench-templates", default-features = false }
+ark-ec = { version = "0.6.0", path = "../ec", default-features = false }
+ark-ff = { version = "0.6.0", path = "../ff", default-features = false }
+ark-ff-asm = { version = "0.6.0", path = "../ff-asm" }
+ark-poly = { version = "0.6.0", path = "../poly", default-features = false }
+ark-serialize = { version = "0.6.0", path = "../serialize", default-features = false }
+ark-algebra-test-templates = { version = "0.6.0", path = "../test-templates", default-features = false }
+ark-algebra-bench-templates =  { version = "0.6.0", path = "../bench-templates", default-features = false }
 
-ark-bls12-377 = { version = "0.5.0", path = "./bls12_377", default-features = false }
-ark-bls12-381 = { version = "0.5.0", path = "./bls12_381", default-features = false }
-ark-ed-on-cp6-782 = { version = "0.5.0", path = "./ed_on_cp6_782", default-features = false }
-ark-bn254 = { version = "0.5.0", path = "./bn254", default-features = false }
-ark-mnt4-298 = { version = "0.5.0", path = "./mnt4_298", default-features = false }
-ark-mnt4-753 = { version = "0.5.0", path = "./mnt4_753", default-features = false }
-ark-pallas = { version = "0.5.0", path = "./pallas", default-features = false }
-ark-secp256k1 = { version = "0.5.0", path = "./secp256k1" }
-ark-curve25519 = { version = "0.5.0", path = "./curve25519" }
+ark-bls12-377 = { version = "0.6.0", path = "./bls12_377", default-features = false }
+ark-bls12-381 = { version = "0.6.0", path = "./bls12_381", default-features = false }
+ark-ed-on-cp6-782 = { version = "0.6.0", path = "./ed_on_cp6_782", default-features = false }
+ark-bn254 = { version = "0.6.0", path = "./bn254", default-features = false }
+ark-mnt4-298 = { version = "0.6.0", path = "./mnt4_298", default-features = false }
+ark-mnt4-753 = { version = "0.6.0", path = "./mnt4_753", default-features = false }
+ark-pallas = { version = "0.6.0", path = "./pallas", default-features = false }
+ark-secp256k1 = { version = "0.6.0", path = "./secp256k1" }
+ark-curve25519 = { version = "0.6.0", path = "./curve25519" }
 
-ark-curve-constraint-tests = { version = "0.5.0", path = "./curve-constraint-tests" }
+ark-curve-constraint-tests = { version = "0.6.0", path = "./curve-constraint-tests" }
 
-ark-std = { version = "0.5.0", default-features = false }
-ark-r1cs-std = { version = "0.5.0", default-features = false }
-ark-relations = {version = "0.5.0", default-features = false }
+ark-std = { version = "0.6.0", default-features = false }
+ark-r1cs-std = { version = "0.6.0", default-features = false }
+ark-relations = {version = "0.6.0", default-features = false }
 
 [profile.release]
 opt-level = 3

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -33,7 +33,7 @@ ahash = { version = "0.8", default-features = false }
 fnv = { version = "1.0", default-features = false }
 
 [dev-dependencies]
-ark-test-curves = { path = "../test-curves", features = ["bls12_381_curve", "bn384_small_two_adicity_curve", "mnt4_753_curve"], version = "*" }
+ark-test-curves = { path = "../test-curves", features = ["bls12_381_curve", "bn384_small_two_adicity_curve", "mnt4_753_curve"] }
 criterion = { workspace = true }
 
 


### PR DESCRIPTION
## Release v0.6.0

Breaking bump across the arkworks stack — first release since 0.5.0 (2024-10-28).
104 commits of fixes, performance work, new APIs, and one trait-surface change that forces the major-version cut.

## Changes since v0.5.0

**New features**
- SmallFp: dedicated small-prime field implementation (#1044, #1082, #1084, #1088, #1091)
- Stark curve + tests for large 2-adicity fields (#1001)
- Double-odd curve support in `ec` (#986)
- O(n log n) polynomial division (#1010)
- Serde-compatible adapters (#967)
- `CanonicalSerialize`/`Deserialize` for `HashMap`/`HashSet` (#999) and signed integers (#953)
- `MINUS_ONE` const on `Field` / `FpConfig` (#1004)
- Expose `GENERATOR` on `AffineRepr` (#1045)
- `serial_batch_inversion_and_mul` made public (#971)
- `Cargo.toml` `asm` feature (#928)
- `define_field` macro now sets plausible FFT params (#1086)
- Conditional `infinity` flag on `short_weierstrass::Affine` (#639)

**Breaking trait-surface changes** (the reason this is 0.6.0)
- `AffineRepr: Neg<Output = Self>` tightened (#927)
- New required const `MINUS_ONE` on `Field`/`FpConfig` (#1004)
- R1CS → GR1CS migration (#949)

**Performance**
- Fix GLV scalar-multiplication perf bug (#1025)
- `VariableBaseMSM` improvements for small scalars (#995, #996)
- Extended Jacobian coordinates for SW MSM (#961)
- Generalized Mersenne mul path (#1091)

**Bug fixes**
- `ToConstraintField` bound for `Affine` (#1005)
- `to_dense_multilinear_extension` for nv > 30 (#1022)
- `to_evaluations` for sparse multilinear extension (#1019)
- Multilinear extension `rand` (#998)
- Support 5 mod 8 case in `SqrtPrecomputation` (#968)
- `from_random_bytes` consistency between `SmallFp` and `Fp` (#1082)
- Build of `ark-ff` (#1028)

**Refactors / housekeeping**
- Polynomial refactors across `DensePolynomial`, `SparsePolynomial`, `GeneralEvaluationDomain`
- `find_naf`, biginteger, cubic-extension simplifications in `ff`
- Clippy rule rollout across all member crates
- Dep bumps: hashbrown 0.15 → 0.17, criterion 0.6 → 0.8, itertools 0.13 → 0.14
- Removed soft dependencies (#1027)

Full list: `git log v0.5.0..v0.6.0`.

## Release position

Step 2 of the 0.6.0 cascade: std → **algebra** → snark → r1cs-std → crypto-primitives → poly-commit → groth16 → circom-compat.

## Verification
- [x] `cargo test --workspace --all-features` green
- [x] `cargo publish --workspace --dry-run` clean (root + `curves/`)
- [x] CI green on master
