### PR TITLE
fix SmallFp mul overflow on u32

### DIFF
--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -510,7 +510,7 @@ fn generate_mul_impl(
 
                         let mut t = (a.value as u64) * (b.value as u64);
                         let k = t.wrapping_mul(N_PRIME) & R_MASK;
-                        
+
                         let (t, overflow) = t.overflowing_add(k * MODULUS_MUL_TY);
                         let mut r = (t >> #k_bits) + ((overflow as u64) << #shift_bits);
                         if r >= MODULUS_MUL_TY { r -= MODULUS_MUL_TY; }

--- a/ff-macros/src/small_fp/montgomery_backend.rs
+++ b/ff-macros/src/small_fp/montgomery_backend.rs
@@ -500,6 +500,7 @@ fn generate_mul_impl(
                 }
             } else {
                 // Primes where 2^16 < p < 2^32
+                let shift_bits = 64 - k_bits;
                 quote! {
                     #[inline(always)]
                     fn mul_assign(a: &mut SmallFp<Self>, b: &SmallFp<Self>) {
@@ -507,9 +508,11 @@ fn generate_mul_impl(
                         const N_PRIME: u64 = #n_prime as u64;
                         const R_MASK: u64 = #r_mask as u64;
 
-                        let t = (a.value as u64) * (b.value as u64);
+                        let mut t = (a.value as u64) * (b.value as u64);
                         let k = t.wrapping_mul(N_PRIME) & R_MASK;
-                        let mut r = (t + (k * MODULUS_MUL_TY)) >> #k_bits;
+                        
+                        let (t, overflow) = t.overflowing_add(k * MODULUS_MUL_TY);
+                        let mut r = (t >> #k_bits) + ((overflow as u64) << #shift_bits);
                         if r >= MODULUS_MUL_TY { r -= MODULUS_MUL_TY; }
                         a.value = r as u32;
                     }

--- a/test-curves/src/smallfp.rs
+++ b/test-curves/src/smallfp.rs
@@ -24,6 +24,13 @@ define_field!(
     name = SmallFp32Koalabear,
 );
 
+// TeddyBear prime 2^32 - 2^30 + 1
+define_field!(
+    modulus = "3221225473",
+    generator = "5",
+    name = SmallFp32TeddyBear,
+);
+
 // Goldilocks prime 2^64 - 2^32 + 1
 define_field!(
     modulus = "18446744069414584321",
@@ -51,6 +58,7 @@ mod tests {
     test_small_field!(f32_montgomery31; SmallFp32M31);
     test_small_field!(f32_babybear; SmallFp32Babybear);
     test_small_field!(f32_koalabear; SmallFp32Koalabear);
+    test_small_field!(f32_teddybear; SmallFp32TeddyBear);
     test_small_field!(f32; SmallFp32);
     test_small_field!(f64_goldilocks; SmallFp64Goldilocks);
     test_small_field!(f64; SmallFp64);


### PR DESCRIPTION
## Motivation

`SmallFp` multiplication can overflow on `u32` prime fields. This can be replicated on native tests for `TeddyBear` prime.

## Description

Edited case for primes `2^16 < p < 2^32` to handle the overflow. Copied the approach that is used for `u64` primes. Added `TeddyBear` definition and tests for this field. 