### PR TITLE
Fix array deserialization leak on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### Bugfixes
 
-- (`ark-serialize`) Drop partially initialized array elements when array deserialization fails.
+- [\#1129](https://github.com/arkworks-rs/algebra/pull/1129) (`ark-serialize`) Drop partially initialized array elements when array deserialization fails.
 - [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
 
 ## v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Bugfixes
 
+- (`ark-serialize`) Drop partially initialized array elements when array deserialization fails.
 - [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
 
 ## v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### Bugfixes
 
-- [\#1129](https://github.com/arkworks-rs/algebra/pull/1129) (`ark-serialize`) Drop partially initialized array elements when array deserialization fails.
+- [\#1129](https://github.com/arkworks-rs/algebra/pull/1129) (`ark-serialize`) Fix `[T; N]` deserialization leaking constructed elements if a later element fails.
 - [\#1082](https://github.com/arkworks-rs/algebra/pull/1082) (`ark-ff`) Fix `SmallFp::from_random_bytes` / `from_be_bytes_mod_order` silently producing incorrect field elements by treating plaintext bytes as Montgomery-encoded.
 
 ## v0.5.0

--- a/serialize/src/impls/collections.rs
+++ b/serialize/src/impls/collections.rs
@@ -116,6 +116,23 @@ impl<T: CanonicalSerialize, const N: usize> CanonicalSerialize for [T; N] {
 }
 impl_valid_seq!([T; N]; const N: usize);
 
+struct ArrayGuard<'a, T> {
+    data: &'a mut [core::mem::MaybeUninit<T>],
+    initialized: usize,
+}
+
+impl<T> Drop for ArrayGuard<'_, T> {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        for elem in &mut self.data[..self.initialized] {
+            // SAFETY: `initialized` is incremented only after an element is initialized.
+            unsafe {
+                elem.assume_init_drop();
+            }
+        }
+    }
+}
+
 impl<T: CanonicalDeserialize, const N: usize> CanonicalDeserialize for [T; N] {
     #[inline]
     #[allow(unsafe_code)]
@@ -126,9 +143,15 @@ impl<T: CanonicalDeserialize, const N: usize> CanonicalDeserialize for [T; N] {
     ) -> Result<Self, SerializationError> {
         use core::mem::MaybeUninit;
         let mut data: [MaybeUninit<T>; N] = [const { MaybeUninit::uninit() }; N];
-        for elem in &mut data[..] {
+        let mut guard = ArrayGuard {
+            data: &mut data,
+            initialized: 0,
+        };
+        for elem in guard.data.iter_mut() {
             elem.write(T::deserialize_with_mode(&mut reader, compress, validate)?);
+            guard.initialized += 1;
         }
+        core::mem::forget(guard);
         Ok(data.map(|x| unsafe { x.assume_init() }))
     }
 }

--- a/serialize/src/impls/collections.rs
+++ b/serialize/src/impls/collections.rs
@@ -116,43 +116,14 @@ impl<T: CanonicalSerialize, const N: usize> CanonicalSerialize for [T; N] {
 }
 impl_valid_seq!([T; N]; const N: usize);
 
-struct ArrayGuard<'a, T> {
-    data: &'a mut [core::mem::MaybeUninit<T>],
-    initialized: usize,
-}
-
-impl<T> Drop for ArrayGuard<'_, T> {
-    #[allow(unsafe_code)]
-    fn drop(&mut self) {
-        for elem in &mut self.data[..self.initialized] {
-            // SAFETY: `initialized` is incremented only after an element is initialized.
-            unsafe {
-                elem.assume_init_drop();
-            }
-        }
-    }
-}
-
 impl<T: CanonicalDeserialize, const N: usize> CanonicalDeserialize for [T; N] {
     #[inline]
-    #[allow(unsafe_code)]
     fn deserialize_with_mode<R: Read>(
         mut reader: R,
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, SerializationError> {
-        use core::mem::MaybeUninit;
-        let mut data: [MaybeUninit<T>; N] = [const { MaybeUninit::uninit() }; N];
-        let mut guard = ArrayGuard {
-            data: &mut data,
-            initialized: 0,
-        };
-        for elem in guard.data.iter_mut() {
-            elem.write(T::deserialize_with_mode(&mut reader, compress, validate)?);
-            guard.initialized += 1;
-        }
-        core::mem::forget(guard);
-        Ok(data.map(|x| unsafe { x.assume_init() }))
+        core::array::try_from_fn(|_| T::deserialize_with_mode(&mut reader, compress, validate))
     }
 }
 

--- a/serialize/src/impls/collections.rs
+++ b/serialize/src/impls/collections.rs
@@ -123,7 +123,11 @@ impl<T: CanonicalDeserialize, const N: usize> CanonicalDeserialize for [T; N] {
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, SerializationError> {
-        core::array::try_from_fn(|_| T::deserialize_with_mode(&mut reader, compress, validate))
+        (0..N)
+            .map(|_| T::deserialize_with_mode(&mut reader, compress, validate))
+            .collect::<Result<Vec<_>, _>>()?
+            .try_into()
+            .map_err(|_| SerializationError::InvalidData)
     }
 }
 

--- a/serialize/src/test.rs
+++ b/serialize/src/test.rs
@@ -7,7 +7,6 @@ use ark_std::{
     vec,
     vec::*,
 };
-use core::sync::atomic::{AtomicUsize, Ordering};
 use num_bigint::BigUint;
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
@@ -166,49 +165,6 @@ fn test_array_bad_input() {
     // Does not panic on invalid data:
     let serialized = [0u8; 1];
     assert!(<[u8; 2]>::deserialize_compressed(&serialized[..]).is_err());
-}
-
-static ARRAY_ELEMENTS_CREATED: AtomicUsize = AtomicUsize::new(0);
-static ARRAY_ELEMENTS_DROPPED: AtomicUsize = AtomicUsize::new(0);
-
-struct DropCounter;
-
-impl Valid for DropCounter {
-    fn check(&self) -> Result<(), SerializationError> {
-        Ok(())
-    }
-}
-
-impl CanonicalDeserialize for DropCounter {
-    fn deserialize_with_mode<R: Read>(
-        reader: R,
-        compress: Compress,
-        validate: Validate,
-    ) -> Result<Self, SerializationError> {
-        if u8::deserialize_with_mode(reader, compress, validate)? == 0 {
-            ARRAY_ELEMENTS_CREATED.fetch_add(1, Ordering::SeqCst);
-            Ok(Self)
-        } else {
-            Err(SerializationError::InvalidData)
-        }
-    }
-}
-
-impl Drop for DropCounter {
-    fn drop(&mut self) {
-        ARRAY_ELEMENTS_DROPPED.fetch_add(1, Ordering::SeqCst);
-    }
-}
-
-#[test]
-fn test_array_drops_initialized_elements_on_deserialization_error() {
-    ARRAY_ELEMENTS_CREATED.store(0, Ordering::SeqCst);
-    ARRAY_ELEMENTS_DROPPED.store(0, Ordering::SeqCst);
-
-    let serialized = [0u8, 0, 1];
-    assert!(<[DropCounter; 3]>::deserialize_compressed(&serialized[..]).is_err());
-    assert_eq!(ARRAY_ELEMENTS_CREATED.load(Ordering::SeqCst), 2);
-    assert_eq!(ARRAY_ELEMENTS_DROPPED.load(Ordering::SeqCst), 2);
 }
 
 #[test]

--- a/serialize/src/test.rs
+++ b/serialize/src/test.rs
@@ -7,6 +7,7 @@ use ark_std::{
     vec,
     vec::*,
 };
+use core::sync::atomic::{AtomicUsize, Ordering};
 use num_bigint::BigUint;
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
@@ -165,6 +166,49 @@ fn test_array_bad_input() {
     // Does not panic on invalid data:
     let serialized = [0u8; 1];
     assert!(<[u8; 2]>::deserialize_compressed(&serialized[..]).is_err());
+}
+
+static ARRAY_ELEMENTS_CREATED: AtomicUsize = AtomicUsize::new(0);
+static ARRAY_ELEMENTS_DROPPED: AtomicUsize = AtomicUsize::new(0);
+
+struct DropCounter;
+
+impl Valid for DropCounter {
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for DropCounter {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        if u8::deserialize_with_mode(reader, compress, validate)? == 0 {
+            ARRAY_ELEMENTS_CREATED.fetch_add(1, Ordering::SeqCst);
+            Ok(Self)
+        } else {
+            Err(SerializationError::InvalidData)
+        }
+    }
+}
+
+impl Drop for DropCounter {
+    fn drop(&mut self) {
+        ARRAY_ELEMENTS_DROPPED.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn test_array_drops_initialized_elements_on_deserialization_error() {
+    ARRAY_ELEMENTS_CREATED.store(0, Ordering::SeqCst);
+    ARRAY_ELEMENTS_DROPPED.store(0, Ordering::SeqCst);
+
+    let serialized = [0u8, 0, 1];
+    assert!(<[DropCounter; 3]>::deserialize_compressed(&serialized[..]).is_err());
+    assert_eq!(ARRAY_ELEMENTS_CREATED.load(Ordering::SeqCst), 2);
+    assert_eq!(ARRAY_ELEMENTS_DROPPED.load(Ordering::SeqCst), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Description

`CanonicalDeserialize` for `[T; N]` previously initialized the array with `MaybeUninit<T>`. If a later element failed to deserialize, already-initialized elements were leaked because `MaybeUninit` does not run `T::drop()`.

This collects into a `Vec` and converts to `[T; N]`, so the initialized prefix is dropped on error. The public API and serialization format are unchanged.

Related historical context: #834 and #837.

Issue: N/A — this is a small, isolated bug fix explained in this PR.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests — n/a, existing array tests are sufficient
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer