### PR TITLE
fix(poly): honor coset vanishing polynomial in dense multiply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 ### Bugfixes
 
 - [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
+- [\#1106](https://github.com/arkworks-rs/algebra/pull/1106) (`ark-poly`) Make `DensePolynomial::mul_by_vanishing_poly` honor coset-domain offsets.
 
 ## v0.5.0
 

--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -155,22 +155,10 @@ impl<F: FftField> DensePolynomial<F> {
     /// Multiply `self` by the vanishing polynomial for the domain `domain`.
     /// Returns the result of the multiplication.
     pub fn mul_by_vanishing_poly<D: EvaluationDomain<F>>(&self, domain: D) -> Self {
-        if self.is_zero() {
-            return Self::zero();
-        }
-
-        let domain_size = domain.size();
-        let mut shifted = Vec::with_capacity(domain_size + self.coeffs.len());
-        shifted.resize(domain_size, F::zero());
+        let mut shifted = vec![F::zero(); domain.size()];
         shifted.extend_from_slice(&self.coeffs);
 
-        // The domain vanishing polynomial is x^n - k for
-        // k = domain.coset_offset_pow_size(). At this point `shifted` already
-        // contains x^n * self: `domain_size` leading zero coefficients followed
-        // by the coefficients of `self`. Finishing the multiplication therefore
-        // only requires subtracting k * self from the low coefficients. This
-        // keeps the helper as a specialized binomial multiply rather than
-        // falling back to general polynomial multiplication.
+        // Coset domains vanish on x^n - offset^n, not x^n - 1.
         let offset_pow_size = domain.coset_offset_pow_size();
         if offset_pow_size == F::ONE {
             cfg_iter_mut!(shifted)

--- a/poly/src/polynomial/univariate/dense.rs
+++ b/poly/src/polynomial/univariate/dense.rs
@@ -155,11 +155,32 @@ impl<F: FftField> DensePolynomial<F> {
     /// Multiply `self` by the vanishing polynomial for the domain `domain`.
     /// Returns the result of the multiplication.
     pub fn mul_by_vanishing_poly<D: EvaluationDomain<F>>(&self, domain: D) -> Self {
-        let mut shifted = vec![F::zero(); domain.size()];
+        if self.is_zero() {
+            return Self::zero();
+        }
+
+        let domain_size = domain.size();
+        let mut shifted = Vec::with_capacity(domain_size + self.coeffs.len());
+        shifted.resize(domain_size, F::zero());
         shifted.extend_from_slice(&self.coeffs);
-        cfg_iter_mut!(shifted)
-            .zip(&self.coeffs)
-            .for_each(|(s, c)| *s -= c);
+
+        // The domain vanishing polynomial is x^n - k for
+        // k = domain.coset_offset_pow_size(). At this point `shifted` already
+        // contains x^n * self: `domain_size` leading zero coefficients followed
+        // by the coefficients of `self`. Finishing the multiplication therefore
+        // only requires subtracting k * self from the low coefficients. This
+        // keeps the helper as a specialized binomial multiply rather than
+        // falling back to general polynomial multiplication.
+        let offset_pow_size = domain.coset_offset_pow_size();
+        if offset_pow_size == F::ONE {
+            cfg_iter_mut!(shifted)
+                .zip(&self.coeffs)
+                .for_each(|(s, c)| *s -= c);
+        } else {
+            cfg_iter_mut!(shifted).zip(&self.coeffs).for_each(|(s, c)| {
+                *s -= *c * offset_pow_size;
+            });
+        }
         Self::from_coefficients_vec(shifted)
     }
 
@@ -708,7 +729,7 @@ impl_op!(Div, div, FftField);
 mod tests {
     use crate::{polynomial::univariate::*, GeneralEvaluationDomain};
     use ark_ff::{Fp64, MontBackend, MontConfig};
-    use ark_ff::{One, UniformRand};
+    use ark_ff::{One, UniformRand, Zero};
     use ark_std::{rand::Rng, test_rng};
     use ark_test_curves::bls12_381::Fr;
 
@@ -965,13 +986,45 @@ mod tests {
         let rng = &mut test_rng();
         for size in 1..10 {
             let domain = GeneralEvaluationDomain::new(1 << size).unwrap();
-            for degree in 0..70 {
-                let p = DensePolynomial::<Fr>::rand(degree, rng);
-                let ans1 = p.mul_by_vanishing_poly(domain);
-                let ans2 = &p * &domain.vanishing_polynomial().into();
-                assert_eq!(ans1, ans2);
+            let coset = domain.get_coset(Fr::from(5u64)).unwrap();
+            for domain in [domain, coset] {
+                for degree in 0..70 {
+                    let p = DensePolynomial::<Fr>::rand(degree, rng);
+                    let ans1 = p.mul_by_vanishing_poly(domain);
+                    let ans2 = &p * &domain.vanishing_polynomial().into();
+                    assert_eq!(ans1, ans2);
+                }
             }
         }
+    }
+
+    #[test]
+    fn mul_by_vanishing_poly_uses_coset_offset() {
+        let domain = GeneralEvaluationDomain::<Fr>::new(8).unwrap();
+        let coset = domain.get_coset(Fr::from(5u64)).unwrap();
+        let offset_pow_size = coset.coset_offset_pow_size();
+        assert_ne!(offset_pow_size, Fr::one());
+
+        let a = Fr::from(3u64);
+        let b = Fr::from(7u64);
+        let p = DensePolynomial::from_coefficients_vec(vec![a, b]);
+
+        let actual = p.mul_by_vanishing_poly(coset);
+
+        // For p(x) = a + bx, multiplying by the coset vanishing polynomial
+        // x^8 - offset^8 gives low coefficients -offset^8 * [a, b] and high
+        // coefficients [a, b]. This avoids using polynomial multiplication as
+        // the oracle for this regression.
+        let mut expected_coeffs = vec![Fr::zero(); coset.size() + p.coeffs.len()];
+        expected_coeffs[0] = -(offset_pow_size * a);
+        expected_coeffs[1] = -(offset_pow_size * b);
+        expected_coeffs[coset.size()] = a;
+        expected_coeffs[coset.size() + 1] = b;
+        assert_ne!(expected_coeffs[0], -a);
+        assert_ne!(expected_coeffs[1], -b);
+        let expected = DensePolynomial::from_coefficients_vec(expected_coeffs);
+
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1105.

`DensePolynomial::mul_by_vanishing_poly` currently behaves as if every domain has vanishing polynomial `x^n - 1`. That is correct for ordinary subgroup domains, but not for coset domains, whose vanishing polynomial is `x^n - domain.coset_offset_pow_size()`.

This PR updates the helper to use `domain.coset_offset_pow_size()` when subtracting the low coefficients, so it matches the vanishing polynomial of the domain it is given.

## Details

The implementation keeps the existing coefficient-form shortcut for multiplying by a monic binomial:

```text
p(x) * (x^n - k) = x^n * p(x) - k * p(x)
```

where `k = domain.coset_offset_pow_size()`.

For subgroup domains, `k == 1`, so the previous fast path is preserved. For coset domains, the low coefficients are scaled by `k` before subtraction.

## Tests

- Extended the existing randomized `mul_by_vanishing_poly` test to check both subgroup and coset domains against `domain.vanishing_polynomial()`.
- Added a focused regression test for a size-8 coset domain using `p(x) = a + bx`, with direct expected coefficients for `p(x) * (x^8 - offset^8)`.

## Validation

Ran locally:

```text
cargo fmt --check
cargo test -p ark-poly --features std mul_by_vanishing_poly -- --nocapture
cargo test -p ark-poly --features std
```

Results:

```text
focused test: 2 passed
full ark-poly unit tests: 114 passed
ark-poly doc tests: 11 passed
```

## Scope

This intentionally only changes `mul_by_vanishing_poly`. It does not change `divide_by_vanishing_poly`, which is a separate issue area.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code — the existing method documentation states the domain contract, and the implementation comment explains the coset formula.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
