### PR TITLE
feat(serialize): implement Canonical(De)Serialize and Valid for Box<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Features
 
 - (`ark-serialize`) Implementation of `CanonicalSerialize` and `CanonicalDeserialize` for signed integer types
+- [\#1115](https://github.com/arkworks-rs/algebra/pull/1115) (`ark-serialize`) Implement `CanonicalSerialize`, `Valid`, and `CanonicalDeserialize` for `Box<T>`.
 - [\#1084](https://github.com/arkworks-rs/algebra/pull/1084) (`ark-ff`) Add `from_u128` const constructor for `SmallFp` fields
 - [\#1086](https://github.com/arkworks-rs/algebra/pull/1086) (`ark-ff-macros`) Auto-detect small prime subgroup (bases 3, 5, 7) in `define_field!` for both `SmallFp` and `Fp` fields
 

--- a/serialize/src/impls/misc.rs
+++ b/serialize/src/impls/misc.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use ark_std::{
     borrow::*,
+    boxed::Box,
     io::{Read, Write},
     marker::PhantomData,
     rc::Rc,
@@ -207,6 +208,58 @@ impl<T: ?Sized + Valid + Sync + Send> Valid for ark_std::sync::Arc<T> {
 impl<T: CanonicalDeserialize + ToOwned + Sync + Send> CanonicalDeserialize
     for ark_std::sync::Arc<T>
 {
+    #[inline]
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        T::deserialize_with_mode(reader, compress, validate).map(Self::new)
+    }
+}
+
+// NOTE: bounded to `T: Sized`. The unsized slice case `Box<[T]>` is already
+// covered by the sequence impls in `collections.rs`; using `?Sized` here would
+// conflict with those.
+impl<T: CanonicalSerialize> CanonicalSerialize for Box<T> {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.as_ref().serialize_with_mode(&mut writer, compress)
+    }
+
+    #[inline]
+    fn serialized_size(&self, compress: Compress) -> usize {
+        self.as_ref().serialized_size(compress)
+    }
+}
+
+impl<T: Valid> Valid for Box<T> {
+    const TRIVIAL_CHECK: bool = T::TRIVIAL_CHECK;
+
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        self.as_ref().check()
+    }
+
+    #[inline]
+    fn batch_check<'a>(
+        batch: impl Iterator<Item = &'a Self> + Send,
+    ) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        match T::TRIVIAL_CHECK {
+            true => Ok(()),
+            false => T::batch_check(batch.map(|v| v.as_ref())),
+        }
+    }
+}
+
+impl<T: CanonicalDeserialize> CanonicalDeserialize for Box<T> {
     #[inline]
     fn deserialize_with_mode<R: Read>(
         reader: R,

--- a/serialize/src/test.rs
+++ b/serialize/src/test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use ark_std::{
+    boxed::Box,
     collections::{BTreeMap, BTreeSet, LinkedList, VecDeque},
     rand::RngCore,
     string::*,
@@ -259,6 +260,32 @@ fn test_rc_arc() {
     use ark_std::sync::Arc;
     test_serialize(Arc::new(Dummy));
     test_serialize(Arc::new(10u64));
+}
+
+#[test]
+fn test_box() {
+    // Generic `Box<T>` (added here) round-trips like the inner `T`.
+    test_serialize(Box::new(Dummy));
+    test_serialize(Box::new(10u64));
+    test_serialize(Box::new(vec![1u64, 2, 3, 4, 5]));
+
+    // `Box<[T]>` (sequence impl) still round-trips and coexists with `Box<T>`.
+    test_serialize(vec![1u64, 2, 3, 4, 5].into_boxed_slice());
+
+    // `Box<T>` serializes byte-identically to `T`, in both compression modes.
+    for compress in [Compress::Yes, Compress::No] {
+        let val = 192830918u64;
+        let boxed = Box::new(val);
+        let mut direct = Vec::new();
+        val.serialize_with_mode(&mut direct, compress).unwrap();
+        let mut via_box = Vec::new();
+        boxed.serialize_with_mode(&mut via_box, compress).unwrap();
+        assert_eq!(direct, via_box);
+        assert_eq!(
+            val.serialized_size(compress),
+            boxed.serialized_size(compress)
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What

`ark-serialize` already implements the serialization traits for `Box<[T]>` (via the sequence impls in `collections.rs`) and for `Cow<'_, T>` (#1003), but not for the generic `Box<T>`. This adds `CanonicalSerialize`, `Valid`, and `CanonicalDeserialize` for `Box<T>`, delegating to the inner `T` so a boxed value round-trips byte-identically to the value itself.

Closes #1007.

## Details

- The impls are bounded to `T: Sized` on purpose: the unsized slice case `Box<[T]>` is already covered by the sequence impls, and a `?Sized` impl here would conflict with those. (You can't deserialize into `Box<dyn Trait>` anyway.)
- `CanonicalDeserialize` uses `Self::new`, matching the neighbouring `Arc` impl and the workspace `use_self` lint.

Out of scope, per the discussion in #1007:

- `Rc<T>` can't gain `Valid` / `CanonicalDeserialize`: `Valid: Sync` (needed for `batch_check`'s rayon path) and `Rc<T>` is never `Sync`. Relaxing that, e.g. cfg-gating `Valid: Sync` on `parallel`, is semver-sensitive and left for a follow-up.

## Tests

`test_box` in `serialize/src/test.rs` covers:

- round-trips of `Box<Dummy>`, `Box<u64>`, `Box<Vec<u64>>` across `{compressed, uncompressed} x {checked, unchecked}`;
- `Box<[T]>` still round-trips and coexists with the new `Box<T>` impl;
- `Box<T>` serializes byte-identically to `T`, with equal `serialized_size`.

`no_std` is preserved (uses `ark_std::boxed::Box`). `cargo fmt --all -- --check` is clean and the full `ark-serialize` test suite passes.
