### PR TITLE
perf(poly): reduce allocations in DenseMultilinearExtension Sub and parallelize scalar Mul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [\#1039](https://github.com/arkworks-rs/algebra/pull/1039) (`ark-ff-asm`) Remove unused dead spill buffer path.
 - [\#1044](https://github.com/arkworks-rs/algebra/pull/1044), [\#1084](https://github.com/arkworks-rs/algebra/pull/1084), [\#1088](https://github.com/arkworks-rs/algebra/pull/1088) Add implementation for small field with native integer types
 - [\#1061](https://github.com/arkworks-rs/algebra/pull/1061) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::{concat, fix_variables, evaluate}`.
+- [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
 
 ### Breaking changes
 

--- a/poly/benches/dense_multilinear.rs
+++ b/poly/benches/dense_multilinear.rs
@@ -29,6 +29,16 @@ fn arithmetic_op_bench<F: Field>(c: &mut Criterion) {
         });
     }
     group.finish();
+
+    let mut group = c.benchmark_group("DenseMultilinear::ScalarMul");
+    for nv in NUM_VARIABLES_RANGE {
+        group.bench_with_input(BenchmarkId::from_parameter(nv), &nv, |b, &nv| {
+            let poly = DenseMultilinearExtension::<F>::rand(nv, &mut rng);
+            let scalar = F::rand(&mut rng);
+            b.iter(|| black_box(&poly * &scalar))
+        });
+    }
+    group.finish();
 }
 
 fn evaluation_op_bench<F: Field>(c: &mut Criterion) {

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -349,7 +349,20 @@ impl<'a, F: Field> Sub<&'a DenseMultilinearExtension<F>> for &DenseMultilinearEx
     type Output = DenseMultilinearExtension<F>;
 
     fn sub(self, rhs: &'a DenseMultilinearExtension<F>) -> Self::Output {
-        self + &rhs.clone().neg()
+        // handle constant zero case
+        if rhs.is_zero() {
+            return self.clone();
+        }
+        if self.is_zero() {
+            return -rhs.clone();
+        }
+        assert_eq!(self.num_vars, rhs.num_vars);
+        let result: Vec<F> = cfg_iter!(self.evaluations)
+            .zip(&rhs.evaluations)
+            .map(|(a, b)| *a - *b)
+            .collect();
+
+        Self::Output::from_evaluations_vec(self.num_vars, result)
     }
 }
 
@@ -382,7 +395,7 @@ impl<'a, F: Field> Mul<&'a F> for &DenseMultilinearExtension<F> {
         } else if scalar.is_one() {
             return self.clone();
         }
-        let result: Vec<F> = self.evaluations.iter().map(|&x| x * scalar).collect();
+        let result: Vec<F> = cfg_iter!(self.evaluations).map(|&x| x * scalar).collect();
 
         DenseMultilinearExtension {
             num_vars: self.num_vars,
@@ -603,6 +616,27 @@ mod tests {
                 poly1_cloned *= Fr::zero();
                 assert_eq!(poly1_cloned, DenseMultilinearExtension::zero());
             }
+        }
+    }
+
+    #[test]
+    fn sub_with_zero() {
+        const NV: usize = 10;
+        let mut rng = test_rng();
+        for _ in 0..20 {
+            let point: Vec<_> = (0..NV).map(|_| Fr::rand(&mut rng)).collect();
+            let poly = DenseMultilinearExtension::rand(NV, &mut rng);
+            let v = poly.evaluate(&point);
+            let zero = DenseMultilinearExtension::zero();
+
+            // `poly - 0` returns `poly` unchanged
+            assert_eq!(&poly - &zero, poly);
+            // `0 - poly` returns `-poly`
+            let neg = &zero - &poly;
+            assert_eq!(neg, poly.clone().neg());
+            assert_eq!(neg.evaluate(&point), -v);
+            // `poly - poly` evaluates to zero everywhere
+            assert_eq!((&poly - &poly).evaluate(&point), Fr::zero());
         }
     }
 


### PR DESCRIPTION
## Summary

Two allocation/parallelism improvements to `DenseMultilinearExtension` arithmetic, in the spirit of #1061:

- **`Sub` (`&Self - &Self`)** previously evaluated `self + &rhs.clone().neg()`, allocating three full evaluation tables (clone, negation, sum) across two passes. This fuses it into a single `cfg_iter!` pass with one allocation. The zero-operand short-circuits and the `num_vars` assertion mirror the existing `Add` impl, so the output is identical.
- **Scalar `Mul` (`&Self * &F`)** was the only arithmetic operator still using a serial `.iter()`; it now uses `cfg_iter!`, matching `Add`, `Neg`, and `Sub`.

Also adds a `ScalarMul` case to the dense-multilinear benchmark and a `sub_with_zero` regression test (the previous tests did not cover the zero-operand paths of `Sub`).

## Correctness

Output is unchanged. `cargo test -p ark-poly` passes with and without `--features parallel`, including the existing `arithmetic` test and the new `sub_with_zero`.

## Benchmarks

`criterion`, `bls12_381::Fr`, before/after toggled via `git stash`, 12-core machine, 100 samples / 5 s. `nv` = number of variables (table size `2^nv`); median change:

| nv | Sub (serial) | Sub (parallel) | ScalarMul (parallel) |
|---:|---:|---:|---:|
| 14 | −46% | −54% | −62% |
| 16 | −30% | −64% | −80% |
| 18 | −29% | −61% | −85% |
| 20 | −29% | −58% | −86% |

Serial `ScalarMul` is unchanged (in serial builds `cfg_iter!` expands to `.iter()`).

**Tradeoff (parallel `ScalarMul` only):** for very small tables the rayon dispatch overhead exceeds the work, so `ScalarMul` regresses for `nv ≤ 11` (e.g. `nv = 10`: ~11 µs → ~54 µs), crossing over at `nv ≈ 12`. This matches the existing unconditional parallelization of `Add`/`Neg`. `Sub` improves at every size in both modes.
