### PR TITLE
docs: update README Rust and ark-ff versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In addition, the [`curves`](https://github.com/arkworks-rs/algebra/tree/master/c
 
 ## Build guide
 
-The library compiles on the `stable` toolchain of the Rust compiler (v 1.51+). For the optimized assembly backend, Rust 1.59+ is required. To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
+The library compiles on the `stable` toolchain of the Rust compiler (v 1.75+). To install the latest version of Rust, first install `rustup` by following the instructions [here](https://rustup.rs/), or via your platform's package manager. Once `rustup` is installed, install the Rust toolchain by invoking:
 
 ```bash
 rustup install stable
@@ -68,10 +68,10 @@ RUSTFLAGS="-C target-feature=+bmi2,+adx" cargo [test/build/bench] --features asm
 To enable this in the `Cargo.toml` of your own projects, enable the `asm` feature flag:
 
 ```toml
-ark-ff = { version = "0.4", features = [ "asm" ] }
+ark-ff = { version = "0.6", features = [ "asm" ] }
 ```
 
-Note that using this backend requires Rust 1.59+ for stable inline assembly support.
+Note that using this backend requires Rust 1.75+.
 
 ## License
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Updates the root README build guide to match the current workspace metadata:

- changes the documented minimum Rust version from 1.51+ to 1.75+
- updates the `ark-ff` dependency example from 0.4 to 0.6
- adjusts the assembly backend note to reference the current Rust requirement


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
