### PR TITLE
Fix and fuse polynomial arithmetic operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,14 @@
 
 ### Improvements
 
+- (`ark-poly`) Fuse dense and sparse polynomial arithmetic to avoid temporary containers and redundant allocations.
 - [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Replace Fermat-based (`a^{p-2}`) modular inversion for `SmallFp` fields with a constant-time binary extended GCD (based on [Pornin 2020](https://eprint.iacr.org/2020/1340)).
 - [\#1091](https://github.com/arkworks-rs/algebra/pull/1091)(`ark-ff-macros`) Consolidate `SmallFp` multiplication dispatch into a single `match` with Mersenne fast-paths (M7, M13, M31) and generic Montgomery backends for u8/u16/u32/u64 fields.
 - [\#1102](https://github.com/arkworks-rs/algebra/pull/1102) (`ark-ff-macros`) Add specialized `SmallFp` multiplication paths for the BabyBear, KoalaBear, and Goldilocks primes (shift-based Montgomery for BabyBear/KoalaBear, Pornin's reduction for Goldilocks).
 
 ### Bugfixes
 
+- (`ark-poly`) Fix `SparsePolynomial` scaled addition and subtraction assignment semantics.
 - [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
 
 ## v0.5.0

--- a/poly/benches/dense_multilinear.rs
+++ b/poly/benches/dense_multilinear.rs
@@ -2,7 +2,7 @@ use ark_ff::Field;
 use ark_poly::{DenseMultilinearExtension, MultilinearExtension, Polynomial};
 use ark_std::{ops::Range, test_rng};
 use ark_test_curves::bls12_381;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use std::hint::black_box;
 
 const NUM_VARIABLES_RANGE: Range<usize> = 10..21;
@@ -26,6 +26,55 @@ fn arithmetic_op_bench<F: Field>(c: &mut Criterion) {
             let poly1 = DenseMultilinearExtension::<F>::rand(nv, &mut rng);
             let poly2 = DenseMultilinearExtension::<F>::rand(nv, &mut rng);
             b.iter(|| black_box(&poly1 - &poly2))
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("DenseMultilinear::ScalarMul");
+    for nv in NUM_VARIABLES_RANGE {
+        group.bench_with_input(BenchmarkId::from_parameter(nv), &nv, |b, &nv| {
+            let poly = DenseMultilinearExtension::<F>::rand(nv, &mut rng);
+            let scalar = F::rand(&mut rng);
+            b.iter(|| black_box(&poly * &scalar))
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("DenseMultilinear::Assign");
+    for nv in NUM_VARIABLES_RANGE {
+        let poly1 = DenseMultilinearExtension::<F>::rand(nv, &mut rng);
+        let poly2 = DenseMultilinearExtension::<F>::rand(nv, &mut rng);
+        let scalar = F::rand(&mut rng);
+
+        group.bench_with_input(BenchmarkId::new("Add", nv), &nv, |b, _| {
+            b.iter_batched(
+                || poly1.clone(),
+                |mut lhs| {
+                    lhs += &poly2;
+                    black_box(lhs)
+                },
+                BatchSize::LargeInput,
+            )
+        });
+        group.bench_with_input(BenchmarkId::new("Sub", nv), &nv, |b, _| {
+            b.iter_batched(
+                || poly1.clone(),
+                |mut lhs| {
+                    lhs -= &poly2;
+                    black_box(lhs)
+                },
+                BatchSize::LargeInput,
+            )
+        });
+        group.bench_with_input(BenchmarkId::new("ScaledAdd", nv), &nv, |b, _| {
+            b.iter_batched(
+                || poly1.clone(),
+                |mut lhs| {
+                    lhs += (scalar, &poly2);
+                    black_box(lhs)
+                },
+                BatchSize::LargeInput,
+            )
         });
     }
     group.finish();

--- a/poly/src/evaluations/multivariate/multilinear/dense.rs
+++ b/poly/src/evaluations/multivariate/multilinear/dense.rs
@@ -7,7 +7,7 @@ use crate::{
 use ark_ff::{Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
-    cfg_iter,
+    cfg_iter, cfg_iter_mut,
     fmt::{self, Formatter},
     iter::IntoIterator,
     log2,
@@ -278,8 +278,9 @@ impl<F: Field> Index<usize> for DenseMultilinearExtension<F> {
 impl<F: Field> Add for DenseMultilinearExtension<F> {
     type Output = Self;
 
-    fn add(self, other: Self) -> Self {
-        &self + &other
+    fn add(mut self, other: Self) -> Self {
+        self += other;
+        self
     }
 }
 
@@ -306,42 +307,66 @@ impl<'a, F: Field> Add<&'a DenseMultilinearExtension<F>> for &DenseMultilinearEx
 
 impl<F: Field> AddAssign for DenseMultilinearExtension<F> {
     fn add_assign(&mut self, other: Self) {
-        *self = &*self + &other;
+        if self.is_zero() {
+            *self = other;
+        } else {
+            *self += &other;
+        }
     }
 }
 
 impl<'a, F: Field> AddAssign<&'a Self> for DenseMultilinearExtension<F> {
     fn add_assign(&mut self, other: &'a Self) {
-        *self = &*self + other;
+        if other.is_zero() {
+            return;
+        }
+        if self.is_zero() {
+            *self = other.clone();
+            return;
+        }
+        assert_eq!(self.num_vars, other.num_vars);
+        cfg_iter_mut!(self.evaluations)
+            .zip(&other.evaluations)
+            .for_each(|(a, b)| *a += b);
     }
 }
 
 impl<'a, F: Field> AddAssign<(F, &'a Self)> for DenseMultilinearExtension<F> {
     fn add_assign(&mut self, (f, other): (F, &'a Self)) {
-        let other = Self {
-            num_vars: other.num_vars,
-            evaluations: cfg_iter!(other.evaluations).map(|x| f * x).collect(),
-        };
-        *self = &*self + &other;
+        if f.is_zero() || other.is_zero() {
+            return;
+        }
+        if f.is_one() {
+            *self += other;
+            return;
+        }
+        if self.is_zero() {
+            *self = other.clone();
+            cfg_iter_mut!(self.evaluations).for_each(|value| *value *= f);
+            return;
+        }
+        assert_eq!(self.num_vars, other.num_vars);
+        cfg_iter_mut!(self.evaluations)
+            .zip(&other.evaluations)
+            .for_each(|(a, b)| *a += f * b);
     }
 }
 
 impl<F: Field> Neg for DenseMultilinearExtension<F> {
     type Output = Self;
 
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            num_vars: self.num_vars,
-            evaluations: cfg_iter!(self.evaluations).map(|x| -*x).collect(),
-        }
+    fn neg(mut self) -> Self::Output {
+        cfg_iter_mut!(self.evaluations).for_each(|value| *value = -*value);
+        self
     }
 }
 
 impl<F: Field> Sub for DenseMultilinearExtension<F> {
     type Output = Self;
 
-    fn sub(self, other: Self) -> Self {
-        &self - &other
+    fn sub(mut self, other: Self) -> Self {
+        self -= other;
+        self
     }
 }
 
@@ -349,27 +374,55 @@ impl<'a, F: Field> Sub<&'a DenseMultilinearExtension<F>> for &DenseMultilinearEx
     type Output = DenseMultilinearExtension<F>;
 
     fn sub(self, rhs: &'a DenseMultilinearExtension<F>) -> Self::Output {
-        self + &rhs.clone().neg()
+        // handle constant zero case
+        if rhs.is_zero() {
+            return self.clone();
+        }
+        if self.is_zero() {
+            return -rhs.clone();
+        }
+        assert_eq!(self.num_vars, rhs.num_vars);
+        let result: Vec<F> = cfg_iter!(self.evaluations)
+            .zip(&rhs.evaluations)
+            .map(|(a, b)| *a - *b)
+            .collect();
+
+        Self::Output::from_evaluations_vec(self.num_vars, result)
     }
 }
 
 impl<F: Field> SubAssign for DenseMultilinearExtension<F> {
     fn sub_assign(&mut self, other: Self) {
-        *self = &*self - &other;
+        if self.is_zero() {
+            *self = -other;
+        } else {
+            *self -= &other;
+        }
     }
 }
 
 impl<'a, F: Field> SubAssign<&'a Self> for DenseMultilinearExtension<F> {
     fn sub_assign(&mut self, other: &'a Self) {
-        *self = &*self - other;
+        if other.is_zero() {
+            return;
+        }
+        if self.is_zero() {
+            *self = -other.clone();
+            return;
+        }
+        assert_eq!(self.num_vars, other.num_vars);
+        cfg_iter_mut!(self.evaluations)
+            .zip(&other.evaluations)
+            .for_each(|(a, b)| *a -= b);
     }
 }
 
 impl<F: Field> Mul<F> for DenseMultilinearExtension<F> {
     type Output = Self;
 
-    fn mul(self, scalar: F) -> Self::Output {
-        &self * &scalar
+    fn mul(mut self, scalar: F) -> Self::Output {
+        self *= scalar;
+        self
     }
 }
 
@@ -382,7 +435,7 @@ impl<'a, F: Field> Mul<&'a F> for &DenseMultilinearExtension<F> {
         } else if scalar.is_one() {
             return self.clone();
         }
-        let result: Vec<F> = self.evaluations.iter().map(|&x| x * scalar).collect();
+        let result: Vec<F> = cfg_iter!(self.evaluations).map(|&x| x * scalar).collect();
 
         DenseMultilinearExtension {
             num_vars: self.num_vars,
@@ -393,13 +446,17 @@ impl<'a, F: Field> Mul<&'a F> for &DenseMultilinearExtension<F> {
 
 impl<F: Field> MulAssign<F> for DenseMultilinearExtension<F> {
     fn mul_assign(&mut self, scalar: F) {
-        *self = &*self * &scalar
+        if scalar.is_zero() {
+            *self = Self::zero();
+        } else if !scalar.is_one() {
+            cfg_iter_mut!(self.evaluations).for_each(|value| *value *= scalar);
+        }
     }
 }
 
 impl<'a, F: Field> MulAssign<&'a F> for DenseMultilinearExtension<F> {
     fn mul_assign(&mut self, scalar: &'a F) {
-        *self = &*self * scalar
+        *self *= *scalar
     }
 }
 
@@ -603,6 +660,54 @@ mod tests {
                 poly1_cloned *= Fr::zero();
                 assert_eq!(poly1_cloned, DenseMultilinearExtension::zero());
             }
+        }
+    }
+
+    #[test]
+    fn arithmetic_assign_matches_binary_ops() {
+        const NV: usize = 10;
+        let mut rng = test_rng();
+        for _ in 0..20 {
+            let scalar = Fr::rand(&mut rng);
+            let poly1 = DenseMultilinearExtension::rand(NV, &mut rng);
+            let poly2 = DenseMultilinearExtension::rand(NV, &mut rng);
+
+            let mut sum = poly1.clone();
+            sum += &poly2;
+            assert_eq!(sum, &poly1 + &poly2);
+
+            let mut difference = poly1.clone();
+            difference -= &poly2;
+            assert_eq!(difference, &poly1 - &poly2);
+
+            let mut scaled_sum = poly1.clone();
+            scaled_sum += (scalar, &poly2);
+            assert_eq!(scaled_sum, &poly1 + &(&poly2 * &scalar));
+
+            let mut product = poly1.clone();
+            product *= scalar;
+            assert_eq!(product, &poly1 * &scalar);
+        }
+    }
+
+    #[test]
+    fn sub_with_zero() {
+        const NV: usize = 10;
+        let mut rng = test_rng();
+        for _ in 0..20 {
+            let poly = DenseMultilinearExtension::<Fr>::rand(NV, &mut rng);
+            let zero = DenseMultilinearExtension::zero();
+
+            assert_eq!(&poly - &zero, poly);
+            assert_eq!(&zero - &poly, -poly.clone());
+
+            let mut difference = zero.clone();
+            difference -= &poly;
+            assert_eq!(difference, -poly.clone());
+
+            let mut unchanged = poly.clone();
+            unchanged -= &zero;
+            assert_eq!(unchanged, poly);
         }
     }
 

--- a/poly/src/evaluations/multivariate/multilinear/sparse.rs
+++ b/poly/src/evaluations/multivariate/multilinear/sparse.rs
@@ -7,7 +7,7 @@ use crate::{
 use ark_ff::{Field, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
-    cfg_iter,
+    cfg_iter, cfg_iter_mut,
     collections::BTreeMap,
     fmt::{self, Debug, Formatter},
     ops::{Add, AddAssign, Index, Neg, Sub, SubAssign},
@@ -93,6 +93,35 @@ impl<F: Field> SparseMultilinearExtension<F> {
             evaluations[i] = v;
         }
         DenseMultilinearExtension::from_evaluations_vec(self.num_vars, evaluations)
+    }
+
+    fn add_assign_with(&mut self, other: &Self, map_other: impl Fn(F) -> F) {
+        if other.is_zero() {
+            return;
+        }
+        if self.is_zero() {
+            self.num_vars = other.num_vars;
+        } else {
+            assert_eq!(
+                other.num_vars, self.num_vars,
+                "trying to add non-zero polynomial with different number of variables"
+            );
+        }
+
+        for (&index, &value) in &other.evaluations {
+            let value = map_other(value);
+            if value.is_zero() {
+                continue;
+            }
+            let remove_entry = {
+                let result = self.evaluations.entry(index).or_insert_with(F::zero);
+                *result += value;
+                result.is_zero()
+            };
+            if remove_entry {
+                self.evaluations.remove(&index);
+            }
+        }
     }
 }
 
@@ -244,81 +273,42 @@ impl<'a, F: Field> Add<&'a SparseMultilinearExtension<F>> for &SparseMultilinear
     type Output = SparseMultilinearExtension<F>;
 
     fn add(self, rhs: &'a SparseMultilinearExtension<F>) -> Self::Output {
-        // handle zero case
-        if self.is_zero() {
-            return rhs.clone();
-        }
-        if rhs.is_zero() {
-            return self.clone();
-        }
-
-        assert_eq!(
-            rhs.num_vars, self.num_vars,
-            "trying to add non-zero polynomial with different number of variables"
-        );
-        // simply merge the evaluations
-        let mut evaluations =
-            HashMap::with_hasher(core::hash::BuildHasherDefault::<DefaultHasher>::default());
-        for (&i, &v) in self.evaluations.iter().chain(rhs.evaluations.iter()) {
-            *(evaluations.entry(i).or_insert(F::zero())) += v;
-        }
-        let evaluations: Vec<_> = evaluations
-            .into_iter()
-            .filter(|(_, v)| !v.is_zero())
-            .collect();
-
-        Self::Output {
-            evaluations: tuples_to_treemap(&evaluations),
-            num_vars: self.num_vars,
-            zero: F::zero(),
-        }
+        let mut result = self.clone();
+        result.add_assign_with(rhs, |value| value);
+        result
     }
 }
 
 impl<F: Field> AddAssign for SparseMultilinearExtension<F> {
     fn add_assign(&mut self, other: Self) {
-        *self = &*self + &other;
+        if self.is_zero() {
+            *self = other;
+        } else {
+            self.add_assign_with(&other, |value| value);
+        }
     }
 }
 
 impl<'a, F: Field> AddAssign<&'a Self> for SparseMultilinearExtension<F> {
     fn add_assign(&mut self, other: &'a Self) {
-        *self = &*self + other;
+        self.add_assign_with(other, |value| value);
     }
 }
 
 impl<'a, F: Field> AddAssign<(F, &'a Self)> for SparseMultilinearExtension<F> {
     fn add_assign(&mut self, (f, other): (F, &'a Self)) {
-        if !self.is_zero() && !other.is_zero() {
-            assert_eq!(
-                other.num_vars, self.num_vars,
-                "trying to add non-zero polynomial with different number of variables"
-            );
+        if !f.is_zero() {
+            self.add_assign_with(other, |value| f * value);
         }
-        let ev: Vec<_> = cfg_iter!(other.evaluations)
-            .map(|(i, v)| (*i, f * v))
-            .collect();
-        let other = Self {
-            num_vars: other.num_vars,
-            evaluations: tuples_to_treemap(&ev),
-            zero: F::zero(),
-        };
-        *self += &other;
     }
 }
 
 impl<F: Field> Neg for SparseMultilinearExtension<F> {
     type Output = Self;
 
-    fn neg(self) -> Self::Output {
-        let ev: Vec<_> = cfg_iter!(self.evaluations)
-            .map(|(i, v)| (*i, -*v))
-            .collect();
-        Self::Output {
-            num_vars: self.num_vars,
-            evaluations: tuples_to_treemap(&ev),
-            zero: F::zero(),
-        }
+    fn neg(mut self) -> Self::Output {
+        cfg_iter_mut!(self.evaluations).for_each(|(_, value)| *value = -*value);
+        self
     }
 }
 
@@ -334,19 +324,32 @@ impl<'a, F: Field> Sub<&'a SparseMultilinearExtension<F>> for &SparseMultilinear
     type Output = SparseMultilinearExtension<F>;
 
     fn sub(self, rhs: &'a SparseMultilinearExtension<F>) -> Self::Output {
-        self + &rhs.clone().neg()
+        if self.is_zero() {
+            return -rhs.clone();
+        }
+        let mut result = self.clone();
+        result.add_assign_with(rhs, |value| -value);
+        result
     }
 }
 
 impl<F: Field> SubAssign for SparseMultilinearExtension<F> {
     fn sub_assign(&mut self, other: Self) {
-        *self = &*self - &other;
+        if self.is_zero() {
+            *self = -other;
+        } else {
+            self.add_assign_with(&other, |value| -value);
+        }
     }
 }
 
 impl<'a, F: Field> SubAssign<&'a Self> for SparseMultilinearExtension<F> {
     fn sub_assign(&mut self, other: &'a Self) {
-        *self = &*self - other;
+        if self.is_zero() {
+            *self = -other.clone();
+        } else {
+            self.add_assign_with(other, |value| -value);
+        }
     }
 }
 
@@ -562,6 +565,54 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn arithmetic_assign_matches_binary_ops() {
+        const NV: usize = 10;
+        let mut rng = test_rng();
+        for _ in 0..20 {
+            let scalar = Fr::rand(&mut rng);
+            let poly1 = SparseMultilinearExtension::rand(NV, &mut rng);
+            let poly2 = SparseMultilinearExtension::rand(NV, &mut rng);
+
+            let mut sum = poly1.clone();
+            sum += &poly2;
+            assert_eq!(sum, &poly1 + &poly2);
+
+            let mut difference = poly1.clone();
+            difference -= &poly2;
+            assert_eq!(difference, &poly1 - &poly2);
+
+            let mut scaled_sum = poly1.clone();
+            scaled_sum += (scalar, &poly2);
+            let mut expected = poly1.clone();
+            for (&index, &value) in &poly2.evaluations {
+                let entry = expected.evaluations.entry(index).or_insert_with(Fr::zero);
+                *entry += scalar * value;
+                if entry.is_zero() {
+                    expected.evaluations.remove(&index);
+                }
+            }
+            assert_eq!(scaled_sum, expected);
+        }
+    }
+
+    #[test]
+    fn arithmetic_removes_cancelled_entries() {
+        let poly1 =
+            SparseMultilinearExtension::from_evaluations(3, &[(1, Fr::from(2)), (3, Fr::from(5))]);
+        let poly2 =
+            SparseMultilinearExtension::from_evaluations(3, &[(1, Fr::from(2)), (2, Fr::from(7))]);
+
+        let difference = &poly1 - &poly2;
+        assert!(!difference.evaluations.contains_key(&1));
+        assert_eq!(difference[2], -Fr::from(7));
+        assert_eq!(difference[3], Fr::from(5));
+
+        let mut assigned = poly1;
+        assigned -= &poly2;
+        assert_eq!(assigned, difference);
     }
 
     #[test]

--- a/poly/src/polynomial/multivariate/sparse.rs
+++ b/poly/src/polynomial/multivariate/sparse.rs
@@ -35,6 +35,47 @@ impl<F: Field, T: Term> SparsePolynomial<F, T> {
     fn remove_zeros(&mut self) {
         self.terms.retain(|(c, _)| !c.is_zero());
     }
+
+    fn combine_with(&self, other: &Self, map_other: impl Fn(F) -> F) -> Self {
+        let mut result = Vec::with_capacity(self.terms.len() + other.terms.len());
+        let mut self_iter = self.terms.iter().peekable();
+        let mut other_iter = other.terms.iter().peekable();
+
+        loop {
+            let ordering = match (self_iter.peek(), other_iter.peek()) {
+                (Some(current), Some(other)) => Some((current.1).cmp(&other.1)),
+                (Some(_), None) => Some(Ordering::Less),
+                (None, Some(_)) => Some(Ordering::Greater),
+                (None, None) => None,
+            };
+            let term = match ordering {
+                Some(Ordering::Less) => self_iter.next().cloned(),
+                Some(Ordering::Equal) => {
+                    let (other_coeff, _) = other_iter.next().unwrap();
+                    let (current_coeff, current_term) = self_iter.next().unwrap();
+                    Some((
+                        *current_coeff + map_other(*other_coeff),
+                        current_term.clone(),
+                    ))
+                },
+                Some(Ordering::Greater) => {
+                    let (other_coeff, other_term) = other_iter.next().unwrap();
+                    Some((map_other(*other_coeff), other_term.clone()))
+                },
+                None => None,
+            };
+            match term {
+                Some((coeff, term)) if !coeff.is_zero() => result.push((coeff, term)),
+                Some(_) => {},
+                None => break,
+            }
+        }
+
+        Self {
+            num_vars: core::cmp::max(self.num_vars, other.num_vars),
+            terms: result,
+        }
+    }
 }
 
 impl<F: Field> Polynomial<F> for SparsePolynomial<F, SparseTerm> {
@@ -184,59 +225,19 @@ impl<'a, F: Field, T: Term> Add<&'a SparsePolynomial<F, T>> for &SparsePolynomia
     type Output = SparsePolynomial<F, T>;
 
     fn add(self, other: &'a SparsePolynomial<F, T>) -> SparsePolynomial<F, T> {
-        let mut result = Vec::new();
-        let mut cur_iter = self.terms.iter().peekable();
-        let mut other_iter = other.terms.iter().peekable();
-        // Since both polynomials are sorted, iterate over them in ascending order,
-        // combining any common terms
-        loop {
-            // Peek at iterators to decide which to take from
-            let which = match (cur_iter.peek(), other_iter.peek()) {
-                (Some(cur), Some(other)) => Some((cur.1).cmp(&other.1)),
-                (Some(_), None) => Some(Ordering::Less),
-                (None, Some(_)) => Some(Ordering::Greater),
-                (None, None) => None,
-            };
-            // Push the smallest element to the `result` coefficient vec
-            let smallest = match which {
-                Some(Ordering::Less) => cur_iter.next().unwrap().clone(),
-                Some(Ordering::Equal) => {
-                    let other = other_iter.next().unwrap();
-                    let cur = cur_iter.next().unwrap();
-                    (cur.0 + other.0, cur.1.clone())
-                },
-                Some(Ordering::Greater) => other_iter.next().unwrap().clone(),
-                None => break,
-            };
-            result.push(smallest);
-        }
-        // Remove any zero terms
-        result.retain(|(c, _)| !c.is_zero());
-        SparsePolynomial {
-            num_vars: core::cmp::max(self.num_vars, other.num_vars),
-            terms: result,
-        }
+        self.combine_with(other, |coeff| coeff)
     }
 }
 
 impl<'a, F: Field, T: Term> AddAssign<&'a Self> for SparsePolynomial<F, T> {
     fn add_assign(&mut self, other: &'a Self) {
-        *self = &*self + other;
+        *self = self.combine_with(other, |coeff| coeff);
     }
 }
 
 impl<'a, F: Field, T: Term> AddAssign<(F, &'a Self)> for SparsePolynomial<F, T> {
     fn add_assign(&mut self, (f, other): (F, &'a Self)) {
-        let other = Self {
-            num_vars: other.num_vars,
-            terms: other
-                .terms
-                .iter()
-                .map(|(coeff, term)| (*coeff * f, term.clone()))
-                .collect(),
-        };
-        // Note the call to `Add` will remove also any duplicates
-        *self = &*self + &other;
+        *self = self.combine_with(other, |coeff| f * coeff);
     }
 }
 
@@ -257,15 +258,14 @@ impl<'a, F: Field, T: Term> Sub<&'a SparsePolynomial<F, T>> for &SparsePolynomia
 
     #[inline]
     fn sub(self, other: &'a SparsePolynomial<F, T>) -> SparsePolynomial<F, T> {
-        let neg_other = other.clone().neg();
-        self + &neg_other
+        self.combine_with(other, |coeff| -coeff)
     }
 }
 
 impl<'a, F: Field, T: Term> SubAssign<&'a Self> for SparsePolynomial<F, T> {
     #[inline]
     fn sub_assign(&mut self, other: &'a Self) {
-        *self = &*self - other;
+        *self = self.combine_with(other, |coeff| -coeff);
     }
 }
 
@@ -351,6 +351,23 @@ mod tests {
                 let res1 = &p1 + &p2;
                 let res2 = &p2 + &p1;
                 assert_eq!(res1, res2);
+
+                let mut assigned = p1.clone();
+                assigned += &p2;
+                assert_eq!(assigned, res1);
+
+                let scalar = Fr::rand(rng);
+                let scaled_p2 = SparsePolynomial {
+                    num_vars: p2.num_vars,
+                    terms: p2
+                        .terms
+                        .iter()
+                        .map(|(coeff, term)| (scalar * coeff, term.clone()))
+                        .collect(),
+                };
+                let mut scaled_assigned = p1.clone();
+                scaled_assigned += (scalar, &p2);
+                assert_eq!(scaled_assigned, &p1 + &scaled_p2);
             }
         }
     }
@@ -367,6 +384,10 @@ mod tests {
                 let res2 = &p2 - &p1;
                 assert_eq!(&res1 + &p2, p1);
                 assert_eq!(res1, -res2);
+
+                let mut assigned = p1.clone();
+                assigned -= &p2;
+                assert_eq!(assigned, res1);
             }
         }
     }

--- a/poly/src/polynomial/univariate/sparse.rs
+++ b/poly/src/polynomial/univariate/sparse.rs
@@ -28,6 +28,62 @@ pub struct SparsePolynomial<F: Field> {
     pub coeffs: Vec<(usize, F)>,
 }
 
+fn merge_coefficients<F: Field>(
+    lhs: &[(usize, F)],
+    rhs: &[(usize, F)],
+    map_rhs: impl Fn(F) -> F,
+) -> Vec<(usize, F)> {
+    let mut result = Vec::with_capacity(lhs.len() + rhs.len());
+    let mut lhs_index = 0;
+    let mut rhs_index = 0;
+
+    while lhs_index < lhs.len() || rhs_index < rhs.len() {
+        match (lhs.get(lhs_index), rhs.get(rhs_index)) {
+            (Some(&(lhs_degree, lhs_coeff)), Some(&(rhs_degree, rhs_coeff))) => {
+                match lhs_degree.cmp(&rhs_degree) {
+                    Ordering::Less => {
+                        if !lhs_coeff.is_zero() {
+                            result.push((lhs_degree, lhs_coeff));
+                        }
+                        lhs_index += 1;
+                    },
+                    Ordering::Equal => {
+                        let coeff = lhs_coeff + map_rhs(rhs_coeff);
+                        if !coeff.is_zero() {
+                            result.push((lhs_degree, coeff));
+                        }
+                        lhs_index += 1;
+                        rhs_index += 1;
+                    },
+                    Ordering::Greater => {
+                        let coeff = map_rhs(rhs_coeff);
+                        if !coeff.is_zero() {
+                            result.push((rhs_degree, coeff));
+                        }
+                        rhs_index += 1;
+                    },
+                }
+            },
+            (Some(&(degree, coeff)), None) => {
+                if !coeff.is_zero() {
+                    result.push((degree, coeff));
+                }
+                lhs_index += 1;
+            },
+            (None, Some(&(degree, coeff))) => {
+                let coeff = map_rhs(coeff);
+                if !coeff.is_zero() {
+                    result.push((degree, coeff));
+                }
+                rhs_index += 1;
+            },
+            (None, None) => break,
+        }
+    }
+
+    result
+}
+
 impl<F: Field> fmt::Debug for SparsePolynomial<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         for (i, coeff) in self.coeffs.iter().filter(|(_, c)| !c.is_zero()) {
@@ -115,69 +171,26 @@ impl<'a, F: Field> Add<&'a SparsePolynomial<F>> for &SparsePolynomial<F> {
     type Output = SparsePolynomial<F>;
 
     fn add(self, other: &'a SparsePolynomial<F>) -> SparsePolynomial<F> {
-        if self.is_zero() {
-            return other.clone();
-        } else if other.is_zero() {
-            return self.clone();
-        }
-        // Single pass add algorithm (merging two sorted sets)
-        let mut result = SparsePolynomial::<F>::zero();
-        // our current index in each vector
-        let mut self_index = 0;
-        let mut other_index = 0;
-        loop {
-            // if we've reached the end of one vector, just append the other vector to our
-            // result.
-            if self_index == self.coeffs.len() && other_index == other.coeffs.len() {
-                return result;
-            } else if self_index == self.coeffs.len() {
-                result.append_coeffs(&other.coeffs[other_index..]);
-                return result;
-            } else if other_index == other.coeffs.len() {
-                result.append_coeffs(&self.coeffs[self_index..]);
-                return result;
-            }
-
-            // Get the current degree / coeff for each
-            let (self_term_degree, self_term_coeff) = self.coeffs[self_index];
-            let (other_term_degree, other_term_coeff) = other.coeffs[other_index];
-            // add the lower degree term to our sorted set.
-            match self_term_degree.cmp(&other_term_degree) {
-                Ordering::Less => {
-                    result.coeffs.push((self_term_degree, self_term_coeff));
-                    self_index += 1;
-                },
-                Ordering::Equal => {
-                    let term_sum = self_term_coeff + other_term_coeff;
-                    if !term_sum.is_zero() {
-                        result.coeffs.push((self_term_degree, term_sum));
-                    }
-                    self_index += 1;
-                    other_index += 1;
-                },
-                Ordering::Greater => {
-                    result.coeffs.push((other_term_degree, other_term_coeff));
-                    other_index += 1;
-                },
-            }
+        SparsePolynomial {
+            coeffs: merge_coefficients(&self.coeffs, &other.coeffs, |coeff| coeff),
         }
     }
 }
 
 impl<'a, F: Field> AddAssign<&'a Self> for SparsePolynomial<F> {
-    // TODO: Reduce number of clones
     fn add_assign(&mut self, other: &'a Self) {
-        self.coeffs = (self.clone() + other.clone()).coeffs;
+        let lhs = core::mem::take(&mut self.coeffs);
+        self.coeffs = merge_coefficients(&lhs, &other.coeffs, |coeff| coeff);
     }
 }
 
 impl<'a, F: Field> AddAssign<(F, &'a Self)> for SparsePolynomial<F> {
-    // TODO: Reduce number of clones
     fn add_assign(&mut self, (f, other): (F, &'a Self)) {
-        self.coeffs = (self.clone() + other.clone()).coeffs;
-        for i in 0..self.coeffs.len() {
-            self.coeffs[i].1 *= f;
+        if f.is_zero() || other.is_zero() {
+            return;
         }
+        let lhs = core::mem::take(&mut self.coeffs);
+        self.coeffs = merge_coefficients(&lhs, &other.coeffs, |coeff| f * coeff);
     }
 }
 
@@ -194,11 +207,10 @@ impl<F: Field> Neg for SparsePolynomial<F> {
 }
 
 impl<'a, F: Field> SubAssign<&'a Self> for SparsePolynomial<F> {
-    // TODO: Reduce number of clones
     #[inline]
     fn sub_assign(&mut self, other: &'a Self) {
-        let self_copy = -self.clone();
-        self.coeffs = (self_copy + other.clone()).coeffs;
+        let lhs = core::mem::take(&mut self.coeffs);
+        self.coeffs = merge_coefficients(&lhs, &other.coeffs, |coeff| -coeff);
     }
 }
 
@@ -278,14 +290,6 @@ impl<F: Field> SparsePolynomial<F> {
         let divisor: DenseOrSparsePolynomial<'_, F> = other.into();
 
         dividend.naive_div(&divisor).expect("division failed").0
-    }
-
-    // append append_coeffs to self.
-    // Correctness relies on the lowest degree term in append_coeffs
-    // being higher than self.degree()
-    fn append_coeffs(&mut self, append_coeffs: &[(usize, F)]) {
-        assert!(append_coeffs.is_empty() || self.degree() < append_coeffs[0].0);
-        self.coeffs.extend_from_slice(append_coeffs);
     }
 }
 
@@ -422,6 +426,32 @@ mod tests {
             let mut result = sparse_poly.clone();
             result -= &sparse_poly;
             assert!(result.is_zero());
+        }
+    }
+
+    #[test]
+    fn add_scaled_and_sub_assign_match_dense() {
+        let mut rng = test_rng();
+        for degree_a in 0..20 {
+            let sparse_a = rand_sparse_poly(degree_a, &mut rng);
+            let dense_a: DensePolynomial<Fr> = sparse_a.clone().into();
+            for degree_b in 0..20 {
+                let sparse_b = rand_sparse_poly(degree_b, &mut rng);
+                let dense_b: DensePolynomial<Fr> = sparse_b.clone().into();
+
+                let mut sparse_difference = sparse_a.clone();
+                sparse_difference -= &sparse_b;
+                let mut dense_difference = dense_a.clone();
+                dense_difference -= &dense_b;
+                assert_eq!(DensePolynomial::from(sparse_difference), dense_difference);
+
+                let scalar = Fr::rand(&mut rng);
+                let mut sparse_scaled_sum = sparse_a.clone();
+                sparse_scaled_sum += (scalar, &sparse_b);
+                let mut dense_scaled_sum = dense_a.clone();
+                dense_scaled_sum += (scalar, &dense_b);
+                assert_eq!(DensePolynomial::from(sparse_scaled_sum), dense_scaled_sum);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes two incorrect sparse univariate assignment implementations and applies the allocation-avoidance pattern across adjacent `ark-poly` arithmetic:

- fix `SparsePolynomial::add_assign((scalar, rhs))` to compute `self + scalar * rhs` instead of scaling the whole sum
- fix `SparsePolynomial::sub_assign` to compute `self - rhs` instead of `rhs - self`
- merge sorted sparse univariate and multivariate terms in one pass, applying scale or negation while merging
- make dense multilinear owned and assignment operations reuse their existing evaluation buffer
- update sparse multilinear arithmetic directly in its `BTreeMap`, removing cancelled entries
- add differential and structural regression tests plus assignment benchmarks

This extends #1109, which is now part of `master`. The borrowed dense multilinear subtraction and parallel scalar-multiplication improvements were identified there by @wstran and are retained from the base branch; this PR applies the same underlying pattern to the related operations found elsewhere. The #1109 changes are deliberately excluded from the benchmark claims below.

## Benchmarks

Criterion central estimates on the same machine, comparing current `master` (`4ac5a4be`, including #1109) with this branch. Each row used 30 samples, a 0.5 s warm-up, and a 2 s measurement target.

| Operation | Size | master | this PR | change |
| --- | ---: | ---: | ---: | ---: |
| Dense add-assign | 2^20 | 8.304 ms | 6.414 ms | -22.8% |
| Dense sub-assign | 2^20 | 7.373 ms | 5.636 ms | -23.6% |
| Dense scaled-add-assign | 2^20 | 24.996 ms | 23.938 ms | -4.2% |
| Sparse MLE addition | 2^22, 2048 entries | 217.85 us | 146.52 us | -32.7% |
| Sparse MLE subtraction | 2^22, 2048 entries | 260.25 us | 153.34 us | -41.1% |

## Validation

Re-run after merging current `master` and resolving the #1109 overlap:

- `cargo test -p ark-poly` (118 unit tests, 11 doctests)
- `cargo test -p ark-poly --features parallel` (120 unit tests, 11 doctests)
- `cargo check -p ark-poly --no-default-features`
- `cargo fmt --all --check`
- `git diff --check`
