### PR TITLE
Use GLV in Pasta and Barrett reduction in glv decomposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [\#1044](https://github.com/arkworks-rs/algebra/pull/1044), [\#1084](https://github.com/arkworks-rs/algebra/pull/1084), [\#1088](https://github.com/arkworks-rs/algebra/pull/1088) Add implementation for small field with native integer types
 - [\#1061](https://github.com/arkworks-rs/algebra/pull/1061) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::{concat, fix_variables, evaluate}`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
+- [\#1122](https://github.com/arkworks-rs/algebra/pull/1122) (`ark-pallas`, `ark-vesta`) Use GLV for `mul_projective`/`mul_affine`. Pallas and Vesta had GLV constants but were not using them.
 
 ### Breaking changes
 
@@ -37,6 +38,7 @@
 ### Bugfixes
 
 - [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
+- [\#1122](https://github.com/arkworks-rs/algebra/pull/1122) (`ark-ec`) Fix `From<Bucket> for Affine` computing the affine `x` as `X * ZZ^2` instead of `X / ZZ`.
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [\#1061](https://github.com/arkworks-rs/algebra/pull/1061) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::{concat, fix_variables, evaluate}`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
 - [\#1122](https://github.com/arkworks-rs/algebra/pull/1122) (`ark-pallas`, `ark-vesta`) Use GLV for `mul_projective`/`mul_affine`. Pallas and Vesta had GLV constants but were not using them.
+- [\#1118](https://github.com/arkworks-rs/algebra/pull/1118) (`ark-ec`, `ark-pallas`, `ark-vesta`) Speed up GLV scalar decomposition using Barrett reduction (similar to gnark).
 
 ### Breaking changes
 

--- a/curves/pallas/src/curves/mod.rs
+++ b/curves/pallas/src/curves/mod.rs
@@ -1,6 +1,6 @@
 use ark_ec::{
     models::CurveConfig,
-    scalar_mul::glv::GLVConfig,
+    scalar_mul::glv::{GLVConfig, GLVFastDecomp},
     short_weierstrass::{self as sw, SWCurveConfig},
     AffineRepr,
 };
@@ -77,6 +77,30 @@ impl GLVConfig for PallasConfig {
         (false, BigInt!("196462116142286827589391630752301449217")),
         (false, BigInt!("98231058071100081932162823354453065728")),
     ];
+
+    // Constants for the allocation-free decomposition, derived from
+    // `SCALAR_DECOMP_COEFFS` by `scripts/glv_fast_decomp.py`. `g1`/`g2` are
+    // `round(2^384 * |n22|/r)` and `round(2^384 * |n12|/r)`; `a22`/`a12` are
+    // `|n22|`/`|n12|`; and `negate_k2` holds since `sign(n12)*sign(n22) = -1`.
+    const FAST_DECOMP: Option<GLVFastDecomp<Self::ScalarField>> = Some(GLVFastDecomp {
+        g1: &[
+            0x4a95a2d972171db4,
+            0x61afdea68480fa55,
+            0x32c49e4bffffffff,
+            0x279a745902a2654e,
+            0x0000000000000001,
+        ],
+        g2: &[
+            0xc689c5879f98a4df,
+            0x61afdea683e7688a,
+            0xff2b871c00000003,
+            0x279a745903c12455,
+            0x0000000000000001,
+        ],
+        a12: MontFp!("98231058071186745657228807397848383489"),
+        a22: MontFp!("98231058071100081932162823354453065728"),
+        negate_k2: true,
+    });
 
     fn endomorphism(p: &Projective) -> Projective {
         // Endomorphism of the points on the curve.

--- a/curves/pallas/src/curves/mod.rs
+++ b/curves/pallas/src/curves/mod.rs
@@ -2,6 +2,7 @@ use ark_ec::{
     models::CurveConfig,
     scalar_mul::glv::GLVConfig,
     short_weierstrass::{self as sw, SWCurveConfig},
+    AffineRepr,
 };
 use ark_ff::{AdditiveGroup, BigInt, Field, MontFp, PrimeField, Zero};
 
@@ -47,6 +48,18 @@ impl SWCurveConfig for PallasConfig {
     #[inline(always)]
     fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
+    }
+
+    #[inline]
+    fn mul_projective(base: &Projective, scalar: &[u64]) -> Projective {
+        let s = Self::ScalarField::from_sign_and_limbs(true, scalar);
+        GLVConfig::glv_mul_projective(*base, s)
+    }
+
+    #[inline]
+    fn mul_affine(base: &Affine, scalar: &[u64]) -> Projective {
+        let s = Self::ScalarField::from_sign_and_limbs(true, scalar);
+        <Self as GLVConfig>::glv_mul_projective(base.into_group(), s)
     }
 }
 

--- a/curves/pallas/tests/glv_bench.rs
+++ b/curves/pallas/tests/glv_bench.rs
@@ -1,0 +1,80 @@
+//! Run with:
+//! `cargo test --release --manifest-path curves/pallas/Cargo.toml --test glv_bench -- --ignored --nocapture`
+
+use ark_ec::{
+    scalar_mul::glv::{
+        binary_scalar_mul_jsf, binary_scalar_mul_jsf_affine, fast_scalar_decomposition,
+        generic_scalar_decomposition, GLVConfig,
+    },
+    AffineRepr, CurveGroup,
+};
+use ark_ff::{UniformRand, Zero};
+use ark_pallas::{Affine as GAffine, Fr, PallasConfig, Projective as G};
+use ark_std::{test_rng, vec::Vec};
+use std::time::Instant;
+
+#[test]
+#[ignore = "timing comparison; run explicitly with --release --nocapture"]
+fn jsf_affine_vs_projective() {
+    let rng = &mut test_rng();
+    let n = 1000;
+    let b1: Vec<GAffine> = (0..n).map(|_| G::rand(rng).into_affine()).collect();
+    let b2: Vec<GAffine> = (0..n).map(|_| G::rand(rng).into_affine()).collect();
+    let k1: Vec<Fr> = (0..n).map(|_| Fr::rand(rng)).collect();
+    let k2: Vec<Fr> = (0..n).map(|_| Fr::rand(rng)).collect();
+
+    let t = Instant::now();
+    let mut acc = G::zero();
+    for i in 0..n {
+        acc += binary_scalar_mul_jsf(b1[i].into_group(), k1[i], b2[i].into_group(), k2[i]);
+    }
+    let proj = t.elapsed();
+    let g1 = acc;
+
+    let t = Instant::now();
+    let mut acc = G::zero();
+    for i in 0..n {
+        acc += binary_scalar_mul_jsf_affine(b1[i], k1[i], b2[i], k2[i]);
+    }
+    let affine = t.elapsed();
+    assert_eq!(g1, acc);
+
+    println!(
+        "jsf (affine bases) over {n}: projective {proj:?}, mixed-add {affine:?}  ({:.2}x)",
+        proj.as_secs_f64() / affine.as_secs_f64()
+    );
+}
+
+#[test]
+#[ignore = "timing comparison; run explicitly with --release --nocapture"]
+fn fast_decomposition_throughput() {
+    let rng = &mut test_rng();
+    let n = 10000;
+    let scalars: Vec<Fr> = (0..n).map(|_| Fr::rand(rng)).collect();
+    let fd = PallasConfig::FAST_DECOMP.unwrap();
+    let lambda = PallasConfig::LAMBDA;
+    let signed = |(pos, mag): (bool, Fr)| if pos { mag } else { -mag };
+
+    let t = Instant::now();
+    let mut acc = Fr::zero();
+    for s in &scalars {
+        let (k1, k2) = generic_scalar_decomposition::<PallasConfig>(*s);
+        acc += signed(k1) + lambda * signed(k2);
+    }
+    let generic = t.elapsed();
+    let generic_acc = acc;
+
+    let t = Instant::now();
+    let mut acc = Fr::zero();
+    for s in &scalars {
+        let (k1, k2) = fast_scalar_decomposition::<PallasConfig>(*s, &fd);
+        acc += signed(k1) + lambda * signed(k2);
+    }
+    let fast = t.elapsed();
+    assert_eq!(generic_acc, acc);
+
+    println!(
+        "scalar_decomposition over {n}: generic {generic:?}, fast {fast:?}  ({:.2}x)",
+        generic.as_secs_f64() / fast.as_secs_f64()
+    );
+}

--- a/curves/pallas/tests/glv_impl.rs
+++ b/curves/pallas/tests/glv_impl.rs
@@ -1,0 +1,117 @@
+use ark_ec::{
+    scalar_mul::glv::{
+        binary_scalar_mul_jsf, binary_scalar_mul_jsf_affine, joint_sparse_form, GLVConfig,
+    },
+    AffineRepr, CurveGroup,
+};
+use ark_ff::{AdditiveGroup, Field, PrimeField, UniformRand};
+use ark_pallas::{Fr, PallasConfig, Projective as G};
+use ark_std::test_rng;
+
+#[test]
+fn jsf_reconstructs_the_scalars() {
+    let rng = &mut test_rng();
+    for _ in 0..2000 {
+        let k1 = Fr::rand(rng);
+        let k2 = Fr::rand(rng);
+        let digits = joint_sparse_form(k1.into_bigint().as_ref(), k2.into_bigint().as_ref());
+
+        // digits are most-significant first: acc = 2*acc + digit.
+        let mut a1 = Fr::ZERO;
+        let mut a2 = Fr::ZERO;
+        for (u1, u2) in digits {
+            a1.double_in_place();
+            a2.double_in_place();
+            match u1 {
+                1 => a1 += Fr::ONE,
+                -1 => a1 -= Fr::ONE,
+                _ => {},
+            }
+            match u2 {
+                1 => a2 += Fr::ONE,
+                -1 => a2 -= Fr::ONE,
+                _ => {},
+            }
+        }
+        assert_eq!(a1, k1);
+        assert_eq!(a2, k2);
+    }
+}
+
+#[test]
+fn jsf_recodes_full_width_limbs() {
+    // Raw 128-bit inputs (independent of any field), including all-ones values
+    // whose `-1` digit carries into the spare headroom limb. Reconstruct with
+    // wrapping u128 arithmetic, which matches the true value since it is < 2^128.
+    let cases: [(u128, u128); 7] = [
+        (0, 0),
+        (1, 0),
+        (u128::MAX, 0),
+        (u128::MAX, u128::MAX),
+        (u128::MAX, 1),
+        (0x8000_0000_0000_0000_0000_0000_0000_0000, u128::MAX),
+        (
+            0xDEAD_BEEF_DEAD_BEEF_FFFF_FFFF_FFFF_FFFF,
+            0xFFFF_FFFF_0000_0000_FFFF_FFFF_FFFF_FFFF,
+        ),
+    ];
+    let to_limbs = |x: u128| [x as u64, (x >> 64) as u64];
+    for (k1, k2) in cases {
+        let digits = joint_sparse_form(&to_limbs(k1), &to_limbs(k2));
+        let (mut a1, mut a2) = (0u128, 0u128);
+        for (u1, u2) in digits {
+            a1 = a1.wrapping_mul(2).wrapping_add(u1 as i128 as u128);
+            a2 = a2.wrapping_mul(2).wrapping_add(u2 as i128 as u128);
+        }
+        assert_eq!(
+            (a1, a2),
+            (k1, k2),
+            "JSF reconstruction failed for ({k1:#x}, {k2:#x})"
+        );
+    }
+}
+
+#[test]
+fn jsf_mul_handles_edge_scalars() {
+    let rng = &mut test_rng();
+    let b1 = G::rand(rng);
+    let b2 = G::rand(rng);
+    let specials = [Fr::ZERO, Fr::ONE, -Fr::ONE, PallasConfig::LAMBDA];
+    for &k1 in &specials {
+        for &k2 in &specials {
+            let naive = b1 * k1 + b2 * k2;
+            assert_eq!(binary_scalar_mul_jsf(b1, k1, b2, k2), naive);
+            assert_eq!(
+                binary_scalar_mul_jsf_affine(b1.into_affine(), k1, b2.into_affine(), k2),
+                naive
+            );
+        }
+    }
+}
+
+#[test]
+fn glv_mul_identity_point() {
+    // The identity point makes the whole normalized table the identity, which
+    // exercises `normalize_batch` and the mixed adds on infinity inputs.
+    let id = G::ZERO;
+    for k in [Fr::ONE, -Fr::ONE, PallasConfig::LAMBDA, Fr::from(12345u64)] {
+        assert_eq!(PallasConfig::glv_mul_projective(id, k), G::ZERO);
+        assert!(PallasConfig::glv_mul_affine(id.into_affine(), k).is_zero());
+    }
+}
+
+#[test]
+fn glv_mul_handles_edge_scalars() {
+    let rng = &mut test_rng();
+    let p = G::rand(rng);
+    let cases = [
+        Fr::ZERO,
+        Fr::ONE,
+        -Fr::ONE,
+        PallasConfig::LAMBDA,
+        -PallasConfig::LAMBDA,
+    ];
+    for k in cases {
+        assert_eq!(PallasConfig::glv_mul_projective(p, k), p * k);
+    }
+}

--- a/curves/vesta/src/curves/mod.rs
+++ b/curves/vesta/src/curves/mod.rs
@@ -1,7 +1,7 @@
 use crate::{fq::Fq, fr::Fr};
 use ark_ec::{
     models::CurveConfig,
-    scalar_mul::glv::GLVConfig,
+    scalar_mul::glv::{GLVConfig, GLVFastDecomp},
     short_weierstrass::{self as sw, SWCurveConfig},
     AffineRepr,
 };
@@ -75,6 +75,30 @@ impl GLVConfig for VestaConfig {
         (false, BigInt!("196462116142286827589391630752301449217")),
         (false, BigInt!("98231058071100081932162823354453065729")),
     ];
+
+    // Constants for the allocation-free decomposition, derived from
+    // `SCALAR_DECOMP_COEFFS` by `scripts/glv_fast_decomp.py`. `g1`/`g2` are
+    // `round(2^384 * |n22|/r)` and `round(2^384 * |n12|/r)`; `a22`/`a12` are
+    // `|n22|`/`|n12|`; and `negate_k2` holds since `sign(n12)*sign(n22) = -1`.
+    const FAST_DECOMP: Option<GLVFastDecomp<Self::ScalarField>> = Some(GLVFastDecomp {
+        g1: &[
+            0x841414c24bf99a83,
+            0x61afdea685cc1578,
+            0x32c49e4c00000003,
+            0x279a745902a2654e,
+            0x0000000000000001,
+        ],
+        g2: &[
+            0x0009789fdd747ae0,
+            0x61afdea6853283ae,
+            0xff2b871bffffffff,
+            0x279a745903c12455,
+            0x0000000000000001,
+        ],
+        a12: MontFp!("98231058071186745657228807397848383488"),
+        a22: MontFp!("98231058071100081932162823354453065729"),
+        negate_k2: true,
+    });
 
     fn endomorphism(p: &Projective) -> Projective {
         // Endomorphism of the points on the curve.

--- a/curves/vesta/src/curves/mod.rs
+++ b/curves/vesta/src/curves/mod.rs
@@ -3,6 +3,7 @@ use ark_ec::{
     models::CurveConfig,
     scalar_mul::glv::GLVConfig,
     short_weierstrass::{self as sw, SWCurveConfig},
+    AffineRepr,
 };
 use ark_ff::{AdditiveGroup, BigInt, Field, MontFp, PrimeField, Zero};
 
@@ -45,6 +46,18 @@ impl SWCurveConfig for VestaConfig {
     #[inline(always)]
     fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
+    }
+
+    #[inline]
+    fn mul_projective(base: &sw::Projective<Self>, scalar: &[u64]) -> sw::Projective<Self> {
+        let s = Self::ScalarField::from_sign_and_limbs(true, scalar);
+        GLVConfig::glv_mul_projective(*base, s)
+    }
+
+    #[inline]
+    fn mul_affine(base: &sw::Affine<Self>, scalar: &[u64]) -> sw::Projective<Self> {
+        let s = Self::ScalarField::from_sign_and_limbs(true, scalar);
+        <Self as GLVConfig>::glv_mul_projective(base.into_group(), s)
     }
 }
 

--- a/ec/src/models/short_weierstrass/bucket.rs
+++ b/ec/src/models/short_weierstrass/bucket.rs
@@ -372,15 +372,14 @@ impl<P: SWCurveConfig> From<Affine<P>> for Bucket<P> {
     }
 }
 
-// The affine point X, Y is represented in the Jacobian
-// coordinates with Z = 1.
 impl<P: SWCurveConfig> From<Bucket<P>> for Affine<P> {
     #[inline]
     fn from(p: Bucket<P>) -> Self {
+        // Extended Jacobian (xyzz): affine `x = X / ZZ`, `y = Y / ZZZ`
         p.zzz.inverse().map_or_else(Self::zero, |zzz_inv| {
-            let b = p.zz.square();
-            let x = p.x * &b;
-            let y = p.y * zzz_inv;
+            let z_inv = p.zz * zzz_inv; // 1/Z
+            let x = p.x * z_inv.square(); // X / ZZ
+            let y = p.y * zzz_inv; // Y / ZZZ
             Self::new_unchecked(x, y)
         })
     }

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -1,12 +1,37 @@
 use crate::{
     short_weierstrass::{Affine, Projective, SWCurveConfig},
-    AdditiveGroup, CurveGroup,
+    CurveGroup,
 };
-use ark_ff::{PrimeField, Zero};
-use ark_std::ops::Neg;
+use ark_ff::{biginteger::arithmetic as fa, BigInteger, PrimeField};
+use ark_std::{
+    ops::{AddAssign, Neg, SubAssign},
+    vec::Vec,
+};
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::{One, Signed};
+
+/// Precomputed constants that let a curve decompose a scalar without any `num_bigint` (heap)
+/// arithmetic.
+/// With `N = ScalarField::BigInt::NUM_LIMBS` and `M = 64 * (N + 2)`, the
+/// rounding `round(k * |n_ij| / r)` is computed as `round(k * g / 2^M)` for a
+/// precomputed `g = round(2^M * |n_ij| / r)`; rounding by `2^M` is a shift, so
+/// no division is needed. The fields are:
+/// - `g1 = round(2^M * |n22| / r)` and `g2 = round(2^M * |n12| / r)`, each as
+///   `N + 1` little-endian limbs (the `n_ij` are the [`GLVConfig::SCALAR_DECOMP_COEFFS`]).
+/// - `a12 = |n12|` and `a22 = |n22|` as scalar field elements. These are duplicated from
+///    [`GLVConfig::SCALAR_DECOMP_COEFFS`] to avoid multiplication during conversion
+/// - `negate_k2` is `true` when `sign(n12) * sign(n22) == -1`.
+///
+/// These can be generated from `SCALAR_DECOMP_COEFFS` by `scripts/glv_fast_decomp.py`.
+#[derive(Clone, Copy)]
+pub struct GLVFastDecomp<F: PrimeField> {
+    pub g1: &'static [u64],
+    pub g2: &'static [u64],
+    pub a12: F,
+    pub a22: F,
+    pub negate_k2: bool,
+}
 
 /// The GLV parameters for computing the endomorphism and scalar decomposition.
 pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
@@ -25,63 +50,22 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     /// The determinant of this matrix must equal `ScalarField::characteristic()`.
     const SCALAR_DECOMP_COEFFS: [(bool, <Self::ScalarField as PrimeField>::BigInt); 4];
 
-    /// Decomposes a scalar s into k1, k2, s.t. s = k1 + lambda k2,
+    /// Optional precomputed constants enabling allocation-free scalar
+    /// decomposition. When `Some`, [`Self::scalar_decomposition`] uses
+    /// [`fast_scalar_decomposition`] instead of the `num_bigint` path; when
+    /// `None` the curve keeps the generic (slower) decomposition.
+    const FAST_DECOMP: Option<GLVFastDecomp<Self::ScalarField>> = None;
+
+    /// Decomposes a scalar s into k1, k2, s.t. s = k1 + lambda k2. Dispatches to
+    /// [`fast_scalar_decomposition`] when [`Self::FAST_DECOMP`] is set, otherwise
+    /// the generic [`generic_scalar_decomposition`].
     fn scalar_decomposition(
         k: Self::ScalarField,
     ) -> ((bool, Self::ScalarField), (bool, Self::ScalarField)) {
-        let scalar: BigInt = k.into_bigint().into().into();
-
-        let [n11, n12, n21, n22] = Self::SCALAR_DECOMP_COEFFS.map(|x| {
-            let sign = if x.0 { Sign::Plus } else { Sign::Minus };
-            BigInt::from_biguint(sign, x.1.into())
-        });
-
-        let r = BigInt::from(Self::ScalarField::MODULUS.into());
-
-        // beta = vector([k,0]) * self.curve.N_inv
-        // The inverse of N is 1/r * Matrix([[n22, -n12], [-n21, n11]]).
-        // so β = (k*n22, -k*n12)/r
-
-        let beta_1 = {
-            let (mut div, rem) = (&scalar * &n22).div_rem(&r);
-            if (&rem + &rem) > r {
-                div += BigInt::one();
-            }
-            div
-        };
-        let beta_2 = {
-            let (mut div, rem) = (&scalar * &n12.clone().neg()).div_rem(&r);
-            if (&rem + &rem) > r {
-                div += BigInt::one();
-            }
-            div
-        };
-
-        // b = vector([int(beta[0]), int(beta[1])]) * self.curve.N
-        // b = (β1N11 + β2N21, β1N12 + β2N22) with the signs!
-        //   = (b11   + b12  , b21   + b22)   with the signs!
-
-        // b1
-        let b11 = &beta_1 * &n11;
-        let b12 = &beta_2 * &n21;
-        let b1 = b11 + b12;
-
-        // b2
-        let b21 = &beta_1 * &n12;
-        let b22 = &beta_2 * &n22;
-        let b2 = b21 + b22;
-
-        let k1 = &scalar - b1;
-        let k1_abs = BigUint::try_from(k1.abs()).unwrap();
-
-        // k2
-        let k2 = -b2;
-        let k2_abs = BigUint::try_from(k2.abs()).unwrap();
-
-        (
-            (k1.sign() == Sign::Plus, k1_abs.into()),
-            (k2.sign() == Sign::Plus, k2_abs.into()),
-        )
+        match Self::FAST_DECOMP {
+            Some(fd) => fast_scalar_decomposition::<Self>(k, &fd),
+            None => generic_scalar_decomposition::<Self>(k),
+        }
     }
 
     fn endomorphism(p: &Projective<Self>) -> Projective<Self>;
@@ -89,11 +73,11 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     fn endomorphism_affine(p: &Affine<Self>) -> Affine<Self>;
 
     fn glv_mul_projective(p: Projective<Self>, k: Self::ScalarField) -> Projective<Self> {
-        let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
-
         let mut b1 = p;
         let mut b2 = Self::endomorphism(&p);
 
+        let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
+
         if !sgn_k1 {
             b1 = -b1;
         }
@@ -101,36 +85,14 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
             b2 = -b2;
         }
 
-        let b1b2 = b1 + b2;
-
-        let iter_k1 = ark_ff::BitIteratorBE::new(k1.into_bigint());
-        let iter_k2 = ark_ff::BitIteratorBE::new(k2.into_bigint());
-
-        let mut res = Projective::zero();
-        let mut skip_zeros = true;
-        for pair in iter_k1.zip(iter_k2) {
-            if skip_zeros {
-                if pair == (false, false) {
-                    continue;
-                }
-                skip_zeros = false;
-            }
-            res.double_in_place();
-            match pair {
-                (true, false) => res += b1,
-                (false, true) => res += b2,
-                (true, true) => res += b1b2,
-                (false, false) => {},
-            }
-        }
-        res
+        binary_scalar_mul_jsf(b1, k1, b2, k2)
     }
 
     fn glv_mul_affine(p: Affine<Self>, k: Self::ScalarField) -> Affine<Self> {
-        let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
-
         let mut b1 = p;
         let mut b2 = Self::endomorphism_affine(&p);
+
+        let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
 
         if !sgn_k1 {
             b1 = -b1;
@@ -139,28 +101,321 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
             b2 = -b2;
         }
 
-        let b1b2 = b1 + b2;
+        binary_scalar_mul_jsf_affine(b1, k1, b2, k2).into_affine()
+    }
+}
 
-        let iter_k1 = ark_ff::BitIteratorBE::new(k1.into_bigint());
-        let iter_k2 = ark_ff::BitIteratorBE::new(k2.into_bigint());
+/// Computes `round((k * g) / 2^(64 * shift_limbs))`, rounding up, and returns
+/// it as a scalar field element. `k` is the little-endian canonical limbs of the scalar and
+/// `g` is a precomputed multiplier; both are read as unsigned integers. The
+/// result is small (below `2^128`)
+fn mul_shift_round<F: PrimeField>(k: &[u64], g: &[u64], shift_limbs: usize) -> F {
+    // Accumulator wide enough for the product of `k` and `g` and one more limb
+    let mut prod = [0u64; 16];
+    debug_assert!(k.len() + g.len() < prod.len());
+    for (i, &ki) in k.iter().enumerate() {
+        let mut carry = 0u64;
+        for (j, &gj) in g.iter().enumerate() {
+            prod[i + j] = fa::mac_with_carry(prod[i + j], ki, gj, &mut carry);
+        }
+        prod[i + g.len()] = carry;
+    }
 
-        let mut res = Projective::zero();
-        let mut skip_zeros = true;
-        for pair in iter_k1.zip(iter_k2) {
-            if skip_zeros {
-                if pair == (false, false) {
-                    continue;
-                }
-                skip_zeros = false;
-            }
-            res.double_in_place();
-            match pair {
-                (true, false) => res += b1,
-                (false, true) => res += b2,
-                (true, true) => res += b1b2,
-                (false, false) => {},
+    // `floor((prod + 2^(64*shift_limbs - 1)) / 2^(64*shift_limbs))`
+    let mut res = <F::BigInt as Default>::default();
+    let mut carry = prod[shift_limbs - 1] >> 63;
+    for (t, o) in res.as_mut().iter_mut().enumerate() {
+        let (v, c) = prod[shift_limbs + t].overflowing_add(carry);
+        *o = v;
+        carry = c as u64;
+    }
+    debug_assert_eq!(carry, 0);
+    F::from_bigint(res).expect("should be smaller than the modulus")
+}
+
+/// Splits the canonical representative of `x` into `(is_non_negative, magnitude)`.
+/// Values up to `(r-1)/2` are treated as non-negative; the rest are negative,
+/// and for those `-x` has canonical representative `r - rep(x)`, which is exactly
+/// the magnitude.
+fn sign_and_magnitude<F: PrimeField>(x: F) -> (bool, F) {
+    if x.into_bigint() <= F::MODULUS_MINUS_ONE_DIV_TWO {
+        (true, x)
+    } else {
+        (false, -x)
+    }
+}
+
+/// Allocation-free GLV scalar decomposition using [`GLVFastDecomp`].
+///
+/// The two roundings `c1 = round(k * a22 / r)` and `c2 = round(k * a12 / r)` are
+/// done with [`mul_shift_round`]; then `k2 = +/-(c2*a22 - c1*a12)` and
+/// `k1 = k - lambda*k2` are evaluated in the scalar field. Defining `k1` this way
+/// makes `k1 + lambda*k2 == k` hold by construction, so a rounding error of at
+/// most one only affects how short `k1, k2` are, never the correctness of the
+/// identity.
+///
+/// `mul_shift_round` ties up, so on a half-way boundary this can return a
+/// `(k1, k2)` one unit from [`generic_scalar_decomposition`] (which rounds
+/// toward zero). Both are valid and short; only the exact pair differs.
+pub fn fast_scalar_decomposition<P: GLVConfig>(
+    k: P::ScalarField,
+    precomp: &GLVFastDecomp<P::ScalarField>,
+) -> ((bool, P::ScalarField), (bool, P::ScalarField)) {
+    let num_limbs = <<P::ScalarField as PrimeField>::BigInt as BigInteger>::NUM_LIMBS;
+    // same as python script
+    let shift = num_limbs + 2;
+    debug_assert_eq!(precomp.g1.len(), num_limbs + 1);
+    debug_assert_eq!(precomp.g2.len(), num_limbs + 1);
+
+    let k_bigint = k.into_bigint();
+    let k_limbs = k_bigint.as_ref();
+
+    // round(k * a22 / modulus)
+    let c1 = mul_shift_round::<P::ScalarField>(k_limbs, precomp.g1, shift);
+    // round(k * a12 / modulus)
+    let c2 = mul_shift_round::<P::ScalarField>(k_limbs, precomp.g2, shift);
+
+    let mut k2 = c2 * precomp.a22 - c1 * precomp.a12;
+    if precomp.negate_k2 {
+        k2 = -k2;
+    }
+    let k1 = k - P::LAMBDA * k2;
+
+    (sign_and_magnitude(k1), sign_and_magnitude(k2))
+}
+
+/// Generic GLV scalar decomposition
+pub fn generic_scalar_decomposition<P: GLVConfig>(
+    k: P::ScalarField,
+) -> ((bool, P::ScalarField), (bool, P::ScalarField)) {
+    let scalar: BigInt = k.into_bigint().into().into();
+
+    let [n11, n12, n21, n22] = P::SCALAR_DECOMP_COEFFS.map(|x| {
+        let sign = if x.0 { Sign::Plus } else { Sign::Minus };
+        BigInt::from_biguint(sign, x.1.into())
+    });
+
+    let r = BigInt::from(P::ScalarField::MODULUS.into());
+
+    // beta = vector([k,0]) * self.curve.N_inv
+    // The inverse of N is 1/r * Matrix([[n22, -n12], [-n21, n11]]).
+    // so β = (k*n22, -k*n12)/r
+
+    let beta_1 = {
+        let (mut div, rem) = (&scalar * &n22).div_rem(&r);
+        if (&rem + &rem) > r {
+            div += BigInt::one();
+        }
+        div
+    };
+    let beta_2 = {
+        let (mut div, rem) = (&scalar * &n12.clone().neg()).div_rem(&r);
+        if (&rem + &rem) > r {
+            div += BigInt::one();
+        }
+        div
+    };
+
+    // b = vector([int(beta[0]), int(beta[1])]) * self.curve.N
+    // b = (β1N11 + β2N21, β1N12 + β2N22) with the signs!
+    //   = (b11   + b12  , b21   + b22)   with the signs!
+
+    // b1
+    let b11 = &beta_1 * &n11;
+    let b12 = &beta_2 * &n21;
+    let b1 = b11 + b12;
+
+    // b2
+    let b21 = &beta_1 * &n12;
+    let b22 = &beta_2 * &n22;
+    let b2 = b21 + b22;
+
+    let k1 = &scalar - b1;
+    let k1_abs = BigUint::try_from(k1.abs()).unwrap();
+
+    // k2
+    let k2 = -b2;
+    let k2_abs = BigUint::try_from(k2.abs()).unwrap();
+
+    (
+        (k1.sign() == Sign::Plus, k1_abs.into()),
+        (k2.sign() == Sign::Plus, k2_abs.into()),
+    )
+}
+
+/// Computes the joint sparse form (JSF) of two non-negative integers, given as
+/// little-endian `u64` limbs.
+/// The result is a sequence of signed digit pairs `(u1, u2)`, each in `{-1, 0, 1}`, ordered from
+/// most significant to least significant, such that `k1 = \sum_i{u1_i * 2^i}` and `k2 = \sum_i{u2_i * 2^i}`.
+/// The JSF is the joint signed-binary representation of minimal weight: of any three consecutive
+/// positions at least one is `(0, 0)`, so on average only about half the positions are nonzero
+/// The returned sequence never starts with `(0, 0)` and is at most one digit longer than the bit length
+/// of `max(k1, k2)`.
+/// Reference: Taken from Algorithm 3.50 of the book [Guide to Elliptic Curve Cryptography](http://tomlr.free.fr/Math%E9matiques/Math%20Complete/Cryptography/Guide%20to%20Elliptic%20Curve%20Cryptography%20-%20D.%20Hankerson,%20A.%20Menezes,%20S.%20Vanstone.pdf)
+pub fn joint_sparse_form(k1: &[u64], k2: &[u64]) -> Vec<(i8, i8)> {
+    let len = k1.len().max(k2.len());
+    let mut a = k1.to_vec();
+    let mut b = k2.to_vec();
+    // Add one extra limb for carry: a `-1` digit increments the value by 1 before halving,
+    // which can carry out of a full-width top limb (top bit set). The spare limb absorbs that
+    // carry, so the encoding is correct for any input — not only values with a clear top bit.
+    a.resize(len + 1, 0);
+    b.resize(len + 1, 0);
+
+    // The JSF of an L-bit pair has at most L + 1 digits
+    let mut digits = Vec::with_capacity(len * 64 + 1);
+    while !limbs_is_zero(&a) || !limbs_is_zero(&b) {
+        // The JSF in the book uses d for carry but here it's handled in limbs_sub_signed_then_halve
+        let a_low = a[0];
+        let b_low = b[0];
+
+        let mut u1 = 0i8;
+        // If odd
+        if (a_low & 1) == 1 {
+            // a mod 4 is 1 or 3, mapping to +1 or -1.
+            u1 = 2 - (a_low & 3) as i8;
+            // Flip the sign so that the next position can become a joint zero.
+            if matches!(a_low & 7, 3 | 5) && (b_low & 3) == 2 {
+                u1 = -u1;
             }
         }
-        res.into_affine()
+
+        // If odd
+        let mut u2 = 0i8;
+        if (b_low & 1) == 1 {
+            u2 = 2 - (b_low & 3) as i8;
+            if matches!(b_low & 7, 3 | 5) && (a_low & 3) == 2 {
+                u2 = -u2;
+            }
+        }
+
+        digits.push((u1, u2));
+        // a = (a - u1) / 2, b = (b - u2) / 2. `a - u1` is even (a is odd whenever u1 != 0), so the
+        // halving is exact.
+        limbs_sub_signed_then_halve(&mut a, u1);
+        limbs_sub_signed_then_halve(&mut b, u2);
+    }
+
+    digits.reverse();
+    digits
+}
+
+/// Computes `b1 * k1 + b2 * k2` using the joint sparse form of `(k1, k2)`.
+///
+/// Compared to [`binary_scalar_mul_shamir`] (Shamir's trick over the plain bits) this
+/// does the same number of doublings but fewer additions, because the JSF has
+/// about half as many nonzero positions. It precomputes `b1 + b2` and `b1 - b2`;
+/// the four other table entries (the negations) are free for these groups.
+///
+/// When the bases are available in affine form, prefer
+/// [`binary_scalar_mul_jsf_affine`], which uses cheaper mixed additions for the
+/// single-base digits.
+pub fn binary_scalar_mul_jsf<G: SWCurveConfig>(
+    b1: Projective<G>,
+    k1: G::ScalarField,
+    b2: Projective<G>,
+    k2: G::ScalarField,
+) -> Projective<G> {
+    let sum = b1 + b2;
+    let diff = b1 - b2;
+    let digits = joint_sparse_form(k1.into_bigint().as_ref(), k2.into_bigint().as_ref());
+    // Projective bases: the single-base digits use full projective additions.
+    jsf_fold(b1, b2, sum, diff, digits)
+}
+
+/// Computes `b1 * k1 + b2 * k2`. Identical to [`binary_scalar_mul_jsf`] but for affine points
+pub fn binary_scalar_mul_jsf_affine<G: SWCurveConfig>(
+    b1: Affine<G>,
+    k1: G::ScalarField,
+    b2: Affine<G>,
+    k2: G::ScalarField,
+) -> Projective<G> {
+    let sum = b1 + b2; // Affine + Affine -> Projective
+    let diff = b1 + (-b2);
+    let digits = joint_sparse_form(k1.into_bigint().as_ref(), k2.into_bigint().as_ref());
+    // Affine bases: the single-base digits use mixed (projective += affine) additions.
+    jsf_fold(b1, b2, sum, diff, digits)
+}
+
+/// Shared double-and-add core for the JSF double-scalar multiplication, driven by the precomputed
+/// MSB-first `digits` and the `sum = b1 + b2` / `diff = b1 - b2` table entries.
+fn jsf_fold<G, B>(b1: B, b2: B, sum: G, diff: G, digits: Vec<(i8, i8)>) -> G
+where
+    G: CurveGroup + AddAssign<B> + SubAssign<B>,
+    B: Copy,
+{
+    // Apply one JSF digit to the accumulator.
+    let apply = |res: &mut G, (u1, u2): (i8, i8)| match (u1, u2) {
+        (1, 0) => *res += b1,
+        (-1, 0) => *res -= b1,
+        (0, 1) => *res += b2,
+        (0, -1) => *res -= b2,
+        (1, 1) => *res += sum,
+        (-1, -1) => *res -= sum,
+        (1, -1) => *res += diff,
+        (-1, 1) => *res -= diff,
+        // (0, 0) contributes nothing; it never leads the sequence (see `joint_sparse_form`).
+        _ => {},
+    };
+
+    let mut digits = digits.into_iter();
+    let mut res = match digits.next() {
+        // The digit sequence never starts with (0, 0)
+        Some(first) => {
+            let mut res = G::ZERO;
+            apply(&mut res, first);
+            res
+        },
+        // Both scalars are zero.
+        None => return G::ZERO,
+    };
+    for digit in digits {
+        res.double_in_place();
+        apply(&mut res, digit);
+    }
+    res
+}
+
+/// Returns `true` if every limb is zero.
+fn limbs_is_zero(x: &[u64]) -> bool {
+    x.iter().all(|&l| l == 0)
+}
+
+/// Sets `x = (x - d) / 2` for `d` in `{-1, 0, 1}`, treating `x` as a
+/// little-endian unsigned integer. `x` is odd whenever `d != 0`, so the result
+/// is exact.
+fn limbs_sub_signed_then_halve(x: &mut [u64], d: i8) {
+    match d {
+        1 => {
+            // x -= 1
+            let mut borrow = 1u64;
+            for limb in x.iter_mut() {
+                let (v, b) = limb.overflowing_sub(borrow);
+                *limb = v;
+                borrow = b as u64;
+            }
+            // `x` was odd (and so >= 1), so subtracting 1 cannot underflow.
+            debug_assert_eq!(borrow, 0, "subtracting 1 underflowed the limb array");
+        },
+        -1 => {
+            // x += 1
+            let mut carry = 1u64;
+            for limb in x.iter_mut() {
+                let (v, c) = limb.overflowing_add(carry);
+                *limb = v;
+                carry = c as u64;
+            }
+            // `joint_sparse_form` adds an spare top limb, so this cannot carry out.
+            debug_assert_eq!(carry, 0, "increment carried out of the limb array");
+        },
+        _ => {},
+    }
+
+    // x >>= 1
+    let mut carry = 0u64;
+    for limb in x.iter_mut().rev() {
+        let new_carry = *limb << 63;
+        *limb = (*limb >> 1) | carry;
+        carry = new_carry;
     }
 }

--- a/ec/src/scalar_mul/mod.rs
+++ b/ec/src/scalar_mul/mod.rs
@@ -225,7 +225,7 @@ impl<T: ScalarMul> BatchMulPreprocessing<T> {
         T::batch_convert_to_mul_base(&result)
     }
 
-    fn windowed_mul(&self, scalar: &T::ScalarField) -> T {
+    pub fn windowed_mul(&self, scalar: &T::ScalarField) -> T {
         let outerc = self.max_scalar_size.div_ceil(self.window);
         let modulus_size = T::ScalarField::MODULUS_BIT_SIZE as usize;
         let scalar_val = scalar.into_bigint().to_bits_le();

--- a/ec/src/scalar_mul/variable_base/mod.rs
+++ b/ec/src/scalar_mul/variable_base/mod.rs
@@ -237,8 +237,9 @@ impl PackedIndex {
 
 /// Computes multi-scalar multiplication where the scalars
 /// can be negative, zero, or positive.
-/// Should be used when the negation is cheap, i.e. when
-/// `V::NEGATION_IS_CHEAP` is `true`.
+/// Tries to convert large scalars to negative (modulus - scalar) so that their bit size is small.
+/// Partitions the scalars based on size and uses different algorithms based on the size
+/// Uses wNAF when `V::NEGATION_IS_CHEAP` is `true`.
 fn msm_signed<V: VariableBaseMSM>(
     bases: &[V::MulBase],
     scalars: &[<V::ScalarField as PrimeField>::BigInt],

--- a/scripts/glv_fast_decomp.py
+++ b/scripts/glv_fast_decomp.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Generate the `GLVFastDecomp` constants for a curve from its
+`SCALAR_DECOMP_COEFFS`.
+
+`fast_scalar_decomposition` computes the rounding
+`round(k * |n_ij| / r)` as `round(k * g / 2^M)` with `M = 64 * (N + 2)` and a
+precomputed `g = round(2^M * |n_ij| / r)`, so the division by `r` becomes a
+shift. This script prints, for each curve, the `g1`/`g2` limbs and the `a12`,
+`a22`, `negate_k2` fields of `GLVFastDecomp`.
+
+Edit `CURVES` below (the entries mirror `SCALAR_DECOMP_COEFFS`, in the order
+n11, n12, n21, n22, as `(sign, magnitude)` with `sign` being +1 or -1) and run:
+
+    python3 scripts/glv_fast_decomp.py
+
+References
+---------
+- GLV endomorphism method (split `k = k1 + lambda*k2` into ~half-width `k1, k2`) from
+  [Faster Point Multiplication on Elliptic Curves with Efficient Endomorphisms](https://iacr.org/archive/crypto2001/21390189.pdf)
+- Turning `round(k * |n_ij| / r)` into the division-free `round(k * g / 2^M)` with
+  a precomputed `g = round(2^M * |n_ij| / r)` is a Barrett-style precomputed
+  reciprocal.
+- [gnark-crypto](https://hackmd.io/@drouyang/glv) uses the same precomputed
+   reciprocal rounding (precompute `2^m * v / d`, then shift instead of divide at runtime
+"""
+
+CURVES = {
+    "Pallas": dict(
+        # scalar field modulus r
+        r=28948022309329048855892746252171976963363056481941647379679742748393362948097,
+        lam=26005156700822196841419187675678338661165322343552424574062261873906994770353,
+        limbs=4,
+        # (sign, magnitude) for n11, n12, n21, n22
+        n=[
+            (-1, 98231058071100081932162823354453065728),
+            (+1, 98231058071186745657228807397848383489),
+            (-1, 196462116142286827589391630752301449217),
+            (-1, 98231058071100081932162823354453065728),
+        ],
+    ),
+    "Vesta": dict(
+        r=28948022309329048855892746252171976963363056481941560715954676764349967630337,
+        lam=20444556541222657078399132219657928148671392403212669005631716460534733845831,
+        limbs=4,
+        n=[
+            (-1, 98231058071100081932162823354453065729),
+            (+1, 98231058071186745657228807397848383488),
+            (-1, 196462116142286827589391630752301449217),
+            (-1, 98231058071100081932162823354453065729),
+        ],
+    ),
+}
+
+
+def limbs_le(x, n):
+    assert x >> (64 * n) == 0, "value does not fit in the requested number of limbs"
+    # out is 64-bit limbs of x in little-endian
+    out = [(x >> (64 * i)) & 0xFFFFFFFFFFFFFFFF for i in range(n)]
+    return out
+
+
+for name, c in CURVES.items():
+    r, lam, N = c["r"], c["lam"], c["limbs"]
+    (s11, a11), (s12, a12), (s21, a21), (s22, a22) = c["n"]
+    n11, n12, n21, n22 = s11 * a11, s12 * a12, s21 * a21, s22 * a22
+
+    # The short vectors must lie in the GLV lattice and the matrix determinant
+    # must be the scalar field modulus.
+    assert (n11 + n12 * lam) % r == 0, f"{name}: row 1 not in GLV lattice"
+    assert (n21 + n22 * lam) % r == 0, f"{name}: row 2 not in GLV lattice"
+    assert abs(n11 * n22 - n12 * n21) == r, f"{name}: determinant != r"
+
+    # 2 spare limbs to handle error from division
+    M = 64 * (N + 2)
+    # rounding trick: add 1/2 to numerator since python's integer division is equivalent to float
+    g1 = (2**M * a22 + r // 2) // r  # round(2^M * |n22| / r)
+    g2 = (2**M * a12 + r // 2) // r  # round(2^M * |n12| / r)
+
+    # +1 because g1, g2 are 1 limb wider than scalar
+    fmt = lambda g: ",\n            ".join(f"0x{w:016x}" for w in limbs_le(g, N + 1))
+    print(f"// {name}")
+    print("    const FAST_DECOMP: Option<GLVFastDecomp<Self::ScalarField>> = Some(GLVFastDecomp {")
+    print(f"        g1: &[\n            {fmt(g1)},\n        ],")
+    print(f"        g2: &[\n            {fmt(g2)},\n        ],")
+    print(f'        a12: MontFp!("{a12}"),')
+    print(f'        a22: MontFp!("{a22}"),')
+    print(f"        negate_k2: {str(s12 * s22 == -1).lower()},")
+    print("    });\n")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Pallas and Vesta curves had GLV constants but were not using them. Also, decomposition is sped up by using Barrett's reduction (similar to gnark) 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
