### PR TITLE
perf(ec): replace 2-bit GLV joint window with interleaved wNAF -5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
 - [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-ec`) Improve scalar multiplication speed for curves using GLV.
-- [\#N](https://github.com/arkworks-rs/algebra/pull/N) (`ark-ec`) Replace the 2-bit joint window in GLV scalar multiplication with interleaved width-5 wNAF.
+- [\#1133](https://github.com/arkworks-rs/algebra/pull/1133) (`ark-ec`) Replace the 2-bit joint window in GLV scalar multiplication with interleaved width-5 wNAF.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
 - [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-ec`) Improve scalar multiplication speed for curves using GLV.
-- [\#1133](https://github.com/arkworks-rs/algebra/pull/1133) (`ark-ec`) Replace the 2-bit joint window in GLV scalar multiplication with interleaved width-5 wNAF.
+- [\#1133](https://github.com/arkworks-rs/algebra/pull/1133) (`ark-ec`) Replace the 2-bit joint window in GLV scalar multiplication with interleaved width-5 wNAF, and derive the second base's precomputed table from the first through the endomorphism instead of building it with group arithmetic.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
 - [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-ec`) Improve scalar multiplication speed for curves using GLV.
+- [\#N](https://github.com/arkworks-rs/algebra/pull/N) (`ark-ec`) Replace the 2-bit joint window in GLV scalar multiplication with interleaved width-5 wNAF.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [\#1109](https://github.com/arkworks-rs/algebra/pull/1109) (`ark-poly`) Reduce allocations in `DenseMultilinearExtension::Sub` and parallelize scalar `Mul`.
 - [\#1112](https://github.com/arkworks-rs/algebra/pull/1112) (`ark-ec`) Fix rayon::ThreadPoolBuilder panicking in wasm32 when parallel feature is enabled
 - [\#1108](https://github.com/arkworks-rs/algebra/pull/1108) (`ark-ec`) Improve scalar multiplication speed for curves using GLV.
-- [\#1133](https://github.com/arkworks-rs/algebra/pull/1133) (`ark-ec`) Replace the 2-bit joint window in GLV scalar multiplication with interleaved width-5 wNAF, and derive the second base's precomputed table from the first through the endomorphism instead of building it with group arithmetic.
+- [\#1133](https://github.com/arkworks-rs/algebra/pull/1133) (`ark-ec`) Replace the 2-bit joint window in GLV scalar multiplication with interleaved width-5 wNAF, and derive the second base's precomputed table from the first through the endomorphism instead of building it with group arithmetic. Document that GLV scalar multiplication is variable time in the scalar, and clear the wNAF recodings of both half-scalars before returning.
 
 ### Breaking changes
 

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -2,7 +2,7 @@ use crate::{
     short_weierstrass::{Affine, Projective, SWCurveConfig},
     AdditiveGroup, CurveGroup,
 };
-use ark_ff::{PrimeField, Zero};
+use ark_ff::{BigInteger, PrimeField, Zero};
 use ark_std::ops::Neg;
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
@@ -96,102 +96,131 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
         } else {
             -Self::endomorphism(&p)
         };
-        glv_windowed_mul(b1, b2, k1, k2)
+        glv_wnaf_mul(b1, b2, k1, k2)
     }
 
     /// GLV scalar multiplication starting from an affine point.
     ///
-    /// Note: this converts to projective and uses the 2-bit windowed table (projective additions),
+    /// Note: this converts to projective and uses projective additions against the wNAF tables,
     /// rather than mixed additions against affine table entries.
     fn glv_mul_affine(p: Affine<Self>, k: Self::ScalarField) -> Affine<Self> {
         Self::glv_mul_projective(p.into(), k).into_affine()
     }
 }
 
-/// Precompute the 15-point table for 2-bit windowed GLV.
+/// Width of the signed-digit windows used by [`glv_wnaf_mul`].
 ///
-/// Adapted from gnark-crypto's `mulGLV` (Apache-2.0, Copyright Consensys Software Inc.):
-/// <https://github.com/ConsenSys/gnark-crypto/blob/v0.19.0/ecc/bls12-381/g1.go#L620>
-/// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
+/// Recoded digits are odd and lie in `-(2^(W-1) - 1)..=2^(W-1) - 1`, so each base needs a table
+/// of `2^(W-2)` odd multiples. Recoding an `n`-bit half-scalar at width `W` leaves about
+/// `n / (W + 1)` non-zero digits, against `n * (1 - 4^-2) / 2` for the 2-bit joint window this
+/// replaces. Counting table plus scan over real decompositions on BLS12-381, BN254 and
+/// BLS12-377 G1, the saving against that window in base-field multiplications is -2.1% at
+/// `W = 3`, -9.5% at `W = 4`, -10.0% at `W = 5` and -1.9% at `W = 6`. `W = 5` is the optimum,
+/// though `W = 4` comes within half a percent of it using half the table.
+const GLV_WNAF_WIDTH: u32 = 5;
+
+/// Number of odd multiples precomputed per base: `1, 3, 5, ..., 2^(W-1) - 1`.
+const GLV_WNAF_TABLE_SIZE: usize = 1 << (GLV_WNAF_WIDTH - 2);
+
+/// Capacity of the stack buffer holding one recoded half-scalar.
 ///
-/// After scalar decomposition, multiplication is `k1*b1 + k2*b2`. Each loop step reads two bits
-/// from each half-length scalar, giving digits `c1`, `c2` in `0..=3`. The point to add is
-/// `c1*b1 + c2*b2`; the two preceding doublings account for advancing two bits on each leg.
+/// Recoding an `n`-bit value yields at most `n + 1` digits, and `scalar_decomposition` bounds
+/// each half-scalar by `ceil(ScalarField::MODULUS_BIT_SIZE / 2)` bits. This bound holds a
+/// *full-width* recoding for any scalar field up to 1023 bits, so it is reached only by a field
+/// far wider than any in use (the widest, MNT4/6-753, is 753 bits) and only then via a
+/// `GLVConfig` whose decomposition is not actually halving. Overrunning it is a bounds-check
+/// panic in `glv_wnaf_digits`, not silent corruption.
+const GLV_WNAF_MAX_DIGITS: usize = 1024;
+
+/// Precompute `[b, 3*b, 5*b, ..., (2^(W-1) - 1)*b]`.
 ///
-/// There are `4*4` digit pairs, but `(c1, c2) = (0, 0)` adds nothing, so we store the other 15.
-/// Pack digits as `idx = c2*4 + c1` (0..16) and use `table[idx - 1]` when `idx != 0`.
-/// Example: `table[0]=b1`, `table[1]=2*b1`, `table[2]=3*b1`, `table[3]=b2`, `table[4]=b1+b2`,
-/// …, `table[14]=3*b1 + 3*b2`.
+/// One doubling plus `2^(W-2) - 1` additions: `t[0] = b` and `t[i] = t[i - 1] + 2*b`.
 #[inline]
-fn glv_precompute_table<P: GLVConfig>(b1: Projective<P>, b2: Projective<P>) -> [Projective<P>; 15] {
-    let b1_2 = b1.double();
-    let b1_3 = b1_2 + b1;
-    let b2_2 = b2.double();
-    let b2_3 = b2_2 + b2;
-    [
-        b1,
-        b1_2,
-        b1_3,
-        b2,
-        b1 + b2,
-        b1_2 + b2,
-        b1_3 + b2,
-        b2_2,
-        b1 + b2_2,
-        b1_2 + b2_2,
-        b1_3 + b2_2,
-        b2_3,
-        b1 + b2_3,
-        b1_2 + b2_3,
-        b1_3 + b2_3,
-    ]
+fn glv_odd_multiples<P: GLVConfig>(b: Projective<P>) -> [Projective<P>; GLV_WNAF_TABLE_SIZE] {
+    let b_2 = b.double();
+    let mut table = [b; GLV_WNAF_TABLE_SIZE];
+    for i in 1..GLV_WNAF_TABLE_SIZE {
+        table[i] = table[i - 1] + b_2;
+    }
+    table
 }
 
-/// 2-bit windowed scan for `k1*b1 + k2*b2` (bases must already include sign fixes).
-fn glv_windowed_mul<P: GLVConfig>(
+/// Recode `k` into width-`GLV_WNAF_WIDTH` non-adjacent form, writing digits into `digits`
+/// least-significant first and returning how many were written.
+///
+/// Every digit is either zero or odd with absolute value below `2^(W-1)`, and any two non-zero
+/// digits are at least `W` positions apart. A non-zero digit `d` selects table entry
+/// `|d| / 2`, added when `d > 0` and subtracted when `d < 0`.
+fn glv_wnaf_digits<F: PrimeField>(k: F, digits: &mut [i8; GLV_WNAF_MAX_DIGITS]) -> usize {
+    // The recoding consumes `k` from the bottom up: at each odd residue it subtracts the signed
+    // remainder mod `2^W`, which clears the low `W` bits and forces the next `W - 1` digits to
+    // zero, then shifts right by one.
+    let mut e = k.into_bigint();
+    let mut len = 0;
+    while !e.is_zero() {
+        let digit = if e.is_odd() {
+            // Signed remainder mod `2^W`, i.e. the representative in `-2^(W-1)..2^(W-1)`. It is
+            // odd because `e` is, so it never attains the even bound `-2^(W-1)`.
+            let low = (e.as_ref()[0] & ((1 << GLV_WNAF_WIDTH) - 1)) as i8;
+            let digit = if low >= (1 << (GLV_WNAF_WIDTH - 1)) {
+                low - (1 << GLV_WNAF_WIDTH)
+            } else {
+                low
+            };
+            // `e -= digit`, which cannot wrap: `e` is at least 1, and a negative digit only adds.
+            if digit >= 0 {
+                e.sub_with_borrow(&F::BigInt::from(digit as u64));
+            } else {
+                e.add_with_carry(&F::BigInt::from(digit.unsigned_abs() as u64));
+            }
+            digit
+        } else {
+            0
+        };
+        digits[len] = digit;
+        len += 1;
+        e.div2();
+    }
+    len
+}
+
+/// Interleaved width-`GLV_WNAF_WIDTH` wNAF evaluation of `k1*b1 + k2*b2`.
+///
+/// The bases must already carry the sign fixes from `scalar_decomposition`, so `k1` and `k2` are
+/// the non-negative half-scalars. Both are recoded independently, then scanned together from the
+/// most significant digit: one doubling per position, and one table addition per non-zero digit
+/// on either leg.
+///
+/// This is the scheme gnark-crypto's `mulGLV` uses (Apache-2.0, Copyright Consensys Software
+/// Inc.): <https://github.com/ConsenSys/gnark-crypto/blob/master/ecc/bls12-381/g1.go#L774>,
+/// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
+fn glv_wnaf_mul<P: GLVConfig>(
     b1: Projective<P>,
     b2: Projective<P>,
     k1: P::ScalarField,
     k2: P::ScalarField,
 ) -> Projective<P> {
-    let table = glv_precompute_table(b1, b2);
+    let mut digits1 = [0i8; GLV_WNAF_MAX_DIGITS];
+    let mut digits2 = [0i8; GLV_WNAF_MAX_DIGITS];
+    let len1 = glv_wnaf_digits(k1, &mut digits1);
+    let len2 = glv_wnaf_digits(k2, &mut digits2);
 
-    let k1_bi = k1.into_bigint();
-    let k2_bi = k2.into_bigint();
-    let limbs1 = k1_bi.as_ref();
-    let limbs2 = k2_bi.as_ref();
-    // `BitIteratorBE::new` / `into_bigint` always yield exactly `64 * NUM_LIMBS` bits for a
-    // given `ScalarField`, so both scalars share the same (even) bit length.
-    debug_assert_eq!(limbs1.len(), limbs2.len());
-    let nbits = limbs1.len() * 64;
+    let table1 = glv_odd_multiples(b1);
+    let table2 = glv_odd_multiples(b2);
 
     let mut res = Projective::zero();
-    let mut started = false;
-    for chunk_idx in 0..(nbits / 2) {
-        let c1 = glv_two_bit_digit(limbs1, chunk_idx);
-        let c2 = glv_two_bit_digit(limbs2, chunk_idx);
-        let idx = (c2 as usize) * 4 + (c1 as usize);
-        if started {
-            res.double_in_place();
-            res.double_in_place();
-            if idx != 0 {
-                res += table[idx - 1];
+    // The two recodings generally differ in length; the shorter one reads as zero above its own
+    // top digit, which `digits` already holds. Doubling `res` while it is still zero is a no-op,
+    // so no separate "first non-zero digit" flag is needed.
+    for i in (0..len1.max(len2)).rev() {
+        res.double_in_place();
+        for (digit, table) in [(digits1[i], &table1), (digits2[i], &table2)] {
+            if digit > 0 {
+                res += table[(digit >> 1) as usize];
+            } else if digit < 0 {
+                res -= table[(digit.unsigned_abs() >> 1) as usize];
             }
-        } else if idx != 0 {
-            started = true;
-            res = table[idx - 1];
         }
     }
     res
-}
-
-/// Extract the `chunk_idx`-th 2-bit window from a big-endian limb encoding.
-///
-/// `chunk_idx = 0` is the most-significant pair of bits across `limbs`. The total bit length
-/// `64 * limbs.len()` is always even, so every window is fully contained in a single limb.
-#[inline]
-fn glv_two_bit_digit(limbs: &[u64], chunk_idx: usize) -> u8 {
-    let bit_from_msb = chunk_idx * 2;
-    let limb = limbs[limbs.len() - 1 - bit_from_msb / 64];
-    ((limb >> (62 - (bit_from_msb % 64))) & 3) as u8
 }

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -225,7 +225,19 @@ fn glv_endo_odd_multiples<P: GLVConfig>(
 /// Every digit is either zero or odd with absolute value below `2^(W-1)`, and any two non-zero
 /// digits are at least `W` positions apart. A non-zero digit `d` selects table entry
 /// `|d| / 2`, added when `d > 0` and subtracted when `d < 0`.
+///
+/// `digits` must be zeroed on entry, and only `digits[..len]` is written. [`glv_wnaf_mul`]
+/// leans on both halves of that: it scans the two recodings in lockstep and reads each one
+/// past its own length, taking the untouched entries as the leading zeroes of the shorter
+/// recoding. A buffer that already held digits would make those reads return the earlier
+/// recoding's tail and produce a wrong point rather than any kind of error, so the
+/// precondition is checked in debug builds.
 fn glv_wnaf_digits<F: PrimeField>(k: F, digits: &mut [i8; GLV_WNAF_MAX_DIGITS]) -> usize {
+    debug_assert!(
+        digits.iter().all(|&d| d == 0),
+        "`glv_wnaf_digits` requires a zeroed buffer: entries above the returned length are \
+         read as the leading zeroes of the shorter recoding",
+    );
     // The recoding consumes `k` from the bottom up: at each odd residue it subtracts the signed
     // remainder mod `2^W`, which clears the low `W` bits and forces the next `W - 1` digits to
     // zero, then shifts right by one.
@@ -241,7 +253,18 @@ fn glv_wnaf_digits<F: PrimeField>(k: F, digits: &mut [i8; GLV_WNAF_MAX_DIGITS]) 
             } else {
                 low
             };
-            // `e -= digit`, which cannot wrap: `e` is at least 1, and a negative digit only adds.
+            // `e -= digit`. Both calls discard the borrow/carry they return, which is sound
+            // in each direction:
+            //
+            // * Subtracting cannot borrow: a non-negative `digit` is exactly `e mod 2^W`,
+            //   hence at most `e`.
+            // * Adding cannot carry out of the top limb. A negative digit means
+            //   `low >= 2^(W-1)`, so the sum is `(e - low) + 2^W` and the next `e` is
+            //   `2^(W-1) * (e / 2^W + 1)`, which is at most `e`: the recoding never lets `e`
+            //   grow. Every value the buffer holds is therefore bounded by the initial `e`
+            //   plus the one-iteration overshoot `|digit| <= 2^(W-1) - 1`. That initial `e`
+            //   is a half-scalar, so it occupies about `F::MODULUS_BIT_SIZE / 2` bits and the
+            //   sum has the whole upper half of `F::BigInt` to spare.
             if digit >= 0 {
                 e.sub_with_borrow(&F::BigInt::from(digit as u64));
             } else {
@@ -291,15 +314,21 @@ fn glv_wnaf_mul<P: GLVConfig>(
 
     let mut res = Projective::zero();
     // The two recodings generally differ in length; the shorter one reads as zero above its own
-    // top digit, which `digits` already holds. Doubling `res` while it is still zero is a no-op,
-    // so no separate "first non-zero digit" flag is needed.
+    // top digit, which holds because `glv_wnaf_digits` leaves everything past its returned
+    // length untouched in a buffer that started zeroed. Doubling `res` while it is still zero
+    // is a no-op, so no separate "first non-zero digit" flag is needed.
     for i in (0..len1.max(len2)).rev() {
         res.double_in_place();
         for (digit, table) in [(digits1[i], &table1), (digits2[i], &table2)] {
+            // `unsigned_abs` on both sides rather than `digit >> 1` on the positive one. That
+            // shift is correct only while it stays under the `digit > 0` guard: an arithmetic
+            // shift of a negative `i8` keeps the sign bit, and `as usize` then widens it into
+            // an enormous index.
+            let entry = (digit.unsigned_abs() >> 1) as usize;
             if digit > 0 {
-                res += table[(digit >> 1) as usize];
+                res += table[entry];
             } else if digit < 0 {
-                res -= table[(digit.unsigned_abs() >> 1) as usize];
+                res -= table[entry];
             }
         }
     }

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -192,7 +192,7 @@ fn glv_wnaf_digits<F: PrimeField>(k: F, digits: &mut [i8; GLV_WNAF_MAX_DIGITS]) 
 /// on either leg.
 ///
 /// This is the scheme gnark-crypto's `mulGLV` uses (Apache-2.0, Copyright Consensys Software
-/// Inc.): <https://github.com/ConsenSys/gnark-crypto/blob/master/ecc/bls12-381/g1.go#L774>,
+/// Inc.): <https://github.com/Consensys/gnark-crypto/blob/v0.21.0/ecc/bls12-381/g1.go#L777>,
 /// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
 fn glv_wnaf_mul<P: GLVConfig>(
     b1: Projective<P>,

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -91,12 +91,10 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     fn glv_mul_projective(p: Projective<Self>, k: Self::ScalarField) -> Projective<Self> {
         let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
         let b1 = if sgn_k1 { p } else { -p };
-        let b2 = if sgn_k2 {
-            Self::endomorphism(&p)
-        } else {
-            -Self::endomorphism(&p)
-        };
-        glv_wnaf_mul(b1, b2, k1, k2)
+        // The second base is `sgn_k2 * endomorphism(p)`, so it is `endomorphism(b1)` up to the
+        // sign the two halves disagree on. `glv_wnaf_mul` derives it, and its whole table, from
+        // `b1`; see `glv_endo_odd_multiples`.
+        glv_wnaf_mul(b1, sgn_k1 == sgn_k2, k1, k2)
     }
 
     /// GLV scalar multiplication starting from an affine point.
@@ -115,8 +113,13 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
 /// `n / (W + 1)` non-zero digits, against `n * (1 - 4^-2) / 2` for the 2-bit joint window this
 /// replaces. Counting table plus scan over real decompositions on BLS12-381, BN254 and
 /// BLS12-377 G1, the saving against that window in base-field multiplications is -2.1% at
-/// `W = 3`, -9.5% at `W = 4`, -10.0% at `W = 5` and -1.9% at `W = 6`. `W = 5` is the optimum,
-/// though `W = 4` comes within half a percent of it using half the table.
+/// `W = 3`, -9.5% at `W = 4`, -10.0% at `W = 5` and -1.9% at `W = 6`.
+///
+/// Those four figures predate `glv_endo_odd_multiples`, which builds only one of the two tables
+/// by group arithmetic. That makes every width cheaper, and the wider ones cheapest, since the
+/// build it removes grows with `2^(W-2)`. Re-counting on BLS12-381 G1 with the derived table,
+/// `W = 5` is still the optimum, but its margin has moved either side: `W = 4` now costs 4.2%
+/// more rather than 0.5%, and `W = 6` 2.3% more rather than 8.9%.
 const GLV_WNAF_WIDTH: u32 = 5;
 
 /// `GLV_WNAF_WIDTH` is bounded by the `i8` that [`glv_wnaf_digits`] packs its digits into. The
@@ -154,6 +157,37 @@ fn glv_odd_multiples<P: GLVConfig>(b: Projective<P>) -> [Projective<P>; GLV_WNAF
         table[i] = table[i - 1] + b_2;
     }
     table
+}
+
+/// Map the first base's odd multiples through the endomorphism to get the second's.
+///
+/// `glv_mul_projective` folds the decomposition signs into the bases, giving `b1 = s1*p` and
+/// `b2 = s2*phi(p)`, so `b2 = s1*s2*phi(b1)`. `phi` is a group homomorphism, hence
+/// `(2i+1)*b2 = s1*s2*phi((2i+1)*b1)` and the whole second table follows from the first: one
+/// endomorphism application per entry, negated when the signs disagree (`signs_agree` is
+/// `s1 == s2`). On every `GLVConfig` in this tree `endomorphism` is a single base-field
+/// multiplication, so this replaces a doubling and `2^(W-2) - 1` projective additions with
+/// `2^(W-2)` multiplications and at most as many negations.
+///
+/// This asks less of `phi` than the surrounding GLV method already does: only that it is a
+/// homomorphism, which holds on the whole curve, whereas `phi(p) = lambda*p` holds only on the
+/// prime-order subgroup. It does rely on `endomorphism` being correct for an arbitrary
+/// projective representative rather than just `z = 1`, since table entries carry accumulated
+/// `z` values, but `glv_mul_projective` already hands it an arbitrary `p`. The point at
+/// infinity survives, as scaling `x` leaves `z` zero.
+#[inline]
+fn glv_endo_odd_multiples<P: GLVConfig>(
+    table: &[Projective<P>; GLV_WNAF_TABLE_SIZE],
+    signs_agree: bool,
+) -> [Projective<P>; GLV_WNAF_TABLE_SIZE] {
+    let mut endo_table = *table;
+    for t in &mut endo_table {
+        *t = P::endomorphism(t);
+        if !signs_agree {
+            *t = -*t;
+        }
+    }
+    endo_table
 }
 
 /// Recode `k` into width-`GLV_WNAF_WIDTH` non-adjacent form, writing digits into `digits`
@@ -197,17 +231,19 @@ fn glv_wnaf_digits<F: PrimeField>(k: F, digits: &mut [i8; GLV_WNAF_MAX_DIGITS]) 
 
 /// Interleaved width-`GLV_WNAF_WIDTH` wNAF evaluation of `k1*b1 + k2*b2`.
 ///
-/// The bases must already carry the sign fixes from `scalar_decomposition`, so `k1` and `k2` are
-/// the non-negative half-scalars. Both are recoded independently, then scanned together from the
-/// most significant digit: one doubling per position, and one table addition per non-zero digit
-/// on either leg.
+/// `b1` must already carry the sign fix from `scalar_decomposition`, and `signs_agree` records
+/// whether the second half-scalar took the same sign, so `k1` and `k2` are the non-negative
+/// half-scalars. The second base is left implicit: only `b1`'s odd multiples are built by group
+/// arithmetic, and `glv_endo_odd_multiples` derives the second table from them. Both scalars are
+/// recoded independently, then scanned together from the most significant digit: one doubling
+/// per position, and one table addition per non-zero digit on either leg.
 ///
 /// This is the scheme gnark-crypto's `mulGLV` uses (Apache-2.0, Copyright Consensys Software
 /// Inc.): <https://github.com/Consensys/gnark-crypto/blob/v0.21.0/ecc/bls12-381/g1.go#L777>,
 /// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
 fn glv_wnaf_mul<P: GLVConfig>(
     b1: Projective<P>,
-    b2: Projective<P>,
+    signs_agree: bool,
     k1: P::ScalarField,
     k2: P::ScalarField,
 ) -> Projective<P> {
@@ -217,7 +253,7 @@ fn glv_wnaf_mul<P: GLVConfig>(
     let len2 = glv_wnaf_digits(k2, &mut digits2);
 
     let table1 = glv_odd_multiples(b1);
-    let table2 = glv_odd_multiples(b2);
+    let table2 = glv_endo_odd_multiples(&table1, signs_agree);
 
     let mut res = Projective::zero();
     // The two recodings generally differ in length; the shorter one reads as zero above its own

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -7,8 +7,12 @@ use ark_std::ops::Neg;
 use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
 use num_traits::{One, Signed};
+use zeroize::Zeroize;
 
 /// The GLV parameters for computing the endomorphism and scalar decomposition.
+///
+/// The scalar multiplications this trait provides are variable time in the scalar; see
+/// [`GLVConfig::glv_mul_projective`].
 pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     /// Constant used to calculate `phi(G) := lambda*G`.
     ///
@@ -88,6 +92,29 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
 
     fn endomorphism_affine(p: &Affine<Self>) -> Affine<Self>;
 
+    /// GLV scalar multiplication `k * p`.
+    ///
+    /// # Timing
+    ///
+    /// This is not constant time: its running time, its memory access pattern and the number of
+    /// group operations it performs all depend on `k`. The implementation recodes the two
+    /// half-scalars into signed digits, then indexes a precomputed table by those digits, runs
+    /// for as many iterations as the longer half-scalar has bits, and adds once per non-zero
+    /// digit. An attacker who can observe the cache lines touched by one call, or time enough
+    /// calls, learns the recoding, and the recoding determines `k`.
+    ///
+    /// Recovering a secret from exactly these signals is a well studied attack rather than a
+    /// theoretical one: Percival, *Cache Missing for Fun and Profit* (2005) against
+    /// sliding-window exponentiation, and against wNAF specifically, Brumley and Hakala,
+    /// *Cache-Timing Template Attacks* (ASIACRYPT 2009) and Benger, van de Pol, Smart and Yarom,
+    /// *"Just a Little Bit More"* (CT-RSA 2014), both of which turn partial knowledge of the
+    /// recoded digits into full ECDSA key recovery by lattice methods.
+    ///
+    /// No part of `ark-ec` is constant time, so this is a property of the library rather than of
+    /// this function alone. It is called out here because it is easy to reach without asking for
+    /// it: several curves in this workspace override `mul_projective` for G1 to route into GLV,
+    /// so an ordinary `Projective::mul` runs this code without GLV ever being named. Prefer an
+    /// implementation written for the purpose when multiplying by a long-lived secret key.
     fn glv_mul_projective(p: Projective<Self>, k: Self::ScalarField) -> Projective<Self> {
         let ((sgn_k1, k1), (sgn_k2, k2)) = Self::scalar_decomposition(k);
         let b1 = if sgn_k1 { p } else { -p };
@@ -101,6 +128,8 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
     ///
     /// Note: this converts to projective and uses projective additions against the wNAF tables,
     /// rather than mixed additions against affine table entries.
+    ///
+    /// This inherits the timing behaviour of [`GLVConfig::glv_mul_projective`].
     fn glv_mul_affine(p: Affine<Self>, k: Self::ScalarField) -> Affine<Self> {
         Self::glv_mul_projective(p.into(), k).into_affine()
     }
@@ -238,6 +267,11 @@ fn glv_wnaf_digits<F: PrimeField>(k: F, digits: &mut [i8; GLV_WNAF_MAX_DIGITS]) 
 /// recoded independently, then scanned together from the most significant digit: one doubling
 /// per position, and one table addition per non-zero digit on either leg.
 ///
+/// Each of those three properties is secret dependent, and together they are what makes
+/// `GLVConfig::glv_mul_projective` variable time in the scalar: the table index is a memory
+/// access derived from a digit, the trip count is the longer half-scalar's bit length, and the
+/// number of additions is the non-zero digit count. See the `# Timing` section there.
+///
 /// This is the scheme gnark-crypto's `mulGLV` uses (Apache-2.0, Copyright Consensys Software
 /// Inc.): <https://github.com/Consensys/gnark-crypto/blob/v0.21.0/ecc/bls12-381/g1.go#L777>,
 /// implementing the GLV method (<https://www.iacr.org/archive/crypto2001/21390189.pdf>).
@@ -269,5 +303,20 @@ fn glv_wnaf_mul<P: GLVConfig>(
             }
         }
     }
+
+    // The recodings are an invertible encoding of the two half-scalars, and so of `k` itself, so
+    // leaving 2 KiB of them as garbage in a released stack frame is worth avoiding: `ark-ec`
+    // already implements `Zeroize` for `Affine`, `Projective` and `PairingOutput` on the same
+    // reasoning. Only `..len` was written, into buffers this function freshly zeroed, so clearing
+    // the prefixes clears everything either recoding touched. That is ~`n` volatile bytes per
+    // leg rather than the full 1024, e.g. 129 on BLS12-381 G1, against the ~1700 base-field
+    // multiplications the scan above costs.
+    //
+    // This is hygiene, not a countermeasure. It does not make the routine constant time, and it
+    // does not reach the `num-bigint` temporaries in `scalar_decomposition`, which hold `k` and
+    // both half-scalars on the heap and are freed without being cleared.
+    digits1[..len1].zeroize();
+    digits2[..len2].zeroize();
+
     res
 }

--- a/ec/src/scalar_mul/glv.rs
+++ b/ec/src/scalar_mul/glv.rs
@@ -119,6 +119,17 @@ pub trait GLVConfig: Send + Sync + 'static + SWCurveConfig {
 /// though `W = 4` comes within half a percent of it using half the table.
 const GLV_WNAF_WIDTH: u32 = 5;
 
+/// `GLV_WNAF_WIDTH` is bounded by the `i8` that [`glv_wnaf_digits`] packs its digits into. The
+/// binding constraint is the sign correction there: at `W = 7`, `1i8 << 7` is `-128`, so
+/// `low - (1 << W)` overflows. Release builds happen to survive it, because the wrap is
+/// congruent mod 256 and lands on the right residue, but any debug or test build panics on
+/// the overflow. Six is the widest window this recoding can express, and nothing above five
+/// is competitive anyway.
+const _: () = assert!(
+    GLV_WNAF_WIDTH >= 2 && (1i64 << GLV_WNAF_WIDTH) <= i8::MAX as i64,
+    "GLV_WNAF_WIDTH must lie in 2..=6 so the width-sized constants fit in `i8`"
+);
+
 /// Number of odd multiples precomputed per base: `1, 3, 5, ..., 2^(W-1) - 1`.
 const GLV_WNAF_TABLE_SIZE: usize = 1 << (GLV_WNAF_WIDTH - 2);
 

--- a/test-templates/src/glv.rs
+++ b/test-templates/src/glv.rs
@@ -4,7 +4,7 @@ use ark_ec::{
     AffineRepr, CurveGroup, PrimeGroup,
 };
 use ark_ff::{AdditiveGroup, BigInteger, Field, PrimeField};
-use ark_std::{ops::Mul, vec, UniformRand, Zero};
+use ark_std::{ops::Mul, vec, One, UniformRand, Zero};
 
 pub fn glv_scalar_decomposition<P: GLVConfig>() {
     let mut rng = ark_std::test_rng();
@@ -46,6 +46,24 @@ pub fn glv_endomorphism_eigenvalue<P: GLVConfig>() {
     let g = Projective::generator();
     let endo_g = <P as GLVConfig>::endomorphism(&g);
     assert_eq!(endo_g, g.mul(P::LAMBDA));
+}
+
+/// `endomorphism` must act as multiplication by `LAMBDA` on any projective representative, not
+/// only on the `z = 1` ones. `glv_mul_projective` maps a whole wNAF table through it to derive
+/// the second base's table, and those entries carry accumulated `z` values.
+pub fn glv_endomorphism_projective<P: GLVConfig>() {
+    let mut rng = ark_std::test_rng();
+    let g = Projective::<P>::generator();
+    for _i in 0..20 {
+        // Both sides go through `double_and_add` rather than `Mul`, which on the configs under
+        // test routes back into GLV and so into the endomorphism being checked.
+        let p = double_and_add(&g, P::ScalarField::rand(&mut rng).into_bigint());
+        assert!(!p.z.is_one(), "test point has a trivial z");
+        assert_eq!(
+            <P as GLVConfig>::endomorphism(&p),
+            double_and_add(&p, P::LAMBDA.into_bigint()),
+        );
+    }
 }
 
 pub fn glv_projective<P: GLVConfig>() {

--- a/test-templates/src/glv.rs
+++ b/test-templates/src/glv.rs
@@ -3,8 +3,8 @@ use ark_ec::{
     short_weierstrass::{Affine, Projective},
     AffineRepr, CurveGroup, PrimeGroup,
 };
-use ark_ff::{BigInteger, PrimeField};
-use ark_std::{ops::Mul, UniformRand};
+use ark_ff::{AdditiveGroup, BigInteger, Field, PrimeField};
+use ark_std::{ops::Mul, vec, UniformRand, Zero};
 
 pub fn glv_scalar_decomposition<P: GLVConfig>() {
     let mut rng = ark_std::test_rng();
@@ -73,5 +73,56 @@ pub fn glv_affine<P: GLVConfig>() {
         let k_g = <P as GLVConfig>::glv_mul_affine(g, k);
         let k_g_2 = double_and_add_affine(&g, k.into_bigint()).into_affine();
         assert_eq!(k_g, k_g_2);
+    }
+}
+
+/// Structured inputs that random scalars are unlikely to reach: the identity base, a zero
+/// scalar, and scalars whose half-scalars land on a wNAF window boundary.
+pub fn glv_edge_cases<P: GLVConfig>() {
+    let g = Projective::<P>::generator();
+
+    // The identity absorbs every scalar, including ones that decompose to non-zero halves.
+    let mut rng = ark_std::test_rng();
+    for _ in 0..10 {
+        let k = P::ScalarField::rand(&mut rng);
+        assert!(<P as GLVConfig>::glv_mul_projective(Projective::<P>::zero(), k).is_zero());
+        assert!(<P as GLVConfig>::glv_mul_affine(Affine::<P>::zero(), k).is_zero());
+    }
+
+    // `k = 0` decomposes to two zero half-scalars, so the scan produces no digits at all.
+    assert!(<P as GLVConfig>::glv_mul_projective(g, P::ScalarField::ZERO).is_zero());
+
+    let mut scalars = vec![
+        P::ScalarField::ZERO,
+        P::ScalarField::ONE,
+        -P::ScalarField::ONE,
+    ];
+
+    // Around each of the first few powers of two. Recoding `2^n` and its neighbours exercises
+    // the carry that makes a half-scalar one digit longer than its bit length, and the small
+    // values force one half-scalar to zero while the other is non-zero.
+    for n in 0..8u32 {
+        let p = P::ScalarField::from(1u64 << n);
+        scalars.extend([p - P::ScalarField::ONE, p, p + P::ScalarField::ONE]);
+    }
+
+    // All-ones runs, which recode to a single positive digit far above a long carry chain.
+    for n in 1..=16u32 {
+        scalars.push(P::ScalarField::from((1u64 << n) - 1));
+    }
+
+    // Scalars straddling the half-scalar boundary, where `k1` and `k2` differ most in length.
+    let half = P::ScalarField::MODULUS_BIT_SIZE / 2;
+    for shift in [half.saturating_sub(1), half, half + 1] {
+        let p = P::ScalarField::from(2u64).pow([shift as u64]);
+        scalars.extend([p - P::ScalarField::ONE, p, p + P::ScalarField::ONE]);
+    }
+
+    for k in scalars {
+        assert_eq!(
+            <P as GLVConfig>::glv_mul_projective(g, k),
+            double_and_add(&g, k.into_bigint()),
+            "glv_mul_projective disagrees at k = {k}",
+        );
     }
 }

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -424,6 +424,7 @@ macro_rules! __test_group {
         #[test]
         fn test_endomorphism_eigenvalue() {
             $crate::glv::glv_endomorphism_eigenvalue::<Config>();
+            $crate::glv::glv_endomorphism_projective::<Config>();
         }
 
         #[test]

--- a/test-templates/src/groups.rs
+++ b/test-templates/src/groups.rs
@@ -430,6 +430,7 @@ macro_rules! __test_group {
         fn test_glv_mul() {
             $crate::glv::glv_projective::<Config>();
             $crate::glv::glv_affine::<Config>();
+            $crate::glv::glv_edge_cases::<Config>();
         }
     }
 }


### PR DESCRIPTION
## Description

Implements #1128  (follow-up to #1108). Two changes to the GLV joint scan, both confined to
`ec/src/scalar_mul/glv.rs`. No public API change; `scalar_decomposition` and `endomorphism`
are untouched.

1. Interleaved width-5 wNAF replaces the 2-bit joint window.
2. The second base's table is derived from the first through the endomorphism. Since
   `b2 = s1*s2*phi(b1)` and phi is a homomorphism, `(2i+1)*b2 = s1*s2*phi((2i+1)*b1)`, so one
   doubling and 7 additions build both tables.

### Result

Base-field multiplications per `glv_mul_projective`, counted over real decompositions.
Jacobian `add-2007-bl` = 11M + 5S, `dbl-2009-l` = 2M + 5S, S = 0.8M.

| curve | vs 2-bit window |
|---|---|
| BLS12-381 G1 | **-16.9%** |
| BN254 G1 | -16.9% |
| BLS12-377 G1 | -16.8% |
| BW6-761 G1 | -16.5% |
| Pallas | -17.0% |

Operation count is the claim; wall clock is not, since this machine's cross-process noise
floor is 5-8%.

### Window width

W = 5, matching gnark-crypto. Same counting, relative to W = 5: W = 3 +14.9%, W = 4 +4.3%,
W = 6 +2.3%. On BW6-761, W = 6 is ahead by 0.3%, so 5 is a BLS12/BN optimum rather than a
universal one. A compile-time guard rejects anything outside `2..=6`: at W = 7 the sign
correction `low - (1 << W)` overflows `i8` and panics in any debug build, though release
wraps to the correct residue.

closes: #1128

