### PR TITLE
docs(ff): clarify pow_with_table bit length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Replace Fermat-based (`a^{p-2}`) modular inversion for `SmallFp` fields with a constant-time binary extended GCD (based on [Pornin 2020](https://eprint.iacr.org/2020/1340)).
 - [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Consolidate `SmallFp` multiplication dispatch into a single `match` with Mersenne fast-paths (M7, M13, M31) and generic Montgomery backends for u8/u16/u32/u64 fields.
 - [\#1102](https://github.com/arkworks-rs/algebra/pull/1102) (`ark-ff-macros`) Add specialized `SmallFp` multiplication paths for the BabyBear, KoalaBear, and Goldilocks primes (shift-based Montgomery for BabyBear/KoalaBear, Pornin's reduction for Goldilocks).
+- (`ark-ff`) Clarify the documented bit length covered by `Field::pow_with_table` precomputed powers.
 
 ### Bugfixes
 

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -335,9 +335,9 @@ pub trait Field:
 
     /// Exponentiates a field element `f` by a number represented with `u64`
     /// limbs, using a precomputed table containing as many powers of 2 of
-    /// `f` as the 1 + the floor of log2 of the exponent `exp`, starting
+    /// `f` as 1 + the floor of log2 of the exponent `exp`, starting
     /// from the 1st power. That is, `powers_of_2` should equal `&[p, p^2,
-    /// p^4, ..., p^(2^n)]` when `exp` has at most `n` bits.
+    /// p^4, ..., p^(2^n)]` when `exp` has at most `n + 1` bits.
     ///
     /// This returns `None` when a power is missing from the table.
     #[inline]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

The current documentation says that `&[p, p^2, p^4, ..., p^(2^n)]` applies when `exp` has at most `n` bits. Since the table includes powers through bit index `n`, it covers exponents with at most `n + 1` bits.

closes: #851


- Clarify the documented bit length covered by `Field::pow_with_table` precomputed powers.
- Add a Pending changelog entry for the `ark-ff` documentation improvement.



---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
