### PR TITLE
refactor(serialize-derive): inline format args in panic messages

### DIFF
--- a/serialize-derive/src/deserialize.rs
+++ b/serialize-derive/src/deserialize.rs
@@ -52,10 +52,7 @@ fn impl_valid(ast: &syn::DeriveInput) -> TokenStream {
     let len = if let Data::Struct(ref data_struct) = ast.data {
         data_struct.fields.len()
     } else {
-        panic!(
-            "`Valid` can only be derived for structs, {} is not a struct",
-            name
-        );
+        panic!("`Valid` can only be derived for structs, {name} is not a struct");
     };
 
     let mut check_body = Vec::<TokenStream>::with_capacity(len);
@@ -88,10 +85,7 @@ fn impl_valid(ast: &syn::DeriveInput) -> TokenStream {
                 idents.clear();
             }
         },
-        _ => panic!(
-            "`Valid` can only be derived for structs, {} is not a struct",
-            name
-        ),
+        _ => panic!("`Valid` can only be derived for structs, {name} is not a struct"),
     };
 
     let check_body = if check_body.len() == 1 {
@@ -187,10 +181,9 @@ pub(super) fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream 
                 })
             };
         },
-        _ => panic!(
-            "`CanonicalDeserialize` can only be derived for structs, {} is not a Struct",
-            name
-        ),
+        _ => {
+            panic!("`CanonicalDeserialize` can only be derived for structs, {name} is not a Struct")
+        },
     };
 
     let mut gen = quote! {

--- a/serialize-derive/src/serialize.rs
+++ b/serialize-derive/src/serialize.rs
@@ -49,10 +49,7 @@ pub(super) fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
     let len = if let Data::Struct(ref data_struct) = ast.data {
         data_struct.fields.len()
     } else {
-        panic!(
-            "`CanonicalSerialize` can only be derived for structs, {} is not a struct",
-            name
-        );
+        panic!("`CanonicalSerialize` can only be derived for structs, {name} is not a struct");
     };
 
     let mut serialize_body = Vec::<TokenStream>::with_capacity(len);
@@ -83,10 +80,7 @@ pub(super) fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
                 idents.clear();
             }
         },
-        _ => panic!(
-            "`CanonicalSerialize` can only be derived for structs, {} is not a struct",
-            name
-        ),
+        _ => panic!("`CanonicalSerialize` can only be derived for structs, {name} is not a struct"),
     };
 
     let gen = quote! {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

`cargo clippy` reports `clippy::uninlined_format_args` in the `ark-serialize-derive` derive helpers.

This follows the same cleanup pattern as #1012 by using captured format arguments directly in panic messages.

This is a refactor-only change and does not alter derive behavior or generated code.

I have executed 

```shell
cargo clippy -p ark-serialize-derive --all-targets -- -W clippy::uninlined_format_args
cargo test -p ark-serialize-derive
```

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
