### PR TITLE
perf(ec): reserve exact capacity for G2Prepared coefficient vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
 - [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-ec`) Improve scalar multiplication speed for curves using GLV.
-- (`ark-ec`) Reduce allocations in `G2Prepared` construction for the `bls12`, `bn`, `bw6`, `mnt4` and `mnt6` models.
+- [\#1130](https://github.com/arkworks-rs/algebra/pull/1130) (`ark-ec`) Reduce allocations in `G2Prepared` construction for the `bls12`, `bn`, `bw6`, `mnt4` and `mnt6` models.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
 - [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-ec`) Improve scalar multiplication speed for curves using GLV.
+- (`ark-ec`) Reduce allocations in `G2Prepared` construction for the `bls12`, `bn`, `bw6`, `mnt4` and `mnt6` models.
 
 ### Breaking changes
 

--- a/curves/bls12_377/src/curves/tests/mod.rs
+++ b/curves/bls12_377/src/curves/tests/mod.rs
@@ -5,6 +5,7 @@ test_group!(g1; G1Projective; sw);
 test_group!(g2; G2Projective; sw);
 test_group!(pairing_output; ark_ec::pairing::PairingOutput<Bls12_377>; msm);
 test_pairing!(pairing; crate::Bls12_377);
+test_g2_prepared!(g2_prepared; crate::Bls12_377; ell_coeffs; infinity);
 test_group!(g1_glv; G1Projective; glv);
 test_group!(g2_glv; G2Projective; glv);
 test_h2c!(g1_h2c; "./src/curves/tests"; "BLS12377G1"; crate::g1::Config; crate::Fq; crate::Fq; 1);

--- a/curves/bls12_381/src/curves/tests/mod.rs
+++ b/curves/bls12_381/src/curves/tests/mod.rs
@@ -12,6 +12,7 @@ test_group!(g1_glv; G1Projective; glv);
 test_group!(g2_glv; G2Projective; glv);
 test_group!(pairing_output; ark_ec::pairing::PairingOutput<Bls12_381>; msm);
 test_pairing!(pairing; crate::Bls12_381);
+test_g2_prepared!(g2_prepared; crate::Bls12_381; ell_coeffs; infinity);
 test_h2c!(g1_h2c; "./src/curves/tests"; "BLS12381G1"; crate::g1::Config; crate::Fq; crate::Fq; 1);
 test_h2c!(g2_hc2; "./src/curves/tests"; "BLS12381G2"; crate::g2::Config; crate::Fq2; crate::Fq; 2);
 

--- a/curves/bn254/src/curves/tests.rs
+++ b/curves/bn254/src/curves/tests.rs
@@ -7,5 +7,6 @@ test_group!(g1; G1Projective; sw);
 test_group!(g2; G2Projective; sw);
 test_group!(pairing_output; ark_ec::pairing::PairingOutput<Bn254>; msm);
 test_pairing!(pairing; crate::Bn254);
+test_g2_prepared!(g2_prepared; crate::Bn254; ell_coeffs; infinity);
 test_group!(g1_glv; G1Projective; glv);
 test_group!(g2_glv; G2Projective; glv);

--- a/curves/bw6_761/src/curves/tests.rs
+++ b/curves/bw6_761/src/curves/tests.rs
@@ -6,5 +6,6 @@ test_group!(g1; G1Projective; sw);
 test_group!(g2; G2Projective; sw);
 test_group!(pairing_output; ark_ec::pairing::PairingOutput<BW6_761>; msm);
 test_pairing!(pairing; crate::BW6_761);
+test_g2_prepared!(g2_prepared; crate::BW6_761; ell_coeffs_1, ell_coeffs_2; infinity);
 test_group!(g1_glv; G1Projective; glv);
 test_group!(g2_glv; G2Projective; glv);

--- a/curves/bw6_767/src/curves/tests.rs
+++ b/curves/bw6_767/src/curves/tests.rs
@@ -6,3 +6,4 @@ test_group!(g1; G1Projective; sw);
 test_group!(g2; G2Projective; sw);
 test_group!(pairing_output; ark_ec::pairing::PairingOutput<BW6_767>; msm);
 test_pairing!(pairing; crate::BW6_767);
+test_g2_prepared!(g2_prepared; crate::BW6_767; ell_coeffs_1, ell_coeffs_2; infinity);

--- a/curves/mnt4_298/src/curves/tests.rs
+++ b/curves/mnt4_298/src/curves/tests.rs
@@ -5,3 +5,4 @@ test_group!(g1; G1Projective; sw);
 test_group!(g2; G2Projective; sw);
 test_group!(pairing_output; ark_ec::pairing::PairingOutput<MNT4_298>; msm);
 test_pairing!(pairing; crate::MNT4_298);
+test_g2_prepared!(g2_prepared; crate::MNT4_298; double_coefficients, addition_coefficients);

--- a/curves/mnt4_753/src/curves/tests.rs
+++ b/curves/mnt4_753/src/curves/tests.rs
@@ -5,3 +5,4 @@ test_group!(50; g1; G1Projective; sw);
 test_group!(50; g2; G2Projective; sw);
 test_group!(50; pairing_output; ark_ec::pairing::PairingOutput<MNT4_753>; msm);
 test_pairing!(pairing; crate::MNT4_753);
+test_g2_prepared!(g2_prepared; crate::MNT4_753; double_coefficients, addition_coefficients);

--- a/curves/mnt6_298/src/curves/tests.rs
+++ b/curves/mnt6_298/src/curves/tests.rs
@@ -5,3 +5,4 @@ test_group!(g1; G1Projective; sw);
 test_group!(g2; G2Projective; sw);
 test_group!(pairing_output; ark_ec::pairing::PairingOutput<MNT6_298>; msm);
 test_pairing!(pairing; crate::MNT6_298);
+test_g2_prepared!(g2_prepared; crate::MNT6_298; double_coefficients, addition_coefficients);

--- a/curves/mnt6_753/src/curves/tests.rs
+++ b/curves/mnt6_753/src/curves/tests.rs
@@ -5,3 +5,4 @@ test_group!(50; g1; G1Projective; sw);
 test_group!(50; g2; G2Projective; sw);
 test_group!(50; pairing_output; ark_ec::pairing::PairingOutput<MNT6_753>; msm);
 test_pairing!(pairing; crate::MNT6_753);
+test_g2_prepared!(g2_prepared; crate::MNT6_753; double_coefficients, addition_coefficients);

--- a/ec/src/models/bls12/g2.rs
+++ b/ec/src/models/bls12/g2.rs
@@ -52,6 +52,10 @@ impl<P: Bls12Config> From<G2Affine<P>> for G2Prepared<P> {
         q.xy().map_or(zero, |(q_x, q_y)| {
             // One doubling coefficient per bit, plus one addition coefficient per set
             // bit. Mirrors the loop below so the vector never reallocates.
+            //
+            // Counting walks `X` a second time; it cannot be hoisted into a `const`
+            // without generic const expressions. One bool add per bit, against a full
+            // Fp2 doubling per bit in the loop below.
             let num_coeffs = BitIteratorBE::new(P::X)
                 .skip(1)
                 .map(|i| 1 + usize::from(i))

--- a/ec/src/models/bls12/g2.rs
+++ b/ec/src/models/bls12/g2.rs
@@ -50,7 +50,13 @@ impl<P: Bls12Config> From<G2Affine<P>> for G2Prepared<P> {
             infinity: true,
         };
         q.xy().map_or(zero, |(q_x, q_y)| {
-            let mut ell_coeffs = Vec::new();
+            // One doubling coefficient per bit, plus one addition coefficient per set
+            // bit. Mirrors the loop below so the vector never reallocates.
+            let num_coeffs = BitIteratorBE::new(P::X)
+                .skip(1)
+                .map(|i| 1 + usize::from(i))
+                .sum();
+            let mut ell_coeffs = Vec::with_capacity(num_coeffs);
             let mut r = G2HomProjective::<P> {
                 x: q_x,
                 y: q_y,
@@ -64,6 +70,7 @@ impl<P: Bls12Config> From<G2Affine<P>> for G2Prepared<P> {
                     ell_coeffs.push(r.add_in_place(&q));
                 }
             }
+            debug_assert_eq!(ell_coeffs.len(), num_coeffs);
 
             Self {
                 ell_coeffs,

--- a/ec/src/models/bn/g2.rs
+++ b/ec/src/models/bn/g2.rs
@@ -108,6 +108,10 @@ impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
             // One doubling coefficient per digit of the ate loop count, plus one
             // addition coefficient per non-zero digit, plus the two final additions.
             // Mirrors the loop below so the vector never reallocates.
+            //
+            // Counting walks `ATE_LOOP_COUNT` a second time; it cannot be hoisted into a
+            // `const` without generic const expressions. One bool add per digit, against
+            // a full Fp2 doubling per digit in the loop below.
             let num_coeffs = P::ATE_LOOP_COUNT
                 .iter()
                 .rev()

--- a/ec/src/models/bn/g2.rs
+++ b/ec/src/models/bn/g2.rs
@@ -105,7 +105,17 @@ impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
             }
         } else {
             let two_inv = P::Fp::one().double().inverse().unwrap();
-            let mut ell_coeffs = Vec::new();
+            // One doubling coefficient per digit of the ate loop count, plus one
+            // addition coefficient per non-zero digit, plus the two final additions.
+            // Mirrors the loop below so the vector never reallocates.
+            let num_coeffs = P::ATE_LOOP_COUNT
+                .iter()
+                .rev()
+                .skip(1)
+                .map(|bit| 1 + usize::from(matches!(bit, 1 | -1)))
+                .sum::<usize>()
+                + 2;
+            let mut ell_coeffs = Vec::with_capacity(num_coeffs);
             let mut r = G2HomProjective::<P> {
                 x: q.x,
                 y: q.y,
@@ -135,6 +145,7 @@ impl<P: BnConfig> From<G2Affine<P>> for G2Prepared<P> {
 
             ell_coeffs.push(r.add_in_place(&q1));
             ell_coeffs.push(r.add_in_place(&q2));
+            debug_assert_eq!(ell_coeffs.len(), num_coeffs);
 
             Self {
                 ell_coeffs,

--- a/ec/src/models/bw6/g2.rs
+++ b/ec/src/models/bw6/g2.rs
@@ -59,7 +59,15 @@ impl<P: BW6Config> From<G2Affine<P>> for G2Prepared<P> {
         }
 
         // f_{u,Q}(P)
-        let mut ell_coeffs_1 = Vec::new();
+        // One doubling coefficient per bit, plus one addition coefficient per set bit,
+        // plus the final addition below. Mirrors the loop so the vector never
+        // reallocates.
+        let num_coeffs_1 = BitIteratorBE::new(P::ATE_LOOP_COUNT_1)
+            .skip(1)
+            .map(|i| 1 + usize::from(i))
+            .sum::<usize>()
+            + 1;
+        let mut ell_coeffs_1 = Vec::with_capacity(num_coeffs_1);
         let mut r = G2HomProjective::<P> {
             x: q.x,
             y: q.y,
@@ -91,8 +99,17 @@ impl<P: BW6Config> From<G2Affine<P>> for G2Prepared<P> {
             z: P::Fp::one(),
         };
         ell_coeffs_1.push(r.clone().add_in_place(&q));
+        debug_assert_eq!(ell_coeffs_1.len(), num_coeffs_1);
 
-        let mut ell_coeffs_2 = Vec::new();
+        // One doubling coefficient per digit of the second ate loop count, plus one
+        // addition coefficient per non-zero digit. Mirrors the loop below.
+        let num_coeffs_2 = P::ATE_LOOP_COUNT_2
+            .iter()
+            .rev()
+            .skip(1)
+            .map(|bit| 1 + usize::from(matches!(bit, 1 | -1)))
+            .sum();
+        let mut ell_coeffs_2 = Vec::with_capacity(num_coeffs_2);
 
         // f_{u^2-u-1,[u]Q}(P)
         for bit in P::ATE_LOOP_COUNT_2.iter().rev().skip(1) {
@@ -104,6 +121,7 @@ impl<P: BW6Config> From<G2Affine<P>> for G2Prepared<P> {
                 _ => {},
             }
         }
+        debug_assert_eq!(ell_coeffs_2.len(), num_coeffs_2);
 
         Self {
             ell_coeffs_1,

--- a/ec/src/models/bw6/g2.rs
+++ b/ec/src/models/bw6/g2.rs
@@ -62,6 +62,10 @@ impl<P: BW6Config> From<G2Affine<P>> for G2Prepared<P> {
         // One doubling coefficient per bit, plus one addition coefficient per set bit,
         // plus the final addition below. Mirrors the loop so the vector never
         // reallocates.
+        //
+        // Counting walks each loop count a second time; neither can be hoisted into a
+        // `const` without generic const expressions. One bool add per digit, against a
+        // full Fp doubling per digit in the loops below.
         let num_coeffs_1 = BitIteratorBE::new(P::ATE_LOOP_COUNT_1)
             .skip(1)
             .map(|i| 1 + usize::from(i))

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use ark_ff::fields::{Field, Fp2};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::{vec, vec::*};
+use ark_std::vec::*;
 use educe::Educe;
 use num_traits::One;
 
@@ -34,13 +34,24 @@ impl<P: MNT4Config> From<G2Affine<P>> for G2Prepared<P> {
     fn from(g: G2Affine<P>) -> Self {
         let twist_inv = P::TWIST.inverse().unwrap();
 
+        // One doubling coefficient per digit of the ate loop count, and one addition
+        // coefficient per non-zero digit plus the final negative-loop addition. Mirrors
+        // the loop below so neither vector reallocates.
+        let num_doubles = P::ATE_LOOP_COUNT.len().saturating_sub(1);
+        let num_additions = P::ATE_LOOP_COUNT
+            .iter()
+            .skip(1)
+            .filter(|bit| matches!(bit, 1 | -1))
+            .count()
+            + usize::from(P::ATE_IS_LOOP_COUNT_NEG);
+
         let mut g_prep = Self {
             x: g.x,
             y: g.y,
             x_over_twist: g.x * &twist_inv,
             y_over_twist: g.y * &twist_inv,
-            double_coefficients: vec![],
-            addition_coefficients: vec![],
+            double_coefficients: Vec::with_capacity(num_doubles),
+            addition_coefficients: Vec::with_capacity(num_additions),
         };
 
         let mut r = G2ProjectiveExtended {
@@ -81,6 +92,8 @@ impl<P: MNT4Config> From<G2Affine<P>> for G2Prepared<P> {
             );
             g_prep.addition_coefficients.push(add_result.1);
         }
+        debug_assert_eq!(g_prep.double_coefficients.len(), num_doubles);
+        debug_assert_eq!(g_prep.addition_coefficients.len(), num_additions);
 
         g_prep
     }

--- a/ec/src/models/mnt4/g2.rs
+++ b/ec/src/models/mnt4/g2.rs
@@ -37,6 +37,10 @@ impl<P: MNT4Config> From<G2Affine<P>> for G2Prepared<P> {
         // One doubling coefficient per digit of the ate loop count, and one addition
         // coefficient per non-zero digit plus the final negative-loop addition. Mirrors
         // the loop below so neither vector reallocates.
+        //
+        // Counting walks `ATE_LOOP_COUNT` a second time; it cannot be hoisted into a
+        // `const` without generic const expressions. One bool add per digit, against a
+        // full Fp2 doubling per digit in the loop below.
         let num_doubles = P::ATE_LOOP_COUNT.len().saturating_sub(1);
         let num_additions = P::ATE_LOOP_COUNT
             .iter()

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -34,13 +34,24 @@ impl<P: MNT6Config> From<G2Affine<P>> for G2Prepared<P> {
     fn from(g: G2Affine<P>) -> Self {
         let twist_inv = P::TWIST.inverse().unwrap();
 
+        // One doubling coefficient per digit of the ate loop count, and one addition
+        // coefficient per non-zero digit plus the final negative-loop addition. Mirrors
+        // the loop below so neither vector reallocates.
+        let num_doubles = P::ATE_LOOP_COUNT.len().saturating_sub(1);
+        let num_additions = P::ATE_LOOP_COUNT
+            .iter()
+            .skip(1)
+            .filter(|bit| matches!(bit, 1 | -1))
+            .count()
+            + usize::from(P::ATE_IS_LOOP_COUNT_NEG);
+
         let mut g_prep = Self {
             x: g.x,
             y: g.y,
             x_over_twist: g.x * &twist_inv,
             y_over_twist: g.y * &twist_inv,
-            double_coefficients: Vec::new(),
-            addition_coefficients: Vec::new(),
+            double_coefficients: Vec::with_capacity(num_doubles),
+            addition_coefficients: Vec::with_capacity(num_additions),
         };
 
         let mut r = G2ProjectiveExtended {
@@ -78,6 +89,8 @@ impl<P: MNT6Config> From<G2Affine<P>> for G2Prepared<P> {
                 MNT6::mixed_addition_for_flipper_miller_loop(&minus_r_x, &minus_r_y, &r);
             g_prep.addition_coefficients.push(add_result.1);
         }
+        debug_assert_eq!(g_prep.double_coefficients.len(), num_doubles);
+        debug_assert_eq!(g_prep.addition_coefficients.len(), num_additions);
 
         g_prep
     }

--- a/ec/src/models/mnt6/g2.rs
+++ b/ec/src/models/mnt6/g2.rs
@@ -37,6 +37,10 @@ impl<P: MNT6Config> From<G2Affine<P>> for G2Prepared<P> {
         // One doubling coefficient per digit of the ate loop count, and one addition
         // coefficient per non-zero digit plus the final negative-loop addition. Mirrors
         // the loop below so neither vector reallocates.
+        //
+        // Counting walks `ATE_LOOP_COUNT` a second time; it cannot be hoisted into a
+        // `const` without generic const expressions. One bool add per digit, against a
+        // full Fp3 doubling per digit in the loop below.
         let num_doubles = P::ATE_LOOP_COUNT.len().saturating_sub(1);
         let num_additions = P::ATE_LOOP_COUNT
             .iter()

--- a/test-curves/src/bls12_381/tests.rs
+++ b/test-curves/src/bls12_381/tests.rs
@@ -22,6 +22,8 @@ test_group!(glv; G1Projective; glv);
 #[cfg(feature = "bls12_381_curve")]
 test_pairing!(pairing; crate::bls12_381::Bls12_381);
 #[cfg(feature = "bls12_381_curve")]
+test_g2_prepared!(g2_prepared; crate::bls12_381::Bls12_381; ell_coeffs; infinity);
+#[cfg(feature = "bls12_381_curve")]
 test_h2c!(g1_h2c; "./src/testdata"; "BLS12381G1"; crate::bls12_381::g1::Config; crate::bls12_381::Fq; crate::bls12_381::Fq; 1);
 #[cfg(feature = "bls12_381_curve")]
 test_h2c!(g2_hc2; "./src/testdata"; "BLS12381G2"; crate::bls12_381::g2::Config; crate::bls12_381::Fq2; crate::bls12_381::Fq; 2);

--- a/test-templates/src/pairing.rs
+++ b/test-templates/src/pairing.rs
@@ -65,3 +65,136 @@ macro_rules! test_pairing {
         }
     };
 }
+
+/// Checks the line-coefficient vectors that a `G2Prepared` constructor fills.
+///
+/// Every model reserves those vectors up front from its loop-count constant, so the
+/// reservation has to match the loop exactly and cannot depend on the point. Each model
+/// names the vectors differently, so they are listed by the caller: `ell_coeffs` for
+/// `bls12` and `bn`, `ell_coeffs_1` and `ell_coeffs_2` for `bw6`, and
+/// `double_coefficients` and `addition_coefficients` for `mnt4` and `mnt6`.
+///
+/// Pass a trailing `; infinity` for the models whose constructor short-circuits the point
+/// at infinity before the loop, namely `bls12`, `bn` and `bw6`. `mnt4` and `mnt6` have no
+/// such path.
+#[macro_export]
+macro_rules! test_g2_prepared {
+    ($mod_name: ident; $Pairing: ty; $($coeffs: ident),+ $(,)?) => {
+        mod $mod_name {
+            $crate::__test_g2_prepared!($Pairing; $($coeffs),+);
+        }
+    };
+
+    ($mod_name: ident; $Pairing: ty; $($coeffs: ident),+; infinity) => {
+        mod $mod_name {
+            $crate::__test_g2_prepared!($Pairing; $($coeffs),+);
+
+            /// The point at infinity returns before the loop with nothing to store, so it
+            /// must not reserve either. Reserving there would allocate the whole
+            /// coefficient buffer -- 19 KiB on BLS12-381 -- for a prepared point that
+            /// holds no coefficients at all, which is the one case where reserving up
+            /// front is strictly worse than growing on demand.
+            #[test]
+            fn test_infinity_reserves_nothing() {
+                use ark_std::Zero;
+
+                let prepared = G2Prepared::from(G2::zero().into_affine());
+                $(
+                    assert_eq!(
+                        prepared.$coeffs.capacity(),
+                        0,
+                        concat!(
+                            "`",
+                            stringify!($coeffs),
+                            "` allocated for the point at infinity, which stores no \
+                             coefficients",
+                        ),
+                    );
+                )+
+            }
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __test_g2_prepared {
+    ($Pairing: ty; $($coeffs: ident),+) => {
+        use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+        use ark_std::{test_rng, UniformRand};
+        const ITERATIONS: usize = 10;
+
+        type G2 = <$Pairing as Pairing>::G2;
+        type G2Affine = <$Pairing as Pairing>::G2Affine;
+        type G2Prepared = <$Pairing as Pairing>::G2Prepared;
+
+        /// Each vector is reserved to its exact final length, so it neither reallocates
+        /// while being filled nor leaves unused slots behind. `len == capacity` catches
+        /// both directions: an under-reservation grows the vector past what was reserved,
+        /// and an over-reservation never fills it.
+        ///
+        /// The constructors also carry `debug_assert_eq!`s on the length, but those are
+        /// compiled out of release builds and say nothing about the capacity.
+        #[test]
+        fn test_coeffs_reserve_exact_capacity() {
+            let rng = &mut test_rng();
+            for _ in 0..ITERATIONS {
+                let q = G2::rand(rng);
+                // The projective constructor delegates to the affine one; check both so
+                // the delegation cannot start over-allocating unnoticed.
+                for prepared in &[G2Prepared::from(q), G2Prepared::from(q.into_affine())] {
+                    $({
+                        let coeffs = &prepared.$coeffs;
+                        assert!(
+                            !coeffs.is_empty(),
+                            concat!(
+                                "`",
+                                stringify!($coeffs),
+                                "` is empty, which would make the capacity check vacuous",
+                            ),
+                        );
+                        assert_eq!(
+                            coeffs.len(),
+                            coeffs.capacity(),
+                            concat!(
+                                "`",
+                                stringify!($coeffs),
+                                "` was not reserved exactly: the capacity expression has \
+                                 drifted from the loop that fills it",
+                            ),
+                        );
+                    })+
+                }
+            }
+        }
+
+        /// The counts come from the curve's loop-count constant, so they are the same for
+        /// every point. That is what makes reserving before the loop possible at all, and
+        /// it is the assumption every capacity expression is written against.
+        #[test]
+        fn test_coeff_counts_are_point_independent() {
+            let rng = &mut test_rng();
+            let generator = G2Prepared::from(G2Affine::generator());
+
+            let default = G2Prepared::default();
+            $(
+                assert_eq!(
+                    default.$coeffs.len(),
+                    generator.$coeffs.len(),
+                    concat!("`", stringify!($coeffs), "` differs for `G2Prepared::default`"),
+                );
+            )+
+
+            for _ in 0..ITERATIONS {
+                let random = G2Prepared::from(G2::rand(rng).into_affine());
+                $(
+                    assert_eq!(
+                        random.$coeffs.len(),
+                        generator.$coeffs.len(),
+                        concat!("`", stringify!($coeffs), "` length depends on the point"),
+                    );
+                )+
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Summary

Every `G2Prepared` constructor pushes a number of line coefficients that is fixed by the curve's loop-count constant, into a `Vec` created with `Vec::new()`. That way the vector reallocates its way up from the default first capacity on every single point preparation.

This reserves the exact count up front. Each capacity expression mirrors the shape of the loop directly below it, so the two cannot drift apart while staying readable.

Affected constructors (8 vectors across 5 models):

| model | vectors |
|---|---|
| `bls12` | `ell_coeffs` |
| `bn` | `ell_coeffs` |
| `bw6` | `ell_coeffs_1`, `ell_coeffs_2` |
| `mnt4` | `double_coefficients`, `addition_coefficients` |
| `mnt6` | `double_coefficients`, `addition_coefficients` |

## Measurements

BLS12-381, one `G2Prepared::from(G2Affine)`  counted with a `GlobalAlloc` wrapper that tallies every allocator call (numbers deterministic):

| | before | after |
|---|---|---|
| allocations | 1 | 1 |
| reallocations | 5 | **0** |
| reallocations that moved the buffer | 5 | **0** |
| bytes copied by reallocation | 35,712 | **0** |
| largest allocation request | 36,864 B | **19,584 B** |

`ell_coeffs` holds 68 `EllCoeff` of 288 bytes each. The existing growth sequence is 4 → 8 → 16 → 32 → 64 → 128, meaning the final buffer had 60 unused slots.. the new request of 19,584 bytes is exactly 68 × 288 (reservation is exact rather than a padded upper bound).

The wall-clock effect on my mac was small.. `G2Prepared::from` for BLS12-381 shows like 1µs improvement out of 91µs across A/B head on runs, well under 1% of a full pairing. But the substantive part of this change is the allocation counts: the reduced peak memory matters more for the `no_std` and targets that use this code.

## Correctness

Each loop is followed by `debug_assert_eq!(vec.len(), reserved)`. If some capacity expression is ever wrong in either direction, the existing pairing tests fail (instead of silently reallocating again).

Verified by running the pairing tests with `-C debug-assertions=yes` under `--release` for all nine pairing curves in this repo: BLS12-377, BLS12-381, BN254, BW6-761, BW6-767, MNT4-298, MNT4-753, MNT6-298, MNT6-753.

To confirm those assertions actually have teeth rather than passing vacuously, I added `+ 1` to the `mnt6` addition count and re-ran; `test_bilinearity` and `test_multi_pairing` both failed with `left: 48, right: 49`, and passed again once reverted.

checks:
- [x] Targeted PR against correct branch (master)
- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
