### PR TITLE
perf: Use 2-bit windowed GLV scalar multiplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending
 
-- [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-curves`) Improve scalar multiplation speed for curves using GLV.
+- [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-curves`) Improve scalar multiplication speed for curves using GLV.
 
 ## v0.6.0
 
@@ -12,6 +12,7 @@ Breaking bump across the arkworks stack — first release since 0.5.0 (2024-10-2
 ## Changes since v0.5.0
 
 **New features**
+
 - SmallFp: dedicated small-prime field implementation (#1044, #1082, #1084, #1088, #1091)
 - Stark curve + tests for large 2-adicity fields (#1001)
 - Double-odd curve support in `ec` (#986)
@@ -26,17 +27,20 @@ Breaking bump across the arkworks stack — first release since 0.5.0 (2024-10-2
 - Conditional `infinity` flag on `short_weierstrass::Affine` (#639)
 
 **Breaking trait-surface changes** (the reason this is 0.6.0)
+
 - `AffineRepr: Neg<Output = Self>` tightened (#927)
 - New required const `MINUS_ONE` on `Field`/`FpConfig` (#1004)
 - R1CS → GR1CS migration (#949)
 
 **Performance**
+
 - Fix GLV scalar-multiplication perf bug (#1025)
 - `VariableBaseMSM` improvements for small scalars (#995, #996)
 - Extended Jacobian coordinates for SW MSM (#961)
 - Generalized Mersenne mul path (#1091)
 
-**Bug fixes**
+**Bugfixes**
+
 - `ToConstraintField` bound for `Affine` (#1005)
 - `to_dense_multilinear_extension` for nv > 30 (#1022)
 - `to_evaluations` for sparse multilinear extension (#1019)
@@ -46,6 +50,7 @@ Breaking bump across the arkworks stack — first release since 0.5.0 (2024-10-2
 - Build of `ark-ff` (#1028)
 
 **Refactors / housekeeping**
+
 - Polynomial refactors across `DensePolynomial`, `SparsePolynomial`, `GeneralEvaluationDomain`
 - `find_naf`, biginteger, cubic-extension simplifications in `ff`
 - Clippy rule rollout across all member crates
@@ -59,10 +64,10 @@ Full list: `git log v0.5.0..v0.6.0`.
 Step 2 of the 0.6.0 cascade: std → **algebra** → snark → r1cs-std → crypto-primitives → poly-commit → groth16 → circom-compat.
 
 ## Verification
+
 - [x] `cargo test --workspace --all-features` green
 - [x] `cargo publish --workspace --dry-run` clean (root + `curves/`)
 - [x] CI green on master
-
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,67 @@
 
 ## Pending
 
-- (`ark-starkcurve`) Add 252 bit [Stark curve](https://docs.starknet.io/architecture/cryptography/#the_stark_curve).
-- [\#971](https://github.com/arkworks-rs/algebra/pull/971) (`ark-ff`) Make serial_batch_inversion_and_mul public.
-- Consolidated logic into `bitreverse_permutation_in_place` and made it public.
-- Remove redundant type constraints from `Pairing::G1Prepared`.
-- (`ark-serialize`) Add serde-compatible wrapper types `CompressedChecked<T>`, `CompressedUnchecked<T>`, `UncompressedChecked<T>`, `UncompressedUnchecked<T>`.
-- [\#989](https://github.com/arkworks-rs/algebra/pull/989) (`ark-poly`) Replace bound `F: FftField` with `F: Field` on `GeneralEvaluationDomain`.
-- (`ark-poly`) Add fast polynomial division
-- (`ark-ec`) Improve GLV scalar multiplication performance by skipping leading zeroes.
-- (`ark-poly`) Make `SparsePolynomial.coeffs` field public
-- [\#1039](https://github.com/arkworks-rs/algebra/pull/1039) (`ark-ff-asm`) Remove unused dead spill buffer path.
-- [\#1044](https://github.com/arkworks-rs/algebra/pull/1044), [\#1084](https://github.com/arkworks-rs/algebra/pull/1084), [\#1088](https://github.com/arkworks-rs/algebra/pull/1088) Add implementation for small field with native integer types
+- [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-curves`) Improve scalar multiplation speed for curves using GLV.
 
-### Breaking changes
+## v0.6.0
 
-- (`ark-poly`) the `Div` implementation is now restricted to polynomials defined over `FftField`. Non-`FftField` polys can instead use the `naive_div` method.
+Breaking bump across the arkworks stack — first release since 0.5.0 (2024-10-28).
+104 commits of fixes, performance work, new APIs, and one trait-surface change that forces the major-version cut.
 
-### Features
+## Changes since v0.5.0
 
-- (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
-- [\#1084](https://github.com/arkworks-rs/algebra/pull/1084) (`ark-ff`) Add `from_u128` const constructor for `SmallFp` fields
-- [\#1086](https://github.com/arkworks-rs/algebra/pull/1086) (`ark-ff-macros`) Auto-detect small prime subgroup (bases 3, 5, 7) in `define_field!` for both `SmallFp` and `Fp` fields
+**New features**
+- SmallFp: dedicated small-prime field implementation (#1044, #1082, #1084, #1088, #1091)
+- Stark curve + tests for large 2-adicity fields (#1001)
+- Double-odd curve support in `ec` (#986)
+- O(n log n) polynomial division (#1010)
+- Serde-compatible adapters (#967)
+- `CanonicalSerialize`/`Deserialize` for `HashMap`/`HashSet` (#999) and signed integers (#953)
+- `MINUS_ONE` const on `Field` / `FpConfig` (#1004)
+- Expose `GENERATOR` on `AffineRepr` (#1045)
+- `serial_batch_inversion_and_mul` made public (#971)
+- `Cargo.toml` `asm` feature (#928)
+- `define_field` macro now sets plausible FFT params (#1086)
+- Conditional `infinity` flag on `short_weierstrass::Affine` (#639)
 
-### Improvements
+**Breaking trait-surface changes** (the reason this is 0.6.0)
+- `AffineRepr: Neg<Output = Self>` tightened (#927)
+- New required const `MINUS_ONE` on `Field`/`FpConfig` (#1004)
+- R1CS → GR1CS migration (#949)
 
-- [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Replace Fermat-based (`a^{p-2}`) modular inversion for `SmallFp` fields with a constant-time binary extended GCD (based on [Pornin 2020](https://eprint.iacr.org/2020/1340)).
-- [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Consolidate `SmallFp` multiplication dispatch into a single `match` with Mersenne fast-paths (M7, M13, M31) and generic Montgomery backends for u8/u16/u32/u64 fields.
+**Performance**
+- Fix GLV scalar-multiplication perf bug (#1025)
+- `VariableBaseMSM` improvements for small scalars (#995, #996)
+- Extended Jacobian coordinates for SW MSM (#961)
+- Generalized Mersenne mul path (#1091)
 
-### Bugfixes
+**Bug fixes**
+- `ToConstraintField` bound for `Affine` (#1005)
+- `to_dense_multilinear_extension` for nv > 30 (#1022)
+- `to_evaluations` for sparse multilinear extension (#1019)
+- Multilinear extension `rand` (#998)
+- Support 5 mod 8 case in `SqrtPrecomputation` (#968)
+- `from_random_bytes` consistency between `SmallFp` and `Fp` (#1082)
+- Build of `ark-ff` (#1028)
 
-- [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
+**Refactors / housekeeping**
+- Polynomial refactors across `DensePolynomial`, `SparsePolynomial`, `GeneralEvaluationDomain`
+- `find_naf`, biginteger, cubic-extension simplifications in `ff`
+- Clippy rule rollout across all member crates
+- Dep bumps: hashbrown 0.15 → 0.17, criterion 0.6 → 0.8, itertools 0.13 → 0.14
+- Removed soft dependencies (#1027)
+
+Full list: `git log v0.5.0..v0.6.0`.
+
+## Release position
+
+Step 2 of the 0.6.0 cascade: std → **algebra** → snark → r1cs-std → crypto-primitives → poly-commit → groth16 → circom-compat.
+
+## Verification
+- [x] `cargo test --workspace --all-features` green
+- [x] `cargo publish --workspace --dry-run` clean (root + `curves/`)
+- [x] CI green on master
+
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,72 +2,43 @@
 
 ## Pending
 
-- [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-curves`) Improve scalar multiplication speed for curves using GLV.
+- (`ark-starkcurve`) Add 252 bit [Stark curve](https://docs.starknet.io/architecture/cryptography/#the_stark_curve).
+- [\#971](https://github.com/arkworks-rs/algebra/pull/971) (`ark-ff`) Make serial_batch_inversion_and_mul public.
+- Consolidated logic into `bitreverse_permutation_in_place` and made it public.
+- Remove redundant type constraints from `Pairing::G1Prepared`.
+- (`ark-serialize`) Add serde-compatible wrapper types `CompressedChecked<T>`, `CompressedUnchecked<T>`, `UncompressedChecked<T>`, `UncompressedUnchecked<T>`.
+- [\#989](https://github.com/arkworks-rs/algebra/pull/989) (`ark-poly`) Replace bound `F: FftField` with `F: Field` on `GeneralEvaluationDomain`.
+- (`ark-poly`) Add fast polynomial division
+- (`ark-ec`) Improve GLV scalar multiplication performance by skipping leading zeroes.
+- (`ark-poly`) Make `SparsePolynomial.coeffs` field public
+- [\#1039](https://github.com/arkworks-rs/algebra/pull/1039) (`ark-ff-asm`) Remove unused dead spill buffer path.
+- [\#1044](https://github.com/arkworks-rs/algebra/pull/1044), [\#1084](https://github.com/arkworks-rs/algebra/pull/1084), [\#1088](https://github.com/arkworks-rs/algebra/pull/1088) Add implementation for small field with native integer types
+- [\#1061](https://github.com/arkworks-rs/algebra/pull/1061) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::{concat, fix_variables, evaluate}`.
+- [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
+- [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
+- [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-ec`) Improve scalar multiplication speed for curves using GLV.
 
-## v0.6.0
+### Breaking changes
 
-Breaking bump across the arkworks stack — first release since 0.5.0 (2024-10-28).
-104 commits of fixes, performance work, new APIs, and one trait-surface change that forces the major-version cut.
+- [\#1121](https://github.com/arkworks-rs/algebra/pull/1121) (all) Bump the minimum supported Rust version to 1.89.
+- (`ark-poly`) the `Div` implementation is now restricted to polynomials defined over `FftField`. Non-`FftField` polys can instead use the `naive_div` method.
 
-## Changes since v0.5.0
+### Features
 
-**New features**
+- (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
+- [\#1115](https://github.com/arkworks-rs/algebra/pull/1115) (`ark-serialize`) Implement `CanonicalSerialize`, `Valid`, and `CanonicalDeserialize` for `Box<T>`.
+- [\#1084](https://github.com/arkworks-rs/algebra/pull/1084) (`ark-ff`) Add `from_u128` const constructor for `SmallFp` fields
+- [\#1086](https://github.com/arkworks-rs/algebra/pull/1086) (`ark-ff-macros`) Auto-detect small prime subgroup (bases 3, 5, 7) in `define_field!` for both `SmallFp` and `Fp` fields
 
-- SmallFp: dedicated small-prime field implementation (#1044, #1082, #1084, #1088, #1091)
-- Stark curve + tests for large 2-adicity fields (#1001)
-- Double-odd curve support in `ec` (#986)
-- O(n log n) polynomial division (#1010)
-- Serde-compatible adapters (#967)
-- `CanonicalSerialize`/`Deserialize` for `HashMap`/`HashSet` (#999) and signed integers (#953)
-- `MINUS_ONE` const on `Field` / `FpConfig` (#1004)
-- Expose `GENERATOR` on `AffineRepr` (#1045)
-- `serial_batch_inversion_and_mul` made public (#971)
-- `Cargo.toml` `asm` feature (#928)
-- `define_field` macro now sets plausible FFT params (#1086)
-- Conditional `infinity` flag on `short_weierstrass::Affine` (#639)
+### Improvements
 
-**Breaking trait-surface changes** (the reason this is 0.6.0)
+- [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Replace Fermat-based (`a^{p-2}`) modular inversion for `SmallFp` fields with a constant-time binary extended GCD (based on [Pornin 2020](https://eprint.iacr.org/2020/1340)).
+- [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Consolidate `SmallFp` multiplication dispatch into a single `match` with Mersenne fast-paths (M7, M13, M31) and generic Montgomery backends for u8/u16/u32/u64 fields.
+- [\#1102](https://github.com/arkworks-rs/algebra/pull/1102) (`ark-ff-macros`) Add specialized `SmallFp` multiplication paths for the BabyBear, KoalaBear, and Goldilocks primes (shift-based Montgomery for BabyBear/KoalaBear, Pornin's reduction for Goldilocks).
 
-- `AffineRepr: Neg<Output = Self>` tightened (#927)
-- New required const `MINUS_ONE` on `Field`/`FpConfig` (#1004)
-- R1CS → GR1CS migration (#949)
+### Bugfixes
 
-**Performance**
-
-- Fix GLV scalar-multiplication perf bug (#1025)
-- `VariableBaseMSM` improvements for small scalars (#995, #996)
-- Extended Jacobian coordinates for SW MSM (#961)
-- Generalized Mersenne mul path (#1091)
-
-**Bugfixes**
-
-- `ToConstraintField` bound for `Affine` (#1005)
-- `to_dense_multilinear_extension` for nv > 30 (#1022)
-- `to_evaluations` for sparse multilinear extension (#1019)
-- Multilinear extension `rand` (#998)
-- Support 5 mod 8 case in `SqrtPrecomputation` (#968)
-- `from_random_bytes` consistency between `SmallFp` and `Fp` (#1082)
-- Build of `ark-ff` (#1028)
-
-**Refactors / housekeeping**
-
-- Polynomial refactors across `DensePolynomial`, `SparsePolynomial`, `GeneralEvaluationDomain`
-- `find_naf`, biginteger, cubic-extension simplifications in `ff`
-- Clippy rule rollout across all member crates
-- Dep bumps: hashbrown 0.15 → 0.17, criterion 0.6 → 0.8, itertools 0.13 → 0.14
-- Removed soft dependencies (#1027)
-
-Full list: `git log v0.5.0..v0.6.0`.
-
-## Release position
-
-Step 2 of the 0.6.0 cascade: std → **algebra** → snark → r1cs-std → crypto-primitives → poly-commit → groth16 → circom-compat.
-
-## Verification
-
-- [x] `cargo test --workspace --all-features` green
-- [x] `cargo publish --workspace --dry-run` clean (root + `curves/`)
-- [x] CI green on master
+- [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
 
 ## v0.5.0
 

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -2,8 +2,8 @@ use crate::{
     short_weierstrass::{Affine, Projective, SWCurveConfig},
     AdditiveGroup, CurveGroup,
 };
-use ark_ff::{PrimeField, Zero};
-use ark_std::ops::Neg;
+use ark_ff::{BitIteratorBE, PrimeField, Zero};
+use ark_std::{cmp::max, ops::Neg, vec::Vec};
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::{One, Signed};
@@ -88,79 +88,109 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
 
     fn endomorphism_affine(p: &Affine<Self>) -> Affine<Self>;
 
-    fn glv_mul_projective(p: Projective<Self>, k: Self::ScalarField) -> Projective<Self> {
-        let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
+    /// Precompute the 15-point table for 2-bit windowed GLV.
+    ///
+    /// After scalar decomposition, multiplication is `k1*b1 + k2*b2`. Each loop step reads two bits
+    /// from each half-length scalar, giving digits `c1`, `c2` in `0..=3`. The point to add is
+    /// `c1*b1 + c2*b2`; the two preceding doublings account for advancing two bits on each leg.
+    ///
+    /// There are `4*4` digit pairs, but `(c1, c2) = (0, 0)` adds nothing, so we store the other 15.
+    /// Pack digits as `idx = c2*4 + c1` (0..16) and use `table[idx - 1]` when `idx != 0`.
+    /// Example: `table[0]=b1`, `table[1]=2*b1`, `table[2]=3*b1`, `table[3]=b2`, `table[4]=b1+b2`,
+    /// …, `table[14]=3*b1 + 3*b2`.
+    #[inline]
+    fn glv_precompute_table(b1: Projective<Self>, b2: Projective<Self>) -> [Projective<Self>; 15] {
+        let b1_2 = b1.double();
+        let b1_3 = b1_2 + b1;
+        let b2_2 = b2.double();
+        let b2_3 = b2_2 + b2;
+        [
+            b1,
+            b1_2,
+            b1_3,
+            b2,
+            b1 + b2,
+            b1_2 + b2,
+            b1_3 + b2,
+            b2_2,
+            b1 + b2_2,
+            b1_2 + b2_2,
+            b1_3 + b2_2,
+            b2_3,
+            b1 + b2_3,
+            b1_2 + b2_3,
+            b1_3 + b2_3,
+        ]
+    }
 
-        let mut b1 = p;
-        let mut b2 = Self::endomorphism(&p);
+    /// 2-bit windowed scan for `k1*b1 + k2*b2` (bases must already include sign fixes).
+    #[inline]
+    fn glv_windowed_mul(
+        b1: Projective<Self>,
+        b2: Projective<Self>,
+        k1: Self::ScalarField,
+        k2: Self::ScalarField,
+    ) -> Projective<Self> {
+        let table = Self::glv_precompute_table(b1, b2);
 
-        if !sgn_k1 {
-            b1 = -b1;
-        }
-        if !sgn_k2 {
-            b2 = -b2;
-        }
-
-        let b1b2 = b1 + b2;
-
-        let iter_k1 = ark_ff::BitIteratorBE::new(k1.into_bigint());
-        let iter_k2 = ark_ff::BitIteratorBE::new(k2.into_bigint());
+        let bits1: Vec<bool> = BitIteratorBE::new(k1.into_bigint()).collect();
+        let bits2: Vec<bool> = BitIteratorBE::new(k2.into_bigint()).collect();
+        let len = max(bits1.len(), bits2.len());
+        let len = if len % 2 != 0 { len + 1 } else { len };
 
         let mut res = Projective::zero();
-        let mut skip_zeros = true;
-        for pair in iter_k1.zip(iter_k2) {
-            if skip_zeros {
-                if pair == (false, false) {
+        let mut started = false;
+        for chunk_idx in 0..(len / 2) {
+            let c1 = glv_two_bit_digit(&bits1, chunk_idx);
+            let c2 = glv_two_bit_digit(&bits2, chunk_idx);
+            let idx = (c2 as usize) * 4 + (c1 as usize);
+            if !started {
+                if idx == 0 {
                     continue;
                 }
-                skip_zeros = false;
-            }
-            res.double_in_place();
-            match pair {
-                (true, false) => res += b1,
-                (false, true) => res += b2,
-                (true, true) => res += b1b2,
-                (false, false) => {},
+                started = true;
+                res = table[idx - 1];
+            } else {
+                res.double_in_place();
+                res.double_in_place();
+                if idx != 0 {
+                    res += table[idx - 1];
+                }
             }
         }
         res
     }
 
+    fn glv_mul_projective(p: Projective<Self>, k: Self::ScalarField) -> Projective<Self> {
+        let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
+        let b1 = if sgn_k1 { p } else { -p };
+        let b2 = if sgn_k2 {
+            Self::endomorphism(&p)
+        } else {
+            -Self::endomorphism(&p)
+        };
+        Self::glv_windowed_mul(b1, b2, k1, k2)
+    }
+
     fn glv_mul_affine(p: Affine<Self>, k: Self::ScalarField) -> Affine<Self> {
         let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
+        let b1: Projective<Self> = p.into();
+        let b2 = Self::endomorphism(&b1);
+        let b1 = if sgn_k1 { b1 } else { -b1 };
+        let b2 = if sgn_k2 { b2 } else { -b2 };
+        Self::glv_windowed_mul(b1, b2, k1, k2).into_affine()
+    }
+}
 
-        let mut b1 = p;
-        let mut b2 = Self::endomorphism_affine(&p);
-
-        if !sgn_k1 {
-            b1 = -b1;
-        }
-        if !sgn_k2 {
-            b2 = -b2;
-        }
-
-        let b1b2 = b1 + b2;
-
-        let iter_k1 = ark_ff::BitIteratorBE::new(k1.into_bigint());
-        let iter_k2 = ark_ff::BitIteratorBE::new(k2.into_bigint());
-
-        let mut res = Projective::zero();
-        let mut skip_zeros = true;
-        for pair in iter_k1.zip(iter_k2) {
-            if skip_zeros {
-                if pair == (false, false) {
-                    continue;
-                }
-                skip_zeros = false;
-            }
-            res.double_in_place();
-            match pair {
-                (true, false) => res += b1,
-                (false, true) => res += b2,
-                (true, true) => res += b1b2,
-                (false, false) => {},
-            }
-        }
-        res.into_affine()
+/// Two-bit window read from a big-endian bit slice (pads missing low bits with zero).
+#[inline]
+fn glv_two_bit_digit(bits: &[bool], chunk_idx: usize) -> u8 {
+    let i = chunk_idx * 2;
+    if i + 1 < bits.len() {
+        (bits[i] as u8) * 2 + (bits[i + 1] as u8)
+    } else if i < bits.len() {
+        bits[i] as u8
+    } else {
+        0
     }
 }

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -88,83 +88,6 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
 
     fn endomorphism_affine(p: &Affine<Self>) -> Affine<Self>;
 
-    /// Precompute the 15-point table for 2-bit windowed GLV.
-    ///
-    /// Adapted from gnark-crypto's `mulGLV` (Apache-2.0, Copyright Consensys Software Inc.):
-    /// <https://github.com/ConsenSys/gnark-crypto/blob/v0.19.0/ecc/bls12-381/g1.go#L620>
-    /// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
-    ///
-    /// After scalar decomposition, multiplication is `k1*b1 + k2*b2`. Each loop step reads two bits
-    /// from each half-length scalar, giving digits `c1`, `c2` in `0..=3`. The point to add is
-    /// `c1*b1 + c2*b2`; the two preceding doublings account for advancing two bits on each leg.
-    ///
-    /// There are `4*4` digit pairs, but `(c1, c2) = (0, 0)` adds nothing, so we store the other 15.
-    /// Pack digits as `idx = c2*4 + c1` (0..16) and use `table[idx - 1]` when `idx != 0`.
-    /// Example: `table[0]=b1`, `table[1]=2*b1`, `table[2]=3*b1`, `table[3]=b2`, `table[4]=b1+b2`,
-    /// …, `table[14]=3*b1 + 3*b2`.
-    #[inline]
-    fn glv_precompute_table(b1: Projective<Self>, b2: Projective<Self>) -> [Projective<Self>; 15] {
-        let b1_2 = b1.double();
-        let b1_3 = b1_2 + b1;
-        let b2_2 = b2.double();
-        let b2_3 = b2_2 + b2;
-        [
-            b1,
-            b1_2,
-            b1_3,
-            b2,
-            b1 + b2,
-            b1_2 + b2,
-            b1_3 + b2,
-            b2_2,
-            b1 + b2_2,
-            b1_2 + b2_2,
-            b1_3 + b2_2,
-            b2_3,
-            b1 + b2_3,
-            b1_2 + b2_3,
-            b1_3 + b2_3,
-        ]
-    }
-
-    /// 2-bit windowed scan for `k1*b1 + k2*b2` (bases must already include sign fixes).
-    fn glv_windowed_mul(
-        b1: Projective<Self>,
-        b2: Projective<Self>,
-        k1: Self::ScalarField,
-        k2: Self::ScalarField,
-    ) -> Projective<Self> {
-        let table = Self::glv_precompute_table(b1, b2);
-
-        let k1_bi = k1.into_bigint();
-        let k2_bi = k2.into_bigint();
-        let limbs1 = k1_bi.as_ref();
-        let limbs2 = k2_bi.as_ref();
-        // `BitIteratorBE::new` / `into_bigint` always yield exactly `64 * NUM_LIMBS` bits for a
-        // given `ScalarField`, so both scalars share the same (even) bit length.
-        debug_assert_eq!(limbs1.len(), limbs2.len());
-        let nbits = limbs1.len() * 64;
-
-        let mut res = Projective::zero();
-        let mut started = false;
-        for chunk_idx in 0..(nbits / 2) {
-            let c1 = glv_two_bit_digit(limbs1, chunk_idx);
-            let c2 = glv_two_bit_digit(limbs2, chunk_idx);
-            let idx = (c2 as usize) * 4 + (c1 as usize);
-            if started {
-                res.double_in_place();
-                res.double_in_place();
-                if idx != 0 {
-                    res += table[idx - 1];
-                }
-            } else if idx != 0 {
-                started = true;
-                res = table[idx - 1];
-            }
-        }
-        res
-    }
-
     fn glv_mul_projective(p: Projective<Self>, k: Self::ScalarField) -> Projective<Self> {
         let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
         let b1 = if sgn_k1 { p } else { -p };
@@ -173,7 +96,7 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
         } else {
             -Self::endomorphism(&p)
         };
-        Self::glv_windowed_mul(b1, b2, k1, k2)
+        glv_windowed_mul(b1, b2, k1, k2)
     }
 
     /// GLV scalar multiplication starting from an affine point.
@@ -183,6 +106,83 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     fn glv_mul_affine(p: Affine<Self>, k: Self::ScalarField) -> Affine<Self> {
         Self::glv_mul_projective(p.into(), k).into_affine()
     }
+}
+
+/// Precompute the 15-point table for 2-bit windowed GLV.
+///
+/// Adapted from gnark-crypto's `mulGLV` (Apache-2.0, Copyright Consensys Software Inc.):
+/// <https://github.com/ConsenSys/gnark-crypto/blob/v0.19.0/ecc/bls12-381/g1.go#L620>
+/// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
+///
+/// After scalar decomposition, multiplication is `k1*b1 + k2*b2`. Each loop step reads two bits
+/// from each half-length scalar, giving digits `c1`, `c2` in `0..=3`. The point to add is
+/// `c1*b1 + c2*b2`; the two preceding doublings account for advancing two bits on each leg.
+///
+/// There are `4*4` digit pairs, but `(c1, c2) = (0, 0)` adds nothing, so we store the other 15.
+/// Pack digits as `idx = c2*4 + c1` (0..16) and use `table[idx - 1]` when `idx != 0`.
+/// Example: `table[0]=b1`, `table[1]=2*b1`, `table[2]=3*b1`, `table[3]=b2`, `table[4]=b1+b2`,
+/// …, `table[14]=3*b1 + 3*b2`.
+#[inline]
+fn glv_precompute_table<P: GLVConfig>(b1: Projective<P>, b2: Projective<P>) -> [Projective<P>; 15] {
+    let b1_2 = b1.double();
+    let b1_3 = b1_2 + b1;
+    let b2_2 = b2.double();
+    let b2_3 = b2_2 + b2;
+    [
+        b1,
+        b1_2,
+        b1_3,
+        b2,
+        b1 + b2,
+        b1_2 + b2,
+        b1_3 + b2,
+        b2_2,
+        b1 + b2_2,
+        b1_2 + b2_2,
+        b1_3 + b2_2,
+        b2_3,
+        b1 + b2_3,
+        b1_2 + b2_3,
+        b1_3 + b2_3,
+    ]
+}
+
+/// 2-bit windowed scan for `k1*b1 + k2*b2` (bases must already include sign fixes).
+fn glv_windowed_mul<P: GLVConfig>(
+    b1: Projective<P>,
+    b2: Projective<P>,
+    k1: P::ScalarField,
+    k2: P::ScalarField,
+) -> Projective<P> {
+    let table = glv_precompute_table(b1, b2);
+
+    let k1_bi = k1.into_bigint();
+    let k2_bi = k2.into_bigint();
+    let limbs1 = k1_bi.as_ref();
+    let limbs2 = k2_bi.as_ref();
+    // `BitIteratorBE::new` / `into_bigint` always yield exactly `64 * NUM_LIMBS` bits for a
+    // given `ScalarField`, so both scalars share the same (even) bit length.
+    debug_assert_eq!(limbs1.len(), limbs2.len());
+    let nbits = limbs1.len() * 64;
+
+    let mut res = Projective::zero();
+    let mut started = false;
+    for chunk_idx in 0..(nbits / 2) {
+        let c1 = glv_two_bit_digit(limbs1, chunk_idx);
+        let c2 = glv_two_bit_digit(limbs2, chunk_idx);
+        let idx = (c2 as usize) * 4 + (c1 as usize);
+        if started {
+            res.double_in_place();
+            res.double_in_place();
+            if idx != 0 {
+                res += table[idx - 1];
+            }
+        } else if idx != 0 {
+            started = true;
+            res = table[idx - 1];
+        }
+    }
+    res
 }
 
 /// Extract the `chunk_idx`-th 2-bit window from a big-endian limb encoding.

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -2,8 +2,8 @@ use crate::{
     short_weierstrass::{Affine, Projective, SWCurveConfig},
     AdditiveGroup, CurveGroup,
 };
-use ark_ff::{BitIteratorBE, PrimeField, Zero};
-use ark_std::{cmp::max, ops::Neg, vec::Vec};
+use ark_ff::{PrimeField, Zero};
+use ark_std::ops::Neg;
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::{One, Signed};
@@ -90,6 +90,10 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
 
     /// Precompute the 15-point table for 2-bit windowed GLV.
     ///
+    /// Adapted from gnark-crypto's `mulGLV` (Apache-2.0, Copyright Consensys Software Inc.):
+    /// <https://github.com/ConsenSys/gnark-crypto/blob/v0.19.0/ecc/bls12-381/g1.go#L620>
+    /// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
+    ///
     /// After scalar decomposition, multiplication is `k1*b1 + k2*b2`. Each loop step reads two bits
     /// from each half-length scalar, giving digits `c1`, `c2` in `0..=3`. The point to add is
     /// `c1*b1 + c2*b2`; the two preceding doublings account for advancing two bits on each leg.
@@ -124,7 +128,6 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     }
 
     /// 2-bit windowed scan for `k1*b1 + k2*b2` (bases must already include sign fixes).
-    #[inline]
     fn glv_windowed_mul(
         b1: Projective<Self>,
         b2: Projective<Self>,
@@ -133,29 +136,30 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     ) -> Projective<Self> {
         let table = Self::glv_precompute_table(b1, b2);
 
-        let bits1: Vec<bool> = BitIteratorBE::new(k1.into_bigint()).collect();
-        let bits2: Vec<bool> = BitIteratorBE::new(k2.into_bigint()).collect();
-        let len = max(bits1.len(), bits2.len());
-        let len = if len % 2 != 0 { len + 1 } else { len };
+        let k1_bi = k1.into_bigint();
+        let k2_bi = k2.into_bigint();
+        let limbs1 = k1_bi.as_ref();
+        let limbs2 = k2_bi.as_ref();
+        // `BitIteratorBE::new` / `into_bigint` always yield exactly `64 * NUM_LIMBS` bits for a
+        // given `ScalarField`, so both scalars share the same (even) bit length.
+        debug_assert_eq!(limbs1.len(), limbs2.len());
+        let nbits = limbs1.len() * 64;
 
         let mut res = Projective::zero();
         let mut started = false;
-        for chunk_idx in 0..(len / 2) {
-            let c1 = glv_two_bit_digit(&bits1, chunk_idx);
-            let c2 = glv_two_bit_digit(&bits2, chunk_idx);
+        for chunk_idx in 0..(nbits / 2) {
+            let c1 = glv_two_bit_digit(limbs1, chunk_idx);
+            let c2 = glv_two_bit_digit(limbs2, chunk_idx);
             let idx = (c2 as usize) * 4 + (c1 as usize);
-            if !started {
-                if idx == 0 {
-                    continue;
-                }
-                started = true;
-                res = table[idx - 1];
-            } else {
+            if started {
                 res.double_in_place();
                 res.double_in_place();
                 if idx != 0 {
                     res += table[idx - 1];
                 }
+            } else if idx != 0 {
+                started = true;
+                res = table[idx - 1];
             }
         }
         res
@@ -172,25 +176,22 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
         Self::glv_windowed_mul(b1, b2, k1, k2)
     }
 
+    /// GLV scalar multiplication starting from an affine point.
+    ///
+    /// Note: this converts to projective and uses the 2-bit windowed table (projective additions),
+    /// rather than mixed additions against affine table entries.
     fn glv_mul_affine(p: Affine<Self>, k: Self::ScalarField) -> Affine<Self> {
-        let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
-        let b1: Projective<Self> = p.into();
-        let b2 = Self::endomorphism(&b1);
-        let b1 = if sgn_k1 { b1 } else { -b1 };
-        let b2 = if sgn_k2 { b2 } else { -b2 };
-        Self::glv_windowed_mul(b1, b2, k1, k2).into_affine()
+        Self::glv_mul_projective(p.into(), k).into_affine()
     }
 }
 
-/// Two-bit window read from a big-endian bit slice (pads missing low bits with zero).
+/// Extract the `chunk_idx`-th 2-bit window from a big-endian limb encoding.
+///
+/// `chunk_idx = 0` is the most-significant pair of bits across `limbs`. The total bit length
+/// `64 * limbs.len()` is always even, so every window is fully contained in a single limb.
 #[inline]
-fn glv_two_bit_digit(bits: &[bool], chunk_idx: usize) -> u8 {
-    let i = chunk_idx * 2;
-    if i + 1 < bits.len() {
-        (bits[i] as u8) * 2 + (bits[i + 1] as u8)
-    } else if i < bits.len() {
-        bits[i] as u8
-    } else {
-        0
-    }
+fn glv_two_bit_digit(limbs: &[u64], chunk_idx: usize) -> u8 {
+    let bit_from_msb = chunk_idx * 2;
+    let limb = limbs[limbs.len() - 1 - bit_from_msb / 64];
+    ((limb >> (62 - (bit_from_msb % 64))) & 3) as u8
 }


### PR DESCRIPTION
## Description

Inspired by `gnark-crypto`, use 2-bit windowed GLV scalar multiplication. For each of the three curves (BLS12-381 G1, BLS12-377 G1 and BN254 G1) in `arkworks` which use GLV code, I'm getting a 15% speedup for scalar multiplication on an M4 Max.

~~Also updates the changelog from v0.5.0 to v0.6.0 (which seems to have been forgotten in an earlier PR).~~

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (already exist)
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
